### PR TITLE
feat: add canonical veil session entrypoint

### DIFF
--- a/client/cli/.goreleaser.yaml
+++ b/client/cli/.goreleaser.yaml
@@ -49,6 +49,8 @@ archives:
     files:
       - src: scripts/vk
         dst: vk
+      - src: deploy/host/veil
+        dst: veil
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 nfpms:
@@ -66,6 +68,10 @@ nfpms:
         dst: /usr/local/bin/vk
         file_info:
           mode: 0755
+      - src: deploy/host/veil
+        dst: /usr/local/bin/veil
+        file_info:
+          mode: 0755
       - src: deploy/host/session-tools.toml.example
         dst: /etc/veilkey/session-tools.toml.example
         type: config|noreplace
@@ -75,6 +81,7 @@ nfpms:
     description: |-
       VeilKey operator CLI package.
       Includes the veilkey-cli binary, veilkey-session-config, the vk helper,
+      the veil entrypoint,
       and example session-tools configuration for host boundary setup.
     license: MIT
     bindir: /usr/local/bin

--- a/client/cli/Makefile
+++ b/client/cli/Makefile
@@ -72,7 +72,8 @@ package: build-all
 		cp "bin/veilkey-cli-$$p" "$$tmpdir/veilkey-cli"; \
 		cp "bin/veilkey-session-config-$$p" "$$tmpdir/veilkey-session-config"; \
 		cp scripts/vk "$$tmpdir/vk"; \
-		tar -czf "dist/manual/veilkey-cli-$(VERSION)-$$p.tar.gz" -C "$$tmpdir" veilkey-cli veilkey-session-config vk; \
+		cp deploy/host/veil "$$tmpdir/veil"; \
+		tar -czf "dist/manual/veilkey-cli-$(VERSION)-$$p.tar.gz" -C "$$tmpdir" veilkey-cli veilkey-session-config vk veil; \
 		rm -rf "$$tmpdir"; \
 	done
 	@if command -v zip >/dev/null 2>&1; then \

--- a/client/cli/README.md
+++ b/client/cli/README.md
@@ -30,6 +30,8 @@ This component owns:
 
 ## Core Surfaces
 
+- `veil`
+  - canonical user-facing session entrypoint
 - `vk`
   - CLI entrypoint
 - `veilkey-cli wrap-pty`
@@ -91,13 +93,14 @@ veilkey-cli exec env DATABASE_URL="postgres://user:VK:b2c3d4e5@db:5432/app" ./mi
 ## Installation
 
 ```bash
-# Script install (binary + session config + vk helper)
+# Script install (binary + session config + veil/vk helpers)
 bash install/install.sh
 
 # Or build directly
 make build
 go build -o bin/veilkey-session-config ./cmd/veilkey-session-config
 cp bin/veilkey-cli bin/veilkey-session-config /usr/local/bin/
+cp deploy/host/veil /usr/local/bin/
 cp scripts/vk /usr/local/bin/
 ```
 
@@ -174,6 +177,9 @@ kubectl get secret -o yaml | veilkey-cli filter
 veilkey-cli scan --exit-code --format sarif src/
 
 # Enter the secure terminal
+veil
+
+# Or call the lower-level PTY wrapper directly
 veilkey-cli wrap-pty
 
 # Encrypt a value

--- a/client/cli/deploy/host/veil
+++ b/client/cli/deploy/host/veil
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+veilroot_shell="${VEILKEY_VEILROOT_SHELL_BIN:-/usr/local/bin/veilroot-shell}"
+
+if [[ ! -x "${veilroot_shell}" ]]; then
+  echo "veil: required session entrypoint not found: ${veilroot_shell}" >&2
+  echo "veil: install the Veil host boundary first or set VEILKEY_VEILROOT_SHELL_BIN" >&2
+  exit 1
+fi
+
+exec "${veilroot_shell}" open "$@"

--- a/client/cli/install/install.sh
+++ b/client/cli/install/install.sh
@@ -89,6 +89,7 @@ install_binary() {
         chmod +x "$bindir/veilkey-cli"
         # Install helpers (Linux/macOS)
         [[ -f "$tmpdir/vk" ]] && mv "$tmpdir/vk" "$bindir/vk" && chmod +x "$bindir/vk"
+        [[ -f "$tmpdir/veil" ]] && mv "$tmpdir/veil" "$bindir/veil" && chmod +x "$bindir/veil"
         [[ -f "$tmpdir/veilkey-session-config" ]] && mv "$tmpdir/veilkey-session-config" "$bindir/veilkey-session-config" && chmod +x "$bindir/veilkey-session-config"
         rm -rf "$tmpdir"
     fi
@@ -173,6 +174,10 @@ install_from_source() {
     if [ -f "$INSTALL_DIR/scripts/vk" ]; then
         ln -sf "$INSTALL_DIR/scripts/vk" /usr/local/bin/vk
         echo "  linked: /usr/local/bin/vk"
+    fi
+    if [ -f "$INSTALL_DIR/deploy/host/veil" ]; then
+        ln -sf "$INSTALL_DIR/deploy/host/veil" /usr/local/bin/veil
+        echo "  linked: /usr/local/bin/veil"
     fi
 }
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -672,6 +672,8 @@ install_component_payload() {
         "${component_src}/veilkey-cli"
       install_required_asset "${VEILKEY_OS_BIN_DIR}/veilkey-session-config" 0755 \
         "${component_src}/veilkey-session-config"
+      install_optional_asset "${VEILKEY_OS_BIN_DIR}/veil" 0755 \
+        "${component_src}/veil"
       install_optional_asset "${VEILKEY_OS_BIN_DIR}/vk" 0755 \
         "${component_src}/vk"
       install_optional_asset "${root%/}/etc/veilkey/session-tools.toml.example" 0644 \

--- a/installer/tests/test_cli_component.sh
+++ b/installer/tests/test_cli_component.sh
@@ -29,9 +29,10 @@ if [[ ! -x ../client/cli/bin/veilkey-session-config-linux-amd64 ]]; then
 fi
 cp ../client/cli/bin/veilkey-cli-linux-amd64 "$cli_root/veilkey-cli"
 cp ../client/cli/bin/veilkey-session-config-linux-amd64 "$cli_root/veilkey-session-config"
+cp ../client/cli/deploy/host/veil "$cli_root/veil"
 cp ../client/cli/scripts/vk "$cli_root/vk"
 cp ../client/cli/deploy/host/session-tools.toml.example "$cli_root/session-tools.toml.example"
-tar -czf "$cli_artifact" -C "$cli_root" veilkey-cli veilkey-session-config vk session-tools.toml.example
+tar -czf "$cli_artifact" -C "$cli_root" veilkey-cli veilkey-session-config veil vk session-tools.toml.example
 
 cp -a ../services/proxy/. "$proxy_root/"
 tar -czf "$proxy_artifact" -C "$tmp_artifact_dir" veilkey-proxy-local
@@ -49,6 +50,7 @@ VEILKEY_INSTALLER_MANIFEST="$tmp_manifest" ./install.sh install proxmox-host-cli
 
 test -x "$tmp_root/usr/local/bin/veilkey-cli"
 test -x "$tmp_root/usr/local/bin/veilkey-session-config"
+test -x "$tmp_root/usr/local/bin/veil"
 test -x "$tmp_root/usr/local/bin/vk"
 test -f "$tmp_root/etc/veilkey/session-tools.toml.example"
 test -x "$tmp_root/usr/local/bin/veilroot-shell"


### PR DESCRIPTION
## Summary
- add a canonical `veil` wrapper as the user-facing session entrypoint
- ship `veil` in CLI packages and installer-managed CLI payloads
- update CLI install/docs surface to point at `veil` first and `veilkey-cli wrap-pty` second
- keep fail-open behavior out of this slice: `veil` errors clearly if its required session entrypoint is missing

## Testing
- `cd client/cli && go test ./...`
- `cd client/cli && PATH="$PATH:/root/go/bin" goreleaser check`
- `cd installer && bash tests/test_cli_component.sh`
- `VEILKEY_VEILROOT_SHELL_BIN=/nonexistent client/cli/deploy/host/veil` -> explicit error

## Related
- refs #31
- follow-up for actual per-user work-container runtime remains in #37 and #36