### PR TITLE
fix: fail closed in CLI session launcher surface

### DIFF
--- a/client/cli/deploy/host/install-user-boundary.sh
+++ b/client/cli/deploy/host/install-user-boundary.sh
@@ -1,1 +1,155 @@
-../../../../shared/deploy/host/install-user-boundary.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+user_name="${1:-}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+default_config_src="/etc/veilkey/session-tools.toml"
+if [[ ! -f "$default_config_src" ]]; then
+  default_config_src="$(dirname "$0")/session-tools.toml.example"
+fi
+config_src="${2:-$default_config_src}"
+config_dst="${VEILKEY_SESSION_CONFIG_DST:-/etc/veilkey/session-tools.toml}"
+session_config_install_bin="${VEILKEY_SESSION_CONFIG_INSTALL_BIN:-/usr/local/bin/veilkey-session-config}"
+session_launch_bin="${VEILKEY_SESSION_LAUNCH_BIN:-/usr/local/bin/veilkey-session-launch}"
+veilkey_bin="${VEILKEY_BIN:-/usr/local/bin/veilkey}"
+profile_dir="${VEILKEY_PROFILE_DIR:-/etc/profile.d}"
+proxy_log_dir="${VEILKEY_PROXY_LOG_DIR:-/var/log/veilkey-proxy}"
+
+if [[ -z "$user_name" ]]; then
+  echo "usage: $(basename "$0") <user> [config-src]" >&2
+  exit 2
+fi
+if ! [[ "$user_name" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+  echo "invalid user name: $user_name" >&2
+  exit 2
+fi
+
+if [[ "${VEILKEY_ALLOW_SESSION_BOOTSTRAP:-0}" != "1" ]]; then
+  echo "$(basename "$0") is an internal session bootstrap helper; use install-veilroot-boundary.sh for supported host boundary setup" >&2
+  exit 1
+fi
+
+ensure_tmux() {
+  if command -v tmux >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ "${VEILKEY_SKIP_PACKAGE_INSTALL:-0}" == "1" ]]; then
+    echo "tmux is missing (skipped package install by VEILKEY_SKIP_PACKAGE_INSTALL=1)" >&2
+    return 0
+  fi
+  if command -v apt-get >/dev/null 2>&1; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update >/dev/null
+    apt-get install -y tmux >/dev/null
+  else
+    echo "tmux is missing and no supported package manager (apt-get) was found" >&2
+  fi
+}
+
+ensure_go() {
+  if command -v go >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ "${VEILKEY_SKIP_PACKAGE_INSTALL:-0}" == "1" ]]; then
+    echo "go is missing (skipped package install by VEILKEY_SKIP_PACKAGE_INSTALL=1)" >&2
+    exit 1
+  fi
+  if command -v apt-get >/dev/null 2>&1; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update >/dev/null
+    apt-get install -y golang-go >/dev/null
+    return 0
+  fi
+  echo "go is missing and no supported package manager (apt-get) was found" >&2
+  exit 1
+}
+
+id "$user_name" >/dev/null 2>&1 || { echo "unknown user: $user_name" >&2; exit 1; }
+
+home_dir="$(getent passwd "$user_name" | cut -d: -f6)"
+
+install -d /etc/veilkey "$proxy_log_dir" "$home_dir/.config/environment.d" "$home_dir/.local/bin" "$profile_dir"
+if [[ "$config_src" != "$config_dst" ]]; then
+  install -m 0644 "$config_src" "$config_dst"
+fi
+ensure_go
+session_config_tmp="$(mktemp)"
+go build -o "$session_config_tmp" "$repo_root/cmd/veilkey-session-config"
+install -m 0755 "$session_config_tmp" "$session_config_install_bin"
+rm -f "$session_config_tmp"
+ensure_tmux
+
+cat >"$session_launch_bin" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+session_config_bin="${VEILKEY_SESSION_CONFIG_BIN:-/usr/local/bin/veilkey-session-config}"
+if [[ $# -lt 1 ]]; then
+  echo "usage: veilkey-session-launch <tool> [args...]" >&2
+  exit 2
+fi
+tool="$1"
+shift
+real_bin="$("$session_config_bin" tool-bin "$tool")" || {
+  echo "unknown or invalid tool mapping: ${tool}" >&2
+  exit 2
+}
+if [[ ! -x "$real_bin" ]]; then
+  echo "mapped binary is not executable: $real_bin" >&2
+  exit 2
+fi
+while IFS='=' read -r _vk_key _vk_val; do
+  _vk_key="${_vk_key#export }"
+  [[ "$_vk_key" =~ ^[A-Za-z_][A-Za-z_0-9]*$ ]] || continue
+  _vk_val="${_vk_val%\"}" ; _vk_val="${_vk_val#\"}"
+  export "${_vk_key}=${_vk_val}"
+done < <("$session_config_bin" tool-shell-exports "$tool")
+if [[ "${VEILKEY_VEILROOT:-}" == "1" ]]; then
+  exec "$real_bin" "$@"
+fi
+echo "veilkey-session-launch: refusing direct exec without a verified Veil session boundary" >&2
+exit 1
+SCRIPT
+chmod 0755 "$session_launch_bin"
+
+cat >"$profile_dir/${user_name}-veilkey-proxy.sh" <<SCRIPT
+[ "\${USER:-}" = "$user_name" ] || return 0
+while IFS='=' read -r _vk_key _vk_val; do
+  _vk_key="\${_vk_key#export }"
+  [[ "\$_vk_key" =~ ^[A-Za-z_][A-Za-z_0-9]*$ ]] || continue
+  _vk_val="\${_vk_val%\"}" ; _vk_val="\${_vk_val#\"}"
+  export "\${_vk_key}=\${_vk_val}"
+done < <("$session_config_install_bin" shell-exports)
+export VEILKEY_PROXY_STATE=active
+SCRIPT
+chmod 0644 "$profile_dir/${user_name}-veilkey-proxy.sh"
+
+"$session_config_install_bin" shell-exports | sed 's/^export //' >"$home_dir/.config/environment.d/50-veilkey-proxy.conf"
+for tool in codex claude opencode; do
+  cat >"$home_dir/.local/bin/${tool}" <<SCRIPT
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$session_launch_bin" ${tool} "\$@"
+SCRIPT
+  chmod 0755 "$home_dir/.local/bin/${tool}"
+done
+
+cat >"$home_dir/.bash_profile" <<SCRIPT
+# ${user_name} login boundary
+[ -f ~/.profile ] && . ~/.profile
+while IFS='=' read -r _vk_key _vk_val; do
+  _vk_key="\${_vk_key#export }"
+  [[ "\$_vk_key" =~ ^[A-Za-z_][A-Za-z_0-9]*$ ]] || continue
+  _vk_val="\${_vk_val%\"}" ; _vk_val="\${_vk_val#\"}"
+  export "\${_vk_key}=\${_vk_val}"
+done < <("$session_config_install_bin" shell-exports)
+alias codex="\$HOME/.local/bin/codex"
+alias claude="\$HOME/.local/bin/claude"
+alias opencode="\$HOME/.local/bin/opencode"
+SCRIPT
+
+chown -R "${user_name}:${user_name}" "$home_dir/.config" "$home_dir/.local" "$home_dir/.bash_profile"
+systemctl daemon-reload
+if [[ "${VEILKEY_SKIP_SESSION_PRIME:-0}" != "1" ]]; then
+  su - "$user_name" -c "tmux has-session -t main >/dev/null 2>&1 || tmux new-session -d -s main" >/dev/null 2>&1 || true
+fi
+echo "installed veilkey boundary for ${user_name}"

--- a/client/cli/tests/test_session_launch_fail_closed.sh
+++ b/client/cli/tests/test_session_launch_fail_closed.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+. tests/lib/testlib.sh
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/fakebin" "$tmp/home" "$tmp/etc/veilkey"
+
+cat >"$tmp/session-tools.toml" <<'SCRIPT'
+version = 1
+SCRIPT
+
+cat >"$tmp/fakebin/id" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-u" ]]; then
+  printf '%s\n' "1234"
+  exit 0
+fi
+exit 0
+SCRIPT
+chmod +x "$tmp/fakebin/id"
+
+cat >"$tmp/fakebin/getent" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "passwd" ]]; then
+  printf 'veiltest:x:1234:1234::%s:/bin/bash\n' "${VEILKEY_TEST_HOME:?}"
+  exit 0
+fi
+exit 1
+SCRIPT
+chmod +x "$tmp/fakebin/getent"
+
+cat >"$tmp/fakebin/chown" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+SCRIPT
+chmod +x "$tmp/fakebin/chown"
+
+cat >"$tmp/fakebin/systemctl" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+SCRIPT
+chmod +x "$tmp/fakebin/systemctl"
+
+cat >"$tmp/stub-session-config" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  tool-bin)
+    printf '%s\n' "${VEILKEY_REAL_TOOL:?}"
+    ;;
+  tool-shell-exports)
+    exit 0
+    ;;
+  shell-exports)
+    exit 0
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$tmp/stub-session-config"
+
+cat >"$tmp/real-tool" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "real-tool:$*"
+SCRIPT
+chmod +x "$tmp/real-tool"
+
+VEILKEY_ALLOW_SESSION_BOOTSTRAP=1 \
+VEILKEY_SKIP_PACKAGE_INSTALL=1 \
+VEILKEY_SKIP_SESSION_PRIME=1 \
+VEILKEY_TEST_HOME="$tmp/home" \
+VEILKEY_SESSION_CONFIG_DST="$tmp/etc/veilkey/session-tools.toml" \
+VEILKEY_SESSION_CONFIG_INSTALL_BIN="$tmp/fakebin/veilkey-session-config" \
+VEILKEY_SESSION_LAUNCH_BIN="$tmp/fakebin/veilkey-session-launch" \
+VEILKEY_PROFILE_DIR="$tmp/etc/profile.d" \
+VEILKEY_PROXY_LOG_DIR="$tmp/log" \
+PATH="$tmp/fakebin:$PATH" \
+deploy/host/install-user-boundary.sh veiltest "$tmp/session-tools.toml" >/dev/null
+
+cp "$tmp/stub-session-config" "$tmp/fakebin/veilkey-session-config"
+
+out="$(VEILKEY_SESSION_CONFIG_BIN="$tmp/fakebin/veilkey-session-config" VEILKEY_ACTIVE=1 VEILKEY_REAL_TOOL="$tmp/real-tool" "$tmp/fakebin/veilkey-session-launch" codex 2>&1 || true)"
+assert_contains "$out" "refusing direct exec without a verified Veil session boundary"
+
+out="$(VEILKEY_SESSION_CONFIG_BIN="$tmp/fakebin/veilkey-session-config" VEILKEY_VEILROOT=1 VEILKEY_REAL_TOOL="$tmp/real-tool" "$tmp/fakebin/veilkey-session-launch" codex hello)"
+assert_contains "$out" "real-tool:hello"
+
+echo "ok: session launch fail closed"


### PR DESCRIPTION
## Summary
- replace the CLI host-boundary source symlink with a dedicated fail-closed launcher script
- require `VEILKEY_VEILROOT=1` before `veilkey-session-launch` will exec the mapped tool
- add a focused shell test for direct-exec refusal and verified-boundary success

## Testing
- `cd client/cli && bash tests/test_install_user_boundary.sh`
- `cd client/cli && bash tests/test_session_launch_fail_closed.sh`
- `cd client/cli && go test ./...`
- `cd client/cli && PATH="$PATH:/root/go/bin" goreleaser check`

Partial fix for #35.