### PR TITLE
feat: make veil default to work-container runtime

### DIFF
--- a/client/cli/deploy/host/veil
+++ b/client/cli/deploy/host/veil
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${VEIL_WORK_CONTAINER_ENABLE:-0}" == "1" ]]; then
-  work_container_bin="${VEIL_WORK_CONTAINER_BIN:-/usr/local/bin/veil-work-container}"
-  if [[ ! -x "${work_container_bin}" ]]; then
-    echo "veil: configured work-container entrypoint not found: ${work_container_bin}" >&2
-    exit 1
-  fi
+work_container_bin="${VEIL_WORK_CONTAINER_BIN:-/usr/local/bin/veil-work-container}"
+if [[ -x "${work_container_bin}" ]]; then
   exec "${work_container_bin}" "$@"
 fi
 
-veilroot_shell="${VEILKEY_VEILROOT_SHELL_BIN:-/usr/local/bin/veilroot-shell}"
-
-if [[ ! -x "${veilroot_shell}" ]]; then
-  echo "veil: required session entrypoint not found: ${veilroot_shell}" >&2
-  echo "veil: install the Veil host boundary first or set VEILKEY_VEILROOT_SHELL_BIN" >&2
-  exit 1
+if [[ "${VEIL_LEGACY_VEILROOT:-0}" == "1" ]]; then
+  veilroot_shell="${VEILKEY_VEILROOT_SHELL_BIN:-/usr/local/bin/veilroot-shell}"
+  if [[ ! -x "${veilroot_shell}" ]]; then
+    echo "veil: legacy veilroot entrypoint not found: ${veilroot_shell}" >&2
+    exit 1
+  fi
+  exec "${veilroot_shell}" open "$@"
 fi
 
-exec "${veilroot_shell}" open "$@"
+echo "veil: work-container entrypoint not found: ${work_container_bin}" >&2
+echo "veil: install the Veil work-container runtime or set VEIL_WORK_CONTAINER_BIN" >&2
+echo "veil: set VEIL_LEGACY_VEILROOT=1 only for temporary fallback during migration" >&2
+exit 1

--- a/client/cli/tests/test_veil_entrypoint.sh
+++ b/client/cli/tests/test_veil_entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+. tests/lib/testlib.sh
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat >"$tmp/veil-work-container" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "work-container:$*"
+SCRIPT
+chmod +x "$tmp/veil-work-container"
+
+cat >"$tmp/veilroot-shell" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "legacy:$*"
+SCRIPT
+chmod +x "$tmp/veilroot-shell"
+
+out="$(VEIL_WORK_CONTAINER_BIN="$tmp/veil-work-container" "$PWD/deploy/host/veil" codex)"
+assert_contains "$out" "work-container:codex"
+
+out="$(VEIL_WORK_CONTAINER_BIN="$tmp/missing-work-container" "$PWD/deploy/host/veil" 2>&1 || true)"
+assert_contains "$out" "work-container entrypoint not found"
+assert_contains "$out" "VEIL_LEGACY_VEILROOT=1"
+
+out="$(VEIL_WORK_CONTAINER_BIN="$tmp/missing-work-container" VEIL_LEGACY_VEILROOT=1 VEILKEY_VEILROOT_SHELL_BIN="$tmp/veilroot-shell" "$PWD/deploy/host/veil" open)"
+assert_contains "$out" "legacy:open"
+
+echo "ok: veil entrypoint"


### PR DESCRIPTION
## Summary
- make `veil` prefer `veil-work-container` by default
- demote `veilroot-shell` to an explicit `VEIL_LEGACY_VEILROOT=1` migration fallback
- add a focused shell test covering default work-container path, missing runtime failure, and legacy fallback

## Testing
- `cd client/cli && bash tests/test_veil_entrypoint.sh`
- `cd client/cli && go test ./...`
- `cd client/cli && PATH="$PATH:/root/go/bin" goreleaser check`

Progress on #31 and #37.