### PR TITLE
fix: remove remaining hardcoded values, add pre-commit enforcement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,14 @@ Contributions are welcome, but changes should prove the exact path they touch.
 2. User-facing or operator-facing behavior changes must update README or docs in the same change.
 3. Installer and deploy changes should verify one real operator path whenever practical.
 4. Do not introduce plaintext-secret examples where an existing masked or file-based path already exists.
+5. Do not hardcode default values (ports, file paths, URLs) in Go source code. All runtime values must come from environment variables. If a value is missing, the process must exit with a clear error — no silent fallbacks. Default values belong in `.env.example` only.
+
+A pre-commit hook enforces rule 5. To install it:
+
+```bash
+cp scripts/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
 
 ## Where To Start
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# 하드코딩된 기본값이 Go 소스코드에 있으면 커밋 차단
+BANNED=(
+  ":10180"
+  ":10181"
+  "/opt/veilkey"
+  "/etc/veilkey"
+  "/usr/local/bin/veilkey"
+)
+
+found=0
+for val in "${BANNED[@]}"; do
+  matches=$(grep -rn --include="*.go" "$val" services/localvault services/vaultcenter 2>/dev/null || true)
+  if [[ -n "$matches" ]]; then
+    echo "❌ 하드코딩 금지: '$val'"
+    echo "$matches"
+    found=1
+  fi
+done
+
+if [[ $found -eq 1 ]]; then
+  echo ""
+  echo "env에서 읽으세요. 기본값은 .env.example 참고."
+  exit 1
+fi

--- a/services/vaultcenter/.env.example
+++ b/services/vaultcenter/.env.example
@@ -24,6 +24,13 @@ VEILKEY_PASSWORD_FILE=/etc/veilkey/vaultcenter.password
 # Interval for temp ref garbage collection (e.g. "5m", "30s"). Default: 5m
 # VEILKEY_GC_INTERVAL=5m
 
+# --- Paths ---
+# Directory for bulk-apply config files
+VEILKEY_BULK_APPLY_DIR=/etc/veilkey/bulk-apply
+
+# Directory for global function binaries (veilkey-cli functions)
+VEILKEY_FUNCTION_DIR=/opt/veilkey/veilkey-cli/functions
+
 # --- TLS Configuration ---
 # Certificate and key for HTTPS listener
 # VEILKEY_TLS_CERT=/etc/veilkey/tls/server.crt

--- a/services/vaultcenter/cmd/main.go
+++ b/services/vaultcenter/cmd/main.go
@@ -240,7 +240,7 @@ func runHKMInit() {
 		fmt.Println("")
 		fmt.Printf("  Password ref: %s\n", tempRef)
 		fmt.Println("  This ref expires in 1 hour. Retrieve your password before then:")
-		fmt.Printf("    curl -s http://localhost:10180/api/resolve/%s\n", tempRef)
+		fmt.Printf("    curl -s http://localhost:<port>/api/resolve/%s\n", tempRef)
 	}
 	fmt.Println("")
 	fmt.Println("  WARNING: Your password is the only way to unlock this server.")

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -139,7 +139,7 @@ func (s *Server) BulkApplyDir() string {
 	if strings.TrimSpace(s.bulkApplyDir) != "" {
 		return strings.TrimSpace(s.bulkApplyDir)
 	}
-	return "/etc/veilkey/bulk-apply"
+	return os.Getenv("VEILKEY_BULK_APPLY_DIR")
 }
 
 func (s *Server) SetSalt(salt []byte) {

--- a/services/vaultcenter/internal/api/hkm_configs_bulk_set.go
+++ b/services/vaultcenter/internal/api/hkm_configs_bulk_set.go
@@ -21,7 +21,7 @@ type bulkSetCheck struct {
 // POST /api/configs/bulk-set
 // Sets a key=value on ALL agents (or creates if not exists).
 // All-or-nothing: if any agent fails, the entire operation is rolled back.
-// Request: {"key": "VEILKEY_VAULTCENTER_URL", "value": "http://your-hub:10180"}
+// Request: {"key": "VEILKEY_VAULTCENTER_URL", "value": "http://your-hub:<port>"}
 // Optional: {"key": "...", "value": "...", "overwrite": false}  — skip agents that already have the key
 func (s *Server) handleConfigsBulkSet(w http.ResponseWriter, r *http.Request) {
 	var req struct {

--- a/services/vaultcenter/internal/api/hkm_global_function_run.go
+++ b/services/vaultcenter/internal/api/hkm_global_function_run.go
@@ -53,7 +53,7 @@ func (s *Server) localFunctionBaseURL() string {
 		scheme = "https"
 	}
 	if addr == "" {
-		return scheme + "://127.0.0.1:10180"
+		return ""
 	}
 	if strings.HasPrefix(addr, ":") {
 		return scheme + "://127.0.0.1" + addr
@@ -142,7 +142,7 @@ func (s *Server) renderGlobalFunctionCommand(fn *db.GlobalFunction) (string, err
 func (s *Server) buildGlobalFunctionRunEnv(req globalFunctionRunRequest) ([]string, []string, error) {
 	env := append(os.Environ(),
 		"VEILKEY_LOCALVAULT_URL="+s.localFunctionBaseURL(),
-		"VEILKEY_FUNCTION_DIR=/opt/veilkey/veilkey-cli/functions",
+		"VEILKEY_FUNCTION_DIR="+os.Getenv("VEILKEY_FUNCTION_DIR"),
 	)
 	applied := []string{}
 	apply := func(key, value string) {

--- a/services/vaultcenter/internal/api/install_apply.go
+++ b/services/vaultcenter/internal/api/install_apply.go
@@ -203,7 +203,7 @@ func validateInstallConfig(cfg *db.UIConfig, req installValidateRequest) install
 		result.Warnings = append(result.Warnings, "localvault_url is empty; localvault health verification will be skipped")
 	}
 	if strings.TrimSpace(cfg.TLSCertPath) == "" || strings.TrimSpace(cfg.TLSKeyPath) == "" {
-		result.Warnings = append(result.Warnings, "TLS cert/key not configured; services will start without HTTPS. Place cert at /etc/veilkey/tls/server.crt and key at /etc/veilkey/tls/server.key")
+		result.Warnings = append(result.Warnings, "TLS cert/key not configured; services will start without HTTPS. Set VEILKEY_TLS_CERT and VEILKEY_TLS_KEY env vars to enable TLS.")
 	}
 	result.CommandPreview = installCommand(result.ResolvedScript, cfg)
 	return result

--- a/services/vaultcenter/internal/db/models.go
+++ b/services/vaultcenter/internal/db/models.go
@@ -189,7 +189,7 @@ type Agent struct {
 	BlockedAt        *time.Time `gorm:"column:blocked_at" json:"blocked_at"`
 	BlockReason      string     `gorm:"column:block_reason" json:"block_reason"`
 	IP               string     `gorm:"column:ip" json:"ip"`
-	Port             int        `gorm:"column:port;default:10180" json:"port"`
+	Port             int        `gorm:"column:port;default:0" json:"port"`
 	DEK              []byte     `gorm:"column:dek" json:"dek"`
 	DEKNonce         []byte     `gorm:"column:dek_nonce" json:"dek_nonce"`
 	SecretsCount     int        `gorm:"column:secrets_count;default:0" json:"secrets_count"`


### PR DESCRIPTION
## Summary

- `vaultcenter`: `:10180` fallback 제거 — `VEILKEY_ADDR` 없으면 빈 문자열 반환
- `vaultcenter`: `VEILKEY_FUNCTION_DIR`, `VEILKEY_BULK_APPLY_DIR` env에서 읽도록 변경
- `vaultcenter`: DB 모델 port default `10180` → `0`
- `vaultcenter`: warning/주석에서 `/etc/veilkey` 경로 제거, env var 참조로 교체
- `vaultcenter/.env.example`: 신규 env 변수 추가
- `scripts/pre-commit`: 하드코딩된 포트/경로 감지 hook 추가 (레포에 포함)
- `CONTRIBUTING.md`: 하드코딩 금지 규칙(#5) 추가

## Test plan

- [ ] `bash scripts/pre-commit` 실행 시 이슈 없음 확인
- [ ] vaultcenter 빌드 성공 확인
- [ ] `VEILKEY_BULK_APPLY_DIR`, `VEILKEY_FUNCTION_DIR` env 없이 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)