### PR TITLE
feat: add opt-in veil work-container launcher

### DIFF
--- a/client/cli/deploy/host/veil
+++ b/client/cli/deploy/host/veil
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${VEIL_WORK_CONTAINER_ENABLE:-0}" == "1" ]]; then
+  work_container_bin="${VEIL_WORK_CONTAINER_BIN:-/usr/local/bin/veil-work-container}"
+  if [[ ! -x "${work_container_bin}" ]]; then
+    echo "veil: configured work-container entrypoint not found: ${work_container_bin}" >&2
+    exit 1
+  fi
+  exec "${work_container_bin}" "$@"
+fi
+
 veilroot_shell="${VEILKEY_VEILROOT_SHELL_BIN:-/usr/local/bin/veilroot-shell}"
 
 if [[ ! -x "${veilroot_shell}" ]]; then

--- a/client/cli/deploy/host/veil-work-container
+++ b/client/cli/deploy/host/veil-work-container
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+choose_runtime() {
+  if [[ -n "${VEIL_WORK_CONTAINER_RUNTIME:-}" ]]; then
+    printf '%s\n' "${VEIL_WORK_CONTAINER_RUNTIME}"
+    return 0
+  fi
+  if command -v docker >/dev/null 2>&1; then
+    printf '%s\n' "docker"
+    return 0
+  fi
+  if command -v podman >/dev/null 2>&1; then
+    printf '%s\n' "podman"
+    return 0
+  fi
+  return 1
+}
+
+runtime="$(choose_runtime || true)"
+if [[ -z "${runtime}" ]]; then
+  echo "veil-work-container: no supported container runtime found (docker or podman)" >&2
+  exit 1
+fi
+
+user_name="${USER:-$(id -un)}"
+safe_user="$(printf '%s' "${user_name}" | tr -c 'A-Za-z0-9_.-' '-')"
+container_name="${VEIL_WORK_CONTAINER_NAME:-veil-${safe_user}}"
+home_volume="${VEIL_WORK_CONTAINER_HOME_VOLUME:-veil-home-${safe_user}}"
+workspace_dir="${VEIL_WORK_CONTAINER_WORKSPACE:-$PWD}"
+image="${VEIL_WORK_CONTAINER_IMAGE:-ghcr.io/veilkey/veil-workspace:latest}"
+shell_cmd="${VEIL_WORK_CONTAINER_SHELL:-tmux new-session -Ad -s main; exec tmux attach -t main}"
+
+inspect_args=(container inspect "${container_name}")
+run_args=(
+  run -d
+  --name "${container_name}"
+  -v "${home_volume}:/home/veil"
+  -v "${workspace_dir}:/workspace"
+  -w /workspace
+  "${image}"
+  sleep infinity
+)
+start_args=(start "${container_name}")
+exec_args=(
+  exec -it
+  "${container_name}"
+  sh -lc "${shell_cmd}"
+)
+
+if [[ "${VEIL_WORK_CONTAINER_DRY_RUN:-0}" == "1" ]]; then
+  printf 'runtime=%s\n' "${runtime}"
+  printf 'inspect=%q ' "${runtime}" "${inspect_args[@]}"
+  printf '\n'
+  printf 'run=%q ' "${runtime}" "${run_args[@]}"
+  printf '\n'
+  printf 'start=%q ' "${runtime}" "${start_args[@]}"
+  printf '\n'
+  printf 'exec=%q ' "${runtime}" "${exec_args[@]}"
+  printf '\n'
+  exit 0
+fi
+
+if ! "${runtime}" "${inspect_args[@]}" >/dev/null 2>&1; then
+  "${runtime}" "${run_args[@]}" >/dev/null
+fi
+
+"${runtime}" "${start_args[@]}" >/dev/null 2>&1 || true
+exec "${runtime}" "${exec_args[@]}"

--- a/client/cli/tests/test_veil_work_container.sh
+++ b/client/cli/tests/test_veil_work_container.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+. tests/lib/testlib.sh
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+script="$PWD/deploy/host/veil-work-container"
+
+out="$(PATH="$tmp:/usr/bin:/bin" VEIL_WORK_CONTAINER_DRY_RUN=1 USER=alice "$script" 2>&1 || true)"
+assert_contains "$out" "no supported container runtime found"
+
+cat >"$tmp/docker" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "docker $*"
+SCRIPT
+chmod +x "$tmp/docker"
+
+out="$(PATH="$tmp:$PATH" USER=alice VEIL_WORK_CONTAINER_DRY_RUN=1 VEIL_WORK_CONTAINER_WORKSPACE=/work/demo VEIL_WORK_CONTAINER_IMAGE=ghcr.io/example/veil:test "$script")"
+assert_contains "$out" "runtime=docker"
+assert_contains "$out" "inspect=docker"
+assert_contains "$out" "inspect=veil-alice"
+assert_contains "$out" "run=docker"
+assert_contains "$out" "run=--name"
+assert_contains "$out" "run=veil-alice"
+assert_contains "$out" "veil-home-alice:/home/veil"
+assert_contains "$out" "/work/demo:/workspace"
+assert_contains "$out" "ghcr.io/example/veil:test"
+assert_contains "$out" "exec=docker"
+assert_contains "$out" "exec=veil-alice"
+assert_contains "$out" "exec=sh"
+assert_contains "$out" "exec=-lc"
+assert_contains "$out" "tmux\\ new-session\\ -Ad\\ -s\\ main"
+
+echo "ok: veil work container"


### PR DESCRIPTION
## Summary
- add an opt-in `veil-work-container` helper that builds the per-user work-container runtime command
- let `veil` route to that helper when `VEIL_WORK_CONTAINER_ENABLE=1`
- add focused shell coverage for dry-run command construction

## Testing
- cd client/cli && bash tests/test_veil_work_container.sh
- cd client/cli && go test ./...

## Notes
- this is the first slice toward #37, not the default runtime switch yet
- current behavior stays unchanged unless `VEIL_WORK_CONTAINER_ENABLE=1`

## Related
- #37
- #36