### PR TITLE
refactor(vaultcenter): reduce boilerplate across api and db layers

### DIFF
--- a/services/vaultcenter/go.mod
+++ b/services/vaultcenter/go.mod
@@ -14,6 +14,7 @@ require (
 require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/wneessen/go-mail v0.7.2 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
 

--- a/services/vaultcenter/go.sum
+++ b/services/vaultcenter/go.sum
@@ -11,6 +11,8 @@ github.com/mutecomm/go-sqlcipher/v4 v4.4.2/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
+github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=

--- a/services/vaultcenter/internal/api/admin_auth.go
+++ b/services/vaultcenter/internal/api/admin_auth.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -665,7 +664,7 @@ func (s *Server) handleAdminTrackedRefCleanupPreview(w http.ResponseWriter, r *h
 		Reasons []string `json:"reasons"`
 	}
 	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = decodeJSON(r, &req)
 	}
 	resp, err := s.adminTrackedRefCleanupResponse(false, req.Reasons)
 	if err != nil {
@@ -892,7 +891,7 @@ func totpCode(secret string, now time.Time) string {
 }
 
 func decodeRequestJSON(r *http.Request, dst any) error {
-	return json.NewDecoder(r.Body).Decode(dst)
+	return decodeJSON(r, dst)
 }
 
 func (s *Server) resolveAdminReveal(ref string) (map[string]any, error) {

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -311,6 +311,14 @@ func (s *Server) requireTrustedIP(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+func pathVal(r *http.Request, key string) string {
+	return strings.TrimSpace(r.PathValue(key))
+}
+
+func decodeJSON(r *http.Request, dst any) error {
+	return json.NewDecoder(r.Body).Decode(dst)
+}
+
 func (s *Server) respondJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/services/vaultcenter/internal/api/approval_tokens.go
+++ b/services/vaultcenter/internal/api/approval_tokens.go
@@ -18,7 +18,7 @@ type approvalTokenSubmitRequest struct {
 }
 
 func (s *Server) handleApprovalTokenPage(w http.ResponseWriter, r *http.Request) {
-	token := strings.TrimSpace(r.PathValue("token"))
+	token := pathVal(r, "token")
 	if token == "" {
 		s.respondError(w, http.StatusBadRequest, "token is required")
 		return
@@ -52,7 +52,7 @@ func (s *Server) handleApprovalTokenPage(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleApprovalTokenSubmit(w http.ResponseWriter, r *http.Request) {
-	token := strings.TrimSpace(r.PathValue("token"))
+	token := pathVal(r, "token")
 	if token == "" {
 		s.respondError(w, http.StatusBadRequest, "token is required")
 		return
@@ -82,7 +82,7 @@ func (s *Server) handleApprovalTokenChallengeSubmit(w http.ResponseWriter, r *ht
 
 	var req approvalTokenSubmitRequest
 	if strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "application/json") {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := decodeJSON(r, &req); err != nil {
 			s.respondError(w, http.StatusBadRequest, "invalid request body")
 			return
 		}

--- a/services/vaultcenter/internal/api/bulk_apply_templates.go
+++ b/services/vaultcenter/internal/api/bulk_apply_templates.go
@@ -187,7 +187,7 @@ func (s *Server) renderResolvedBulkApplyPreview(vaultHash, body string) string {
 }
 
 func (s *Server) handleBulkApplyTemplates(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
+	vaultHash := pathVal(r, "vault")
 	if vaultHash == "" {
 		s.respondError(w, http.StatusBadRequest, "vault is required")
 		return
@@ -226,8 +226,8 @@ func (s *Server) handleBulkApplyTemplates(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleBulkApplyTemplate(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
-	name := strings.TrimSpace(r.PathValue("name"))
+	vaultHash := pathVal(r, "vault")
+	name := pathVal(r, "name")
 	if vaultHash == "" || name == "" {
 		s.respondError(w, http.StatusBadRequest, "vault and name are required")
 		return
@@ -268,8 +268,8 @@ func (s *Server) handleBulkApplyTemplate(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleBulkApplyTemplatePreview(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
-	name := strings.TrimSpace(r.PathValue("name"))
+	vaultHash := pathVal(r, "vault")
+	name := pathVal(r, "name")
 	if vaultHash == "" || name == "" {
 		s.respondError(w, http.StatusBadRequest, "vault and name are required")
 		return

--- a/services/vaultcenter/internal/api/bulk_apply_workflows.go
+++ b/services/vaultcenter/internal/api/bulk_apply_workflows.go
@@ -224,7 +224,7 @@ func (s *Server) saveBulkApplyRun(vaultHash, workflowName, runKind, status strin
 }
 
 func (s *Server) handleBulkApplyWorkflows(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
+	vaultHash := pathVal(r, "vault")
 	if vaultHash == "" {
 		s.respondError(w, http.StatusBadRequest, "vault is required")
 		return
@@ -246,8 +246,8 @@ func (s *Server) handleBulkApplyWorkflows(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleBulkApplyWorkflow(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
-	workflowName := strings.TrimSpace(r.PathValue("name"))
+	vaultHash := pathVal(r, "vault")
+	workflowName := pathVal(r, "name")
 	if vaultHash == "" || workflowName == "" {
 		s.respondError(w, http.StatusBadRequest, "vault and workflow are required")
 		return
@@ -268,8 +268,8 @@ func (s *Server) handleBulkApplyWorkflow(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleBulkApplyWorkflowRuns(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
-	workflowName := strings.TrimSpace(r.PathValue("name"))
+	vaultHash := pathVal(r, "vault")
+	workflowName := pathVal(r, "name")
 	if vaultHash == "" || workflowName == "" {
 		s.respondError(w, http.StatusBadRequest, "vault and workflow are required")
 		return
@@ -292,7 +292,7 @@ func (s *Server) handleBulkApplyWorkflowRuns(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) handleBulkApplyRun(w http.ResponseWriter, r *http.Request) {
-	runID := strings.TrimSpace(r.PathValue("run"))
+	runID := pathVal(r, "run")
 	if runID == "" {
 		s.respondError(w, http.StatusBadRequest, "run is required")
 		return
@@ -326,52 +326,35 @@ func (s *Server) proxyBulkApplyWorkflow(r *http.Request, vaultHash, workflowName
 	return resp.StatusCode, respBody, nil
 }
 
-func (s *Server) handleBulkApplyWorkflowPrecheck(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
-	workflowName := strings.TrimSpace(r.PathValue("name"))
+func (s *Server) proxyAndRecordWorkflow(w http.ResponseWriter, r *http.Request, endpoint, runType, failStatus string) {
+	vaultHash := pathVal(r, "vault")
+	workflowName := pathVal(r, "name")
 	if vaultHash == "" || workflowName == "" {
 		s.respondError(w, http.StatusBadRequest, "vault and workflow are required")
 		return
 	}
-	statusCode, body, err := s.proxyBulkApplyWorkflow(r, vaultHash, workflowName, "/api/bulk-apply/precheck")
+	statusCode, body, err := s.proxyBulkApplyWorkflow(r, vaultHash, workflowName, endpoint)
 	if err != nil {
 		s.respondError(w, statusCode, err.Error())
 		return
 	}
 	var payload map[string]any
-	status := "precheck_failed"
+	status := failStatus
 	if json.Unmarshal(body, &payload) == nil {
 		if raw := strings.TrimSpace(fmt.Sprint(payload["status"])); raw != "" {
 			status = raw
 		}
 	}
-	s.saveBulkApplyRun(vaultHash, workflowName, "precheck", status, body)
+	s.saveBulkApplyRun(vaultHash, workflowName, runType, status, body)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(body)
 }
 
+func (s *Server) handleBulkApplyWorkflowPrecheck(w http.ResponseWriter, r *http.Request) {
+	s.proxyAndRecordWorkflow(w, r, "/api/bulk-apply/precheck", "precheck", "precheck_failed")
+}
+
 func (s *Server) handleBulkApplyWorkflowRun(w http.ResponseWriter, r *http.Request) {
-	vaultHash := strings.TrimSpace(r.PathValue("vault"))
-	workflowName := strings.TrimSpace(r.PathValue("name"))
-	if vaultHash == "" || workflowName == "" {
-		s.respondError(w, http.StatusBadRequest, "vault and workflow are required")
-		return
-	}
-	statusCode, body, err := s.proxyBulkApplyWorkflow(r, vaultHash, workflowName, "/api/bulk-apply/execute")
-	if err != nil {
-		s.respondError(w, statusCode, err.Error())
-		return
-	}
-	var payload map[string]any
-	status := "apply_failed"
-	if json.Unmarshal(body, &payload) == nil {
-		if raw := strings.TrimSpace(fmt.Sprint(payload["status"])); raw != "" {
-			status = raw
-		}
-	}
-	s.saveBulkApplyRun(vaultHash, workflowName, "run", status, body)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	_, _ = w.Write(body)
+	s.proxyAndRecordWorkflow(w, r, "/api/bulk-apply/execute", "run", "apply_failed")
 }

--- a/services/vaultcenter/internal/api/email_otp.go
+++ b/services/vaultcenter/internal/api/email_otp.go
@@ -3,7 +3,6 @@ package api
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -22,7 +21,7 @@ type emailOTPRequest struct {
 
 func (s *Server) handleCreateEmailOTPChallenge(w http.ResponseWriter, r *http.Request) {
 	var req emailOTPRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/handlers_exact_lookup.go
+++ b/services/vaultcenter/internal/api/handlers_exact_lookup.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -21,7 +20,7 @@ func (s *Server) handleExactLookup(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Plaintext string `json:"plaintext"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/handlers_temp_encrypt.go
+++ b/services/vaultcenter/internal/api/handlers_temp_encrypt.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -20,7 +19,7 @@ func (s *Server) handleTempEncrypt(w http.ResponseWriter, r *http.Request) {
 		Plaintext string `json:"plaintext"`
 		Name      string `json:"name"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_agent_heartbeat.go
+++ b/services/vaultcenter/internal/api/hkm_agent_heartbeat.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"log"
 	"net"
 	"net/http"
@@ -65,7 +64,7 @@ func (s *Server) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ConfigsCount   int      `json:"configs_count"`
 		Version        int      `json:"version"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_agent_save_secret.go
+++ b/services/vaultcenter/internal/api/hkm_agent_save_secret.go
@@ -21,7 +21,7 @@ func (s *Server) handleAgentSaveSecret(w http.ResponseWriter, r *http.Request) {
 		Name  string `json:"name"`
 		Value string `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" || req.Value == "" {
+	if err := decodeJSON(r, &req); err != nil || req.Name == "" || req.Value == "" {
 		s.respondError(w, http.StatusBadRequest, "name and value are required")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_agent_secret_fields.go
+++ b/services/vaultcenter/internal/api/hkm_agent_secret_fields.go
@@ -29,7 +29,7 @@ func (s *Server) handleAgentSaveSecretFields(w http.ResponseWriter, r *http.Requ
 	var req struct {
 		Fields []agentSecretField `json:"fields"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Fields) == 0 {
+	if err := decodeJSON(r, &req); err != nil || len(req.Fields) == 0 {
 		s.respondError(w, http.StatusBadRequest, "fields are required")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_configs_bulk_set.go
+++ b/services/vaultcenter/internal/api/hkm_configs_bulk_set.go
@@ -31,7 +31,7 @@ func (s *Server) handleConfigsBulkSet(w http.ResponseWriter, r *http.Request) {
 		Status    string `json:"status"`
 		Overwrite *bool  `json:"overwrite,omitempty"` // default true
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_configs_bulk_update.go
+++ b/services/vaultcenter/internal/api/hkm_configs_bulk_update.go
@@ -17,7 +17,7 @@ func (s *Server) handleConfigsBulkUpdate(w http.ResponseWriter, r *http.Request)
 		OldValue string `json:"old_value"`
 		NewValue string `json:"new_value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_global_function_run.go
+++ b/services/vaultcenter/internal/api/hkm_global_function_run.go
@@ -192,7 +192,7 @@ type globalFunctionRunRequest struct {
 }
 
 func (s *Server) handleGlobalFunctionRun(w http.ResponseWriter, r *http.Request) {
-	name := strings.TrimSpace(r.PathValue("name"))
+	name := pathVal(r, "name")
 	if name == "" {
 		s.respondError(w, http.StatusBadRequest, "function name is required")
 		return
@@ -204,7 +204,7 @@ func (s *Server) handleGlobalFunctionRun(w http.ResponseWriter, r *http.Request)
 	}
 
 	var req globalFunctionRunRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_global_functions.go
+++ b/services/vaultcenter/internal/api/hkm_global_functions.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 	"veilkey-vaultcenter/internal/db"
@@ -21,7 +20,7 @@ func (s *Server) handleGlobalFunctions(w http.ResponseWriter, r *http.Request) {
 		})
 	case http.MethodPost:
 		var req db.GlobalFunction
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := decodeJSON(r, &req); err != nil {
 			s.respondError(w, http.StatusBadRequest, "invalid json body")
 			return
 		}

--- a/services/vaultcenter/internal/api/hkm_heartbeat.go
+++ b/services/vaultcenter/internal/api/hkm_heartbeat.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 )
@@ -16,7 +15,7 @@ func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		URL           string `json:"url"`
 		Version       int    `json:"version"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_ref_cleanup.go
+++ b/services/vaultcenter/internal/api/hkm_ref_cleanup.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"slices"
 )
@@ -62,7 +61,7 @@ func (s *Server) handleTrackedRefCleanup(w http.ResponseWriter, r *http.Request)
 		Reasons []string `json:"reasons"`
 	}
 	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = decodeJSON(r, &req)
 	}
 
 	report, err := s.loadTrackedRefAuditReport()
@@ -83,10 +82,10 @@ func (s *Server) handleTrackedRefCleanup(w http.ResponseWriter, r *http.Request)
 		Apply:   req.Apply,
 		Actions: actions,
 		Counts: map[string]int{
-			"actions":          len(actions),
+			"actions":           len(actions),
 			"delete_candidates": 0,
-			"manual_actions":   0,
-			"deleted":          0,
+			"manual_actions":    0,
+			"deleted":           0,
 		},
 	}
 	for _, action := range actions {

--- a/services/vaultcenter/internal/api/hkm_ref_tracking.go
+++ b/services/vaultcenter/internal/api/hkm_ref_tracking.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -130,7 +129,7 @@ func (s *Server) handleTrackedRefSync(w http.ResponseWriter, r *http.Request) {
 		Version          int    `json:"version"`
 		Status           string `json:"status"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_register.go
+++ b/services/vaultcenter/internal/api/hkm_register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 	"net/url"
@@ -18,7 +17,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		Label         string `json:"label"`
 		URL           string `json:"url"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_rekey.go
+++ b/services/vaultcenter/internal/api/hkm_rekey.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,7 +13,7 @@ func (s *Server) handleRekey(w http.ResponseWriter, r *http.Request) {
 		DEK     []byte `json:"dek"`
 		Version int    `json:"version"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_set_parent.go
+++ b/services/vaultcenter/internal/api/hkm_set_parent.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 	"net/url"
@@ -13,7 +12,7 @@ func (s *Server) handleSetParent(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ParentURL string `json:"parent_url"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm_target_bindings.go
+++ b/services/vaultcenter/internal/api/hkm_target_bindings.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -10,8 +9,8 @@ import (
 )
 
 func (s *Server) handleTargetBindings(w http.ResponseWriter, r *http.Request) {
-	bindingType := strings.TrimSpace(r.PathValue("binding_type"))
-	targetName := strings.TrimSpace(r.PathValue("target_name"))
+	bindingType := pathVal(r, "binding_type")
+	targetName := pathVal(r, "target_name")
 	if bindingType == "" || targetName == "" {
 		s.respondError(w, http.StatusBadRequest, "binding_type and target_name are required")
 		return
@@ -55,8 +54,8 @@ func (s *Server) handleTargetBindings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTargetBindingsReplace(w http.ResponseWriter, r *http.Request) {
-	bindingType := strings.TrimSpace(r.PathValue("binding_type"))
-	targetName := strings.TrimSpace(r.PathValue("target_name"))
+	bindingType := pathVal(r, "binding_type")
+	targetName := pathVal(r, "target_name")
 	if bindingType == "" || targetName == "" {
 		s.respondError(w, http.StatusBadRequest, "binding_type and target_name are required")
 		return
@@ -71,7 +70,7 @@ func (s *Server) handleTargetBindingsReplace(w http.ResponseWriter, r *http.Requ
 			Required     *bool  `json:"required"`
 		} `json:"bindings"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -133,8 +132,8 @@ func (s *Server) handleTargetBindingsReplace(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) handleTargetImpact(w http.ResponseWriter, r *http.Request) {
-	bindingType := strings.TrimSpace(r.PathValue("binding_type"))
-	targetName := strings.TrimSpace(r.PathValue("target_name"))
+	bindingType := pathVal(r, "binding_type")
+	targetName := pathVal(r, "target_name")
 	if bindingType == "" || targetName == "" {
 		s.respondError(w, http.StatusBadRequest, "binding_type and target_name are required")
 		return
@@ -168,8 +167,8 @@ func (s *Server) handleTargetImpact(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTargetBindingsDeleteAll(w http.ResponseWriter, r *http.Request) {
-	bindingType := strings.TrimSpace(r.PathValue("binding_type"))
-	targetName := strings.TrimSpace(r.PathValue("target_name"))
+	bindingType := pathVal(r, "binding_type")
+	targetName := pathVal(r, "target_name")
 	if bindingType == "" || targetName == "" {
 		s.respondError(w, http.StatusBadRequest, "binding_type and target_name are required")
 		return
@@ -191,8 +190,8 @@ func (s *Server) handleTargetBindingsDeleteAll(w http.ResponseWriter, r *http.Re
 }
 
 func (s *Server) handleTargetSummary(w http.ResponseWriter, r *http.Request) {
-	bindingType := strings.TrimSpace(r.PathValue("binding_type"))
-	targetName := strings.TrimSpace(r.PathValue("target_name"))
+	bindingType := pathVal(r, "binding_type")
+	targetName := pathVal(r, "target_name")
 	if bindingType == "" || targetName == "" {
 		s.respondError(w, http.StatusBadRequest, "binding_type and target_name are required")
 		return

--- a/services/vaultcenter/internal/api/hkm_vault_keys.go
+++ b/services/vaultcenter/internal/api/hkm_vault_keys.go
@@ -546,7 +546,7 @@ func (s *Server) handleVaultKeyBindingSave(w http.ResponseWriter, r *http.Reques
 	_ = s.upsertTrackedRef(meta.Token, agent.KeyVersion, meta.Status, agent.AgentHash)
 
 	var raw map[string]json.RawMessage
-	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+	if err := decodeJSON(r, &raw); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -633,7 +633,7 @@ func (s *Server) handleVaultKeyBindingsReplace(w http.ResponseWriter, r *http.Re
 			Required    *bool  `json:"required"`
 		} `json:"bindings"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -781,7 +781,7 @@ func (s *Server) handleVaultKeyAudit(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleVaultKeyBindingDelete(w http.ResponseWriter, r *http.Request) {
 	hashOrLabel := r.PathValue("vault")
 	name := r.PathValue("name")
-	bindingID := strings.TrimSpace(r.PathValue("binding_id"))
+	bindingID := pathVal(r, "binding_id")
 	if bindingID == "" {
 		s.respondError(w, http.StatusBadRequest, "binding_id is required")
 		return
@@ -877,7 +877,7 @@ func (s *Server) handleVaultPatch(w http.ResponseWriter, r *http.Request) {
 		Description string   `json:"description"`
 		Tags        []string `json:"tags"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -899,7 +899,7 @@ func (s *Server) handleVaultKeyMetaPatch(w http.ResponseWriter, r *http.Request)
 		Description string   `json:"description"`
 		Tags        []string `json:"tags"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -983,7 +983,7 @@ func (s *Server) handleVaultKeySave(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleVaultKeyUpdate(w http.ResponseWriter, r *http.Request) {
-	name := strings.TrimSpace(r.PathValue("name"))
+	name := pathVal(r, "name")
 	if name == "" {
 		s.respondError(w, http.StatusBadRequest, "name is required")
 		return
@@ -992,7 +992,7 @@ func (s *Server) handleVaultKeyUpdate(w http.ResponseWriter, r *http.Request) {
 		Name  string `json:"name"`
 		Value string `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -1074,8 +1074,8 @@ func (s *Server) handleVaultKeyFieldGet(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleVaultKeyFieldUpdate(w http.ResponseWriter, r *http.Request) {
-	name := strings.TrimSpace(r.PathValue("name"))
-	fieldKey := strings.TrimSpace(r.PathValue("field"))
+	name := pathVal(r, "name")
+	fieldKey := pathVal(r, "field")
 	if name == "" || fieldKey == "" {
 		s.respondError(w, http.StatusBadRequest, "name and field are required")
 		return
@@ -1085,7 +1085,7 @@ func (s *Server) handleVaultKeyFieldUpdate(w http.ResponseWriter, r *http.Reques
 		Type  string `json:"type"`
 		Value string `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/install_bootstrap.go
+++ b/services/vaultcenter/internal/api/install_bootstrap.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -18,7 +17,7 @@ type installBootstrapRequest struct {
 
 func (s *Server) handleCreateInstallBootstrapChallenge(w http.ResponseWriter, r *http.Request) {
 	var req installBootstrapRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/install_custody.go
+++ b/services/vaultcenter/internal/api/install_custody.go
@@ -2,19 +2,17 @@ package api
 
 import (
 	"crypto/sha256"
-	"crypto/tls"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net"
 	"net/http"
-	"net/smtp"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	vcrypto "veilkey-vaultcenter/internal/crypto"
 	"veilkey-vaultcenter/internal/db"
+
+	"github.com/wneessen/go-mail"
 )
 
 type installCustodyRequest struct {
@@ -40,7 +38,7 @@ func appendUnique(items []string, value string) []string {
 
 func (s *Server) handleCreateInstallCustodyChallenge(w http.ResponseWriter, r *http.Request) {
 	var req installCustodyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -117,7 +115,7 @@ func (s *Server) handleInstallCustodyPage(w http.ResponseWriter, r *http.Request
 func (s *Server) handleSubmitInstallCustody(w http.ResponseWriter, r *http.Request) {
 	var req installCustodySubmitRequest
 	if strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "application/json") {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := decodeJSON(r, &req); err != nil {
 			s.respondError(w, http.StatusBadRequest, "invalid request body")
 			return
 		}
@@ -226,51 +224,36 @@ func sendInstallSendmail(from, to, subject, body string) error {
 
 func sendInstallSMTP(from, to, subject, body string) error {
 	host := strings.TrimSpace(os.Getenv("VEILKEY_OTP_SMTP_HOST"))
-	port := envDefault("VEILKEY_OTP_SMTP_PORT", "587")
+	portStr := envDefault("VEILKEY_OTP_SMTP_PORT", "587")
+	port, _ := strconv.Atoi(portStr)
 	username := strings.TrimSpace(os.Getenv("VEILKEY_OTP_SMTP_USERNAME"))
 	password := strings.TrimSpace(os.Getenv("VEILKEY_OTP_SMTP_PASSWORD"))
 	startTLS := strings.ToLower(envDefault("VEILKEY_OTP_SMTP_STARTTLS", "true")) != "false"
-	addr := net.JoinHostPort(host, port)
-	conn, err := net.Dial("tcp", addr)
+
+	m := mail.NewMsg()
+	if err := m.From(from); err != nil {
+		return fmt.Errorf("smtp from: %w", err)
+	}
+	if err := m.To(to); err != nil {
+		return fmt.Errorf("smtp to: %w", err)
+	}
+	m.Subject(subject)
+	m.SetBodyString(mail.TypeTextPlain, body)
+
+	tlsPolicy := mail.TLSOpportunistic
+	if !startTLS {
+		tlsPolicy = mail.NoTLS
+	}
+	c, err := mail.NewClient(host,
+		mail.WithPort(port),
+		mail.WithUsername(username),
+		mail.WithPassword(password),
+		mail.WithTLSPolicy(tlsPolicy),
+	)
 	if err != nil {
-		return fmt.Errorf("smtp dial failed: %w", err)
+		return fmt.Errorf("smtp client: %w", err)
 	}
-	defer conn.Close()
-	client, err := smtp.NewClient(conn, host)
-	if err != nil {
-		return fmt.Errorf("smtp client failed: %w", err)
-	}
-	defer client.Close()
-	if startTLS {
-		if ok, _ := client.Extension("STARTTLS"); ok {
-			if err := client.StartTLS(&tls.Config{ServerName: host}); err != nil {
-				return fmt.Errorf("smtp starttls failed: %w", err)
-			}
-		}
-	}
-	if username != "" || password != "" {
-		auth := smtp.PlainAuth("", username, password, host)
-		if err := client.Auth(auth); err != nil {
-			return fmt.Errorf("smtp auth failed: %w", err)
-		}
-	}
-	if err := client.Mail(from); err != nil {
-		return fmt.Errorf("smtp MAIL FROM failed: %w", err)
-	}
-	if err := client.Rcpt(to); err != nil {
-		return fmt.Errorf("smtp RCPT TO failed: %w", err)
-	}
-	wc, err := client.Data()
-	if err != nil {
-		return fmt.Errorf("smtp DATA failed: %w", err)
-	}
-	if _, err := io.WriteString(wc, formatInstallMail(from, to, subject, body)); err != nil {
-		return fmt.Errorf("smtp write failed: %w", err)
-	}
-	if err := wc.Close(); err != nil {
-		return fmt.Errorf("smtp close failed: %w", err)
-	}
-	return client.Quit()
+	return c.DialAndSend(m)
 }
 
 func formatInstallMail(from, to, subject, body string) string {

--- a/services/vaultcenter/internal/api/install_sessions.go
+++ b/services/vaultcenter/internal/api/install_sessions.go
@@ -99,7 +99,7 @@ func installStateFromPayload(req installStatePayload) *db.InstallSession {
 
 func (s *Server) handleCreateInstallSession(w http.ResponseWriter, r *http.Request) {
 	var req installStatePayload
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -146,7 +146,7 @@ func (s *Server) handleGetInstallState(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handlePatchInstallState(w http.ResponseWriter, r *http.Request) {
 	var req installStatePatchRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/local_configs.go
+++ b/services/vaultcenter/internal/api/local_configs.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -89,7 +88,7 @@ func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 		Key   string  `json:"key"`
 		Value *string `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -155,7 +154,7 @@ func (s *Server) handleSaveConfigsBulk(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Configs map[string]string `json:"configs"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/services/vaultcenter/internal/api/secret_input.go
+++ b/services/vaultcenter/internal/api/secret_input.go
@@ -29,7 +29,7 @@ type secretInputSubmitRequest struct {
 
 func (s *Server) handleCreateSecretInputChallenge(w http.ResponseWriter, r *http.Request) {
 	var req secretInputRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -91,7 +91,7 @@ func (s *Server) handleSecretInputPage(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSubmitSecretInput(w http.ResponseWriter, r *http.Request) {
 	var req secretInputSubmitRequest
 	if strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "application/json") {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := decodeJSON(r, &req); err != nil {
 			s.respondError(w, http.StatusBadRequest, "invalid request body")
 			return
 		}

--- a/services/vaultcenter/internal/db/admin_auth.go
+++ b/services/vaultcenter/internal/db/admin_auth.go
@@ -60,10 +60,8 @@ func (d *DB) GetAdminSessionByTokenHash(tokenHash string) (*AdminSession, error)
 func (d *DB) TouchAdminSession(sessionID string, lastSeenAt, idleExpiresAt time.Time) error {
 	return d.conn.Model(&AdminSession{}).
 		Where("session_id = ? AND revoked_at IS NULL", sessionID).
-		Updates(map[string]any{
-			"last_seen_at":    lastSeenAt.UTC(),
-			"idle_expires_at": idleExpiresAt.UTC(),
-		}).Error
+		Select("LastSeenAt", "IdleExpiresAt").
+		Updates(&AdminSession{LastSeenAt: lastSeenAt.UTC(), IdleExpiresAt: idleExpiresAt.UTC()}).Error
 }
 
 func (d *DB) UpdateAdminSessionRevealUntil(sessionID string, revealUntil *time.Time) error {

--- a/services/vaultcenter/internal/db/db.go
+++ b/services/vaultcenter/internal/db/db.go
@@ -123,6 +123,29 @@ func (d *DB) migrate() error {
 	return d.PromoteOperationalTempRefs(nil)
 }
 
+// dbFirst fetches the first record matching query. Returns notFound error if no record exists.
+func dbFirst[T any](d *DB, notFound, query string, args ...any) (*T, error) {
+	var out T
+	conds := append([]any{query}, args...)
+	if err := d.conn.First(&out, conds...).Error; err != nil {
+		return nil, fmt.Errorf("%s", notFound)
+	}
+	return &out, nil
+}
+
+// dbDeleteWhere deletes records matching query. Returns notFound error if no rows affected.
+func dbDeleteWhere[T any](d *DB, notFound, query string, args ...any) error {
+	conds := append([]any{query}, args...)
+	result := d.conn.Delete(new(T), conds...)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", notFound)
+	}
+	return nil
+}
+
 func (d *DB) Close() error {
 	sqlDB, err := d.conn.DB()
 	if err != nil {

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -59,24 +59,19 @@ func (d *DB) UpsertAgent(nodeID, label, vaultHash, vaultName, ip string, port, s
 		return d.UpsertVaultInventoryFromAgent(&agent)
 	}
 	// Update existing
-	role := strings.TrimSpace(existing.AgentRole)
-	if role == "" {
-		role = "agent"
+	if strings.TrimSpace(existing.AgentRole) == "" {
+		existing.AgentRole = "agent"
 	}
-	if err := d.conn.Model(&existing).Updates(map[string]interface{}{
-		"label":         label,
-		"vault_hash":    vaultHash,
-		"vault_name":    vaultName,
-		"agent_role":    role,
-		"host_enabled":  existing.HostEnabled,
-		"local_enabled": existing.LocalEnabled,
-		"key_version":   keyVersion,
-		"ip":            ip,
-		"port":          port,
-		"secrets_count": secretsCount,
-		"configs_count": configsCount,
-		"version":       version,
-	}).Error; err != nil {
+	existing.Label = label
+	existing.VaultHash = vaultHash
+	existing.VaultName = vaultName
+	existing.KeyVersion = keyVersion
+	existing.IP = ip
+	existing.Port = port
+	existing.SecretsCount = secretsCount
+	existing.ConfigsCount = configsCount
+	existing.Version = version
+	if err := d.conn.Save(&existing).Error; err != nil {
 		return err
 	}
 	updated, err := d.GetAgentByNodeID(nodeID)
@@ -163,11 +158,9 @@ func (d *DB) UpdateAgentRole(nodeID, role string) error {
 
 func (d *DB) UpdateAgentCapabilities(nodeID, role string, hostEnabled, localEnabled *bool) error {
 	host, local := normalizeAgentCapabilities(role, hostEnabled, localEnabled)
-	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Updates(map[string]any{
-		"agent_role":    canonicalAgentRole(role, host, local),
-		"host_enabled":  host,
-		"local_enabled": local,
-	})
+	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).
+		Select("AgentRole", "HostEnabled", "LocalEnabled").
+		Updates(&Agent{AgentRole: canonicalAgentRole(role, host, local), HostEnabled: host, LocalEnabled: local})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -195,11 +188,9 @@ func (d *DB) BackfillAgentCapabilities() error {
 			continue
 		}
 		host, local := normalizeAgentCapabilities(agent.AgentRole, nil, nil)
-		if err := d.conn.Model(&Agent{}).Where("node_id = ?", agent.NodeID).Updates(map[string]any{
-			"agent_role":    canonicalAgentRole(agent.AgentRole, host, local),
-			"host_enabled":  host,
-			"local_enabled": local,
-		}).Error; err != nil {
+		if err := d.conn.Model(&Agent{}).Where("node_id = ?", agent.NodeID).
+			Select("AgentRole", "HostEnabled", "LocalEnabled").
+			Updates(&Agent{AgentRole: canonicalAgentRole(agent.AgentRole, host, local), HostEnabled: host, LocalEnabled: local}).Error; err != nil {
 			return err
 		}
 	}
@@ -213,32 +204,14 @@ func (d *DB) ListAgents() ([]Agent, error) {
 }
 
 func (d *DB) GetAgentByNodeID(nodeID string) (*Agent, error) {
-	var agent Agent
-	err := d.conn.First(&agent, "node_id = ?", nodeID).Error
-	if err != nil {
-		return nil, fmt.Errorf("agent %s not found", nodeID)
-	}
-	return &agent, nil
+	return dbFirst[Agent](d, "agent "+nodeID+" not found", "node_id = ?", nodeID)
 }
-
 func (d *DB) GetAgentByLabel(label string) (*Agent, error) {
-	var agent Agent
-	err := d.conn.First(&agent, "label = ?", label).Error
-	if err != nil {
-		return nil, fmt.Errorf("agent label %s not found", label)
-	}
-	return &agent, nil
+	return dbFirst[Agent](d, "agent label "+label+" not found", "label = ?", label)
 }
-
 func (d *DB) GetAgentByHash(agentHash string) (*Agent, error) {
-	var agent Agent
-	err := d.conn.First(&agent, "agent_hash = ?", agentHash).Error
-	if err != nil {
-		return nil, fmt.Errorf("agent hash %s not found", agentHash)
-	}
-	return &agent, nil
+	return dbFirst[Agent](d, "agent hash "+agentHash+" not found", "agent_hash = ?", agentHash)
 }
-
 func (d *DB) DeleteAgentByNodeID(nodeID string) error {
 	agent, err := d.GetAgentByNodeID(nodeID)
 	if err != nil {
@@ -282,11 +255,8 @@ func (d *DB) GetAgentRecord(hashOrLabel string) (*Agent, error) {
 
 func (d *DB) UpdateAgentDEK(nodeID string, agentHash string, dek, dekNonce []byte) error {
 	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).
-		Updates(map[string]interface{}{
-			"agent_hash": agentHash,
-			"dek":        dek,
-			"dek_nonce":  dekNonce,
-		})
+		Select("AgentHash", "DEK", "DEKNonce").
+		Updates(&Agent{AgentHash: agentHash, DEK: dek, DEKNonce: dekNonce})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -427,34 +397,24 @@ func (d *DB) ApproveAgentRebind(nodeID string) (*Agent, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Updates(map[string]interface{}{
-		"agent_hash":      newAgentHash,
-		"key_version":     agent.KeyVersion + 1,
-		"rebind_required": false,
-		"rebind_reason":   "",
-		"retry_stage":     0,
-		"next_retry_at":   nil,
-		"blocked_at":      nil,
-		"block_reason":    "",
-	})
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	if result.RowsAffected == 0 {
-		return nil, fmt.Errorf("agent %s not found", nodeID)
+	agent.AgentHash = newAgentHash
+	agent.KeyVersion++
+	agent.RebindRequired = false
+	agent.RebindReason = ""
+	agent.RetryStage = 0
+	agent.NextRetryAt = nil
+	agent.BlockedAt = nil
+	agent.BlockReason = ""
+	if err := d.conn.Save(&agent).Error; err != nil {
+		return nil, err
 	}
 	return d.GetAgentByNodeID(nodeID)
 }
 
 func (d *DB) ClearAgentRebind(nodeID string) (*Agent, error) {
-	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Updates(map[string]interface{}{
-		"rebind_required": false,
-		"rebind_reason":   "",
-		"retry_stage":     0,
-		"next_retry_at":   nil,
-		"blocked_at":      nil,
-		"block_reason":    "",
-	})
+	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).
+		Select("RebindRequired", "RebindReason", "RetryStage", "NextRetryAt", "BlockedAt", "BlockReason").
+		Updates(&Agent{})
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -469,28 +429,25 @@ func (d *DB) ScheduleAgentRotation(nodeID, reason string) (*Agent, error) {
 	if err := d.conn.First(&agent, "node_id = ?", nodeID).Error; err != nil {
 		return nil, fmt.Errorf("agent %s not found", nodeID)
 	}
-	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Updates(map[string]interface{}{
-		"key_version":       agent.KeyVersion + 1,
-		"rotation_required": true,
-		"rotation_reason":   reason,
-		"rebind_required":   false,
-		"rebind_reason":     "",
-		"retry_stage":       0,
-		"next_retry_at":     nil,
-		"blocked_at":        nil,
-		"block_reason":      "",
-	})
-	if result.Error != nil {
-		return nil, result.Error
+	agent.KeyVersion++
+	agent.RotationRequired = true
+	agent.RotationReason = reason
+	agent.RebindRequired = false
+	agent.RebindReason = ""
+	agent.RetryStage = 0
+	agent.NextRetryAt = nil
+	agent.BlockedAt = nil
+	agent.BlockReason = ""
+	if err := d.conn.Save(&agent).Error; err != nil {
+		return nil, err
 	}
 	return d.GetAgentByNodeID(nodeID)
 }
 
 func (d *DB) ClearAgentRotation(nodeID string) (*Agent, error) {
-	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Updates(map[string]interface{}{
-		"rotation_required": false,
-		"rotation_reason":   "",
-	})
+	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).
+		Select("RotationRequired", "RotationReason").
+		Updates(&Agent{})
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -501,14 +458,16 @@ func (d *DB) ClearAgentRotation(nodeID string) (*Agent, error) {
 }
 
 func (d *DB) UpdateAgentRotationState(nodeID string, retryStage int, nextRetryAt *time.Time, rotationRequired bool, rotationReason string, blockedAt *time.Time, blockReason string) error {
-	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Updates(map[string]interface{}{
-		"retry_stage":       retryStage,
-		"next_retry_at":     nextRetryAt,
-		"rotation_required": rotationRequired,
-		"rotation_reason":   rotationReason,
-		"blocked_at":        blockedAt,
-		"block_reason":      blockReason,
-	})
+	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).
+		Select("RetryStage", "NextRetryAt", "RotationRequired", "RotationReason", "BlockedAt", "BlockReason").
+		Updates(&Agent{
+			RetryStage:       retryStage,
+			NextRetryAt:      nextRetryAt,
+			RotationRequired: rotationRequired,
+			RotationReason:   rotationReason,
+			BlockedAt:        blockedAt,
+			BlockReason:      blockReason,
+		})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/services/vaultcenter/internal/db/db_child.go
+++ b/services/vaultcenter/internal/db/db_child.go
@@ -10,14 +10,8 @@ func (d *DB) RegisterChild(child *Child) error {
 }
 
 func (d *DB) GetChild(nodeID string) (*Child, error) {
-	var child Child
-	err := d.conn.First(&child, "node_id = ?", nodeID).Error
-	if err != nil {
-		return nil, fmt.Errorf("child %s not found", nodeID)
-	}
-	return &child, nil
+	return dbFirst[Child](d, "child "+nodeID+" not found", "node_id = ?", nodeID)
 }
-
 func (d *DB) ListChildren() ([]Child, error) {
 	var children []Child
 	err := d.conn.Order("created_at").Find(&children).Error
@@ -27,10 +21,8 @@ func (d *DB) ListChildren() ([]Child, error) {
 func (d *DB) UpdateChildURL(nodeID, url string) error {
 	now := time.Now()
 	result := d.conn.Model(&Child{}).Where("node_id = ?", nodeID).
-		Updates(map[string]interface{}{
-			"url":       url,
-			"last_seen": now,
-		})
+		Select("URL", "LastSeen").
+		Updates(&Child{URL: url, LastSeen: &now})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -42,11 +34,8 @@ func (d *DB) UpdateChildURL(nodeID, url string) error {
 
 func (d *DB) UpdateChildDEK(nodeID string, encryptedDEK, nonce []byte, version int) error {
 	result := d.conn.Model(&Child{}).Where("node_id = ?", nodeID).
-		Updates(map[string]interface{}{
-			"encrypted_dek": encryptedDEK,
-			"nonce":         nonce,
-			"version":       version,
-		})
+		Select("EncryptedDEK", "Nonce", "Version").
+		Updates(&Child{EncryptedDEK: encryptedDEK, Nonce: nonce, Version: version})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/services/vaultcenter/internal/db/db_config.go
+++ b/services/vaultcenter/internal/db/db_config.go
@@ -1,8 +1,6 @@
 package db
 
 import (
-	"fmt"
-
 	"gorm.io/gorm"
 )
 
@@ -34,13 +32,8 @@ func (d *DB) SaveConfigs(configs map[string]string) error {
 }
 
 func (d *DB) GetConfig(key string) (*Config, error) {
-	var entry Config
-	if err := d.conn.First(&entry, "key = ?", key).Error; err != nil {
-		return nil, fmt.Errorf("config %s not found", key)
-	}
-	return &entry, nil
+	return dbFirst[Config](d, "config "+key+" not found", "key = ?", key)
 }
-
 func (d *DB) ListConfigs() ([]Config, error) {
 	var entries []Config
 	if err := d.conn.Order("key asc").Find(&entries).Error; err != nil {
@@ -50,16 +43,8 @@ func (d *DB) ListConfigs() ([]Config, error) {
 }
 
 func (d *DB) DeleteConfig(key string) error {
-	result := d.conn.Delete(&Config{}, "key = ?", key)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return fmt.Errorf("config %s not found", key)
-	}
-	return nil
+	return dbDeleteWhere[Config](d, "config "+key+" not found", "key = ?", key)
 }
-
 func (d *DB) CountConfigs() (int, error) {
 	var count int64
 	if err := d.conn.Model(&Config{}).Count(&count).Error; err != nil {

--- a/services/vaultcenter/internal/db/db_node_info.go
+++ b/services/vaultcenter/internal/db/db_node_info.go
@@ -34,11 +34,8 @@ func (d *DB) SetParentURL(parentURL string) (int64, error) {
 
 func (d *DB) UpdateNodeDEK(dek, nonce []byte, version int) error {
 	result := d.conn.Model(&NodeInfo{}).Where("1 = 1").
-		Updates(map[string]interface{}{
-			"dek":       dek,
-			"dek_nonce": nonce,
-			"version":   version,
-		})
+		Select("DEK", "DEKNonce", "Version").
+		Updates(&NodeInfo{DEK: dek, DEKNonce: nonce, Version: version})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/services/vaultcenter/internal/db/db_operator_catalog.go
+++ b/services/vaultcenter/internal/db/db_operator_catalog.go
@@ -16,12 +16,8 @@ func (d *DB) SaveSecretCatalog(entry *SecretCatalog) error {
 func (d *DB) UpdateSecretCatalogMeta(refCanonical, displayName, description, tagsJSON string) error {
 	return d.conn.Model(&SecretCatalog{}).
 		Where("ref_canonical = ?", refCanonical).
-		Updates(map[string]any{
-			"display_name": displayName,
-			"description":  description,
-			"tags_json":    tagsJSON,
-			"updated_at":   time.Now().UTC(),
-		}).Error
+		Select("DisplayName", "Description", "TagsJSON").
+		Updates(&SecretCatalog{DisplayName: displayName, Description: description, TagsJSON: tagsJSON}).Error
 }
 
 func (d *DB) GetSecretCatalogByRef(refCanonical string) (*SecretCatalog, error) {

--- a/services/vaultcenter/internal/db/db_secret.go
+++ b/services/vaultcenter/internal/db/db_secret.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"time"
 
 	"gorm.io/gorm"
 )
@@ -12,32 +11,14 @@ func (d *DB) SaveSecret(secret *Secret) error {
 }
 
 func (d *DB) GetSecretByName(name string) (*Secret, error) {
-	var s Secret
-	err := d.conn.First(&s, "name = ?", name).Error
-	if err != nil {
-		return nil, fmt.Errorf("secret %s not found", name)
-	}
-	return &s, nil
+	return dbFirst[Secret](d, "secret "+name+" not found", "name = ?", name)
 }
-
 func (d *DB) GetSecretByID(id string) (*Secret, error) {
-	var s Secret
-	err := d.conn.First(&s, "id = ?", id).Error
-	if err != nil {
-		return nil, fmt.Errorf("secret id %s not found", id)
-	}
-	return &s, nil
+	return dbFirst[Secret](d, "secret id "+id+" not found", "id = ?", id)
 }
-
 func (d *DB) GetSecretByRef(refHash string) (*Secret, error) {
-	var s Secret
-	err := d.conn.First(&s, "ref = ?", refHash).Error
-	if err != nil {
-		return nil, fmt.Errorf("secret ref %s not found", refHash)
-	}
-	return &s, nil
+	return dbFirst[Secret](d, "secret ref "+refHash+" not found", "ref = ?", refHash)
 }
-
 func (d *DB) ListSecrets() ([]Secret, error) {
 	var secrets []Secret
 	err := d.conn.Order("name").Find(&secrets).Error
@@ -45,16 +26,8 @@ func (d *DB) ListSecrets() ([]Secret, error) {
 }
 
 func (d *DB) DeleteSecret(name string) error {
-	result := d.conn.Delete(&Secret{}, "name = ?", name)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return fmt.Errorf("secret %s not found", name)
-	}
-	return nil
+	return dbDeleteWhere[Secret](d, "secret "+name+" not found", "name = ?", name)
 }
-
 func (d *DB) CountSecrets() (int, error) {
 	var count int64
 	err := d.conn.Model(&Secret{}).Count(&count).Error
@@ -84,11 +57,10 @@ func (d *DB) ReencryptAllSecrets(
 			if err != nil {
 				return fmt.Errorf("encrypt secret %s: %w", s.Name, err)
 			}
-			if err := tx.Model(s).Updates(map[string]interface{}{
-				"ciphertext": newCiphertext,
-				"nonce":      newNonce,
-				"version":    newVersion,
-				"updated_at": time.Now(),
+			if err := tx.Model(s).Select("Ciphertext", "Nonce", "Version").Updates(&Secret{
+				Ciphertext: newCiphertext,
+				Nonce:      newNonce,
+				Version:    newVersion,
 			}).Error; err != nil {
 				return err
 			}

--- a/services/vaultcenter/internal/db/db_token_ref.go
+++ b/services/vaultcenter/internal/db/db_token_ref.go
@@ -118,11 +118,8 @@ func (d *DB) NormalizeTokenRefStorage() error {
 		if needsBackfill {
 			if err := d.conn.Model(&TokenRef{}).
 				Where("ref_canonical = ?", ref.RefCanonical).
-				Updates(map[string]any{
-					"ref_family": parsed.Family,
-					"ref_scope":  parsed.Scope,
-					"ref_id":     parsed.ID,
-				}).Error; err != nil {
+				Select("RefFamily", "RefScope", "RefID").
+				Updates(&TokenRef{RefFamily: parsed.Family, RefScope: parsed.Scope, RefID: parsed.ID}).Error; err != nil {
 				return err
 			}
 			continue
@@ -147,14 +144,8 @@ func DefaultRefStatus(scope string) string {
 }
 
 func (d *DB) GetRef(canonical string) (*TokenRef, error) {
-	var ref TokenRef
-	err := d.conn.First(&ref, "ref_canonical = ?", canonical).Error
-	if err != nil {
-		return nil, fmt.Errorf("ref %s not found", canonical)
-	}
-	return &ref, nil
+	return dbFirst[TokenRef](d, "ref "+canonical+" not found", "ref_canonical = ?", canonical)
 }
-
 func (d *DB) ListRefs() ([]TokenRef, error) {
 	var refs []TokenRef
 	err := d.conn.Order("ref_canonical ASC").Find(&refs).Error
@@ -211,16 +202,8 @@ func (d *DB) GetRefByCanonicalAndAgent(canonical, agentHash string) (*TokenRef, 
 }
 
 func (d *DB) DeleteRef(canonical string) error {
-	result := d.conn.Delete(&TokenRef{}, "ref_canonical = ?", canonical)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return fmt.Errorf("ref %s not found", canonical)
-	}
-	return nil
+	return dbDeleteWhere[TokenRef](d, "ref "+canonical+" not found", "ref_canonical = ?", canonical)
 }
-
 func (d *DB) CountRefs() (int, error) {
 	var count int64
 	err := d.conn.Model(&TokenRef{}).Count(&count).Error
@@ -322,4 +305,3 @@ WHERE rowid NOT IN (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_token_refs_ref_canonical
 ON token_refs(ref_canonical)`).Error
 }
-

--- a/services/vaultcenter/internal/db/db_vault_inventory.go
+++ b/services/vaultcenter/internal/db/db_vault_inventory.go
@@ -99,10 +99,6 @@ func (d *DB) GetVaultInventoryByNodeID(nodeID string) (*VaultInventory, error) {
 func (d *DB) UpdateVaultInventoryMeta(nodeID, displayName, description, tagsJSON string) error {
 	return d.conn.Model(&VaultInventory{}).
 		Where("vault_node_uuid = ?", nodeID).
-		Updates(map[string]any{
-			"display_name": displayName,
-			"description":  description,
-			"tags_json":    tagsJSON,
-			"updated_at":   time.Now().UTC(),
-		}).Error
+		Select("DisplayName", "Description", "TagsJSON").
+		Updates(&VaultInventory{DisplayName: displayName, Description: description, TagsJSON: tagsJSON}).Error
 }

--- a/services/vaultcenter/internal/db/global_functions.go
+++ b/services/vaultcenter/internal/db/global_functions.go
@@ -22,13 +22,8 @@ func (d *DB) SaveGlobalFunction(fn *GlobalFunction) error {
 }
 
 func (d *DB) GetGlobalFunction(name string) (*GlobalFunction, error) {
-	var fn GlobalFunction
-	if err := d.conn.First(&fn, "name = ?", name).Error; err != nil {
-		return nil, fmt.Errorf("global function %s not found", name)
-	}
-	return &fn, nil
+	return dbFirst[GlobalFunction](d, "global function "+name+" not found", "name = ?", name)
 }
-
 func (d *DB) ListGlobalFunctions() ([]GlobalFunction, error) {
 	var out []GlobalFunction
 	if err := d.conn.Order("name ASC").Find(&out).Error; err != nil {
@@ -38,12 +33,5 @@ func (d *DB) ListGlobalFunctions() ([]GlobalFunction, error) {
 }
 
 func (d *DB) DeleteGlobalFunction(name string) error {
-	result := d.conn.Delete(&GlobalFunction{}, "name = ?", name)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return fmt.Errorf("global function %s not found", name)
-	}
-	return nil
+	return dbDeleteWhere[GlobalFunction](d, "global function "+name+" not found", "name = ?", name)
 }


### PR DESCRIPTION
## Summary

**API layer**
- `pathVal()`, `decodeJSON()` 헬퍼 추가 → 32 + 36 호출 지점 단순화
- `sendInstallSMTP` → `go-mail` 패키지 교체 (50줄 → 20줄)
- `proxyAndRecordWorkflow()` 추출로 precheck/run 핸들러 중복 제거

**DB layer**
- `dbFirst[T]`, `dbDeleteWhere[T]` 제네릭 헬퍼 추가 → 12개 조회/삭제 함수 단순화
- 모든 `map[string]interface{}` Updates → `Select + struct` 패턴으로 교체 (컴파일 타임 타입 체크)
- 전체 레코드를 이미 fetch한 경우 `Save()` 사용

## Result

`41 files changed, 227 insertions(+), 380 deletions(-)`

## Test plan

- [ ] `go build ./...` 통과
- [ ] `go vet ./...` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)