### PR TITLE
docs: record veil-first installer session surface

### DIFF
--- a/installer/INSTALL.md
+++ b/installer/INSTALL.md
@@ -15,6 +15,23 @@ The currently validated install targets are:
 - `proxmox-host-localvault`
 - `proxmox-lxc-allinone`
 
+## Current Operator Entry Command
+
+For the host-side CLI boundary, the installer now ships:
+
+- `veil`
+- `veilkey-cli`
+- `veilkey-session-config`
+- `vk`
+
+Operator guidance:
+
+- prefer `veil` as the first command
+- treat `veilkey-cli wrap-pty` as the lower-level fallback/debug surface
+- `veil` currently enters the existing host boundary/session path
+- a later phase will move `veil` behind a per-user work-container runtime
+- do not treat `veilroot` as the primary operator command anymore
+
 ## 1. Prepare the Installer Repository
 
 Clone the installer repository and initialize the local manifest:
@@ -236,3 +253,26 @@ Runtime LXC:
 ./scripts/proxmox-lxc-runtime-install.sh --activate /
 ./scripts/proxmox-lxc-runtime-health.sh /
 ```
+
+## Host CLI Boundary Surface
+
+When the `proxmox-host-cli` profile is installed successfully, the expected CLI/session files are:
+
+```text
+/usr/local/bin/veil
+/usr/local/bin/veilkey-cli
+/usr/local/bin/veilkey-session-config
+/usr/local/bin/vk
+/etc/veilkey/session-tools.toml.example
+```
+
+Quick check:
+
+```bash
+command -v veil
+command -v veilkey-cli
+command -v veilkey-session-config
+command -v vk
+```
+
+If `veil` cannot find its required boundary/session runtime, it fails with an explicit error instead of silently dropping to an unguarded host path.

--- a/installer/README.md
+++ b/installer/README.md
@@ -40,6 +40,32 @@ The active install targets are:
 - `proxmox-lxc-allinone`
 - `proxmox-lxc-runtime`
 
+## Current CLI / Session Surface
+
+The installer now treats the CLI boundary surface as:
+
+- `veil`
+  - canonical user-facing session entrypoint
+- `veilkey-cli`
+  - lower-level CLI and PTY wrapper surface
+- `veilkey-session-config`
+  - session/boundary configuration helper
+- `vk`
+  - manual ref issuance helper
+
+Current behavior:
+
+- the `cli` component package installs `veil`, `veilkey-cli`, `veilkey-session-config`, and `vk`
+- `veil` is intended to be the one command an operator types first
+- the current implementation still delegates into the existing host-boundary/session path
+- future work will move `veil` behind the per-user work-container runtime tracked in issues `#31`, `#37`, and `#36`
+
+Surface direction:
+
+- keep `veil` as the only user-facing session entrypoint
+- keep `veilkey-cli`, `veilkey-session-config`, and `vk` as lower-level/operator helpers
+- demote `veilroot` and legacy session-launch helper names from primary install/operator paths
+
 ## Main Documents
 
 - `INSTALL.md`
@@ -186,6 +212,25 @@ Important behavior:
 - wrapper commands add target-specific runtime checks on top
 - `proxmox-lxc-allinone` stages boundary assets for host export and follow-up setup
 - `proxmox-lxc-allinone` does not support `VEILKEY_ENABLE_PROXY=1` inside the LXC; use `proxmox-host-cli` on the Proxmox host for companion boundary/proxy runtime
+
+## CLI Component Contract
+
+The `proxmox-host-cli` install profile now assumes a dedicated CLI component payload.
+
+Installed files expected from the `cli` component:
+
+- `/usr/local/bin/veil`
+- `/usr/local/bin/veilkey-cli`
+- `/usr/local/bin/veilkey-session-config`
+- `/usr/local/bin/vk`
+- `/etc/veilkey/session-tools.toml.example`
+
+Validation coverage:
+
+- `installer/tests/test_cli_component.sh`
+  - bundles a local CLI artifact
+  - installs the `proxmox-host-cli` profile
+  - verifies the expected CLI/session files are present
 
 ## Bootstrap SSH Export
 


### PR DESCRIPTION
## Summary
- record the current installer CLI/session surface around `veil`
- document which binaries the `cli` component is expected to install
- clarify that `veilroot` is no longer the primary operator command

## Testing
- git diff --check

## Related
- #34
- #31