### PR TITLE
chore: mark generated eBPF header for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+services/proxy/internal/collector/bpf/vmlinux.h linguist-generated=true


### PR DESCRIPTION
Closes #22

## Summary
- add root `.gitattributes`
- mark `services/proxy/internal/collector/bpf/vmlinux.h` as `linguist-generated=true`

## Why
This keeps the generated kernel header in the repo for eBPF compatibility, while preventing it from dominating GitHub language statistics.