### PR TITLE
chore(vaultcenter): remove redundant comments

### DIFF
--- a/services/vaultcenter/cmd/main.go
+++ b/services/vaultcenter/cmd/main.go
@@ -69,7 +69,6 @@ func runServer() {
 	server := api.NewServer(database, nil, trustedIPs)
 	server.SetSalt(salt)
 
-	// Auto-detect HKM mode
 	if database.HasNodeInfo() {
 		info, err := database.GetNodeInfo()
 		if err != nil {
@@ -86,7 +85,6 @@ func runServer() {
 		log.Fatal("node info not found. Legacy centralized mode is no longer supported; initialize HKM root with 'init --root'.")
 	}
 
-	// Auto-unlock if VEILKEY_PASSWORD_FILE is set
 	if pw := readPasswordFromFileEnv(); pw != "" {
 		kek := crypto.DeriveKEK(pw, salt)
 		if err := server.Unlock(kek); err != nil {
@@ -152,12 +150,10 @@ func runHKMInit() {
 	}
 	saltFile := filepath.Join(dataDir, "salt")
 
-	// Check if already initialized
 	if _, err := os.Stat(saltFile); err == nil {
 		log.Fatal("Already initialized. Salt file exists: " + saltFile)
 	}
 
-	// Get password
 	if password == "" {
 		password = readPassword("Enter KEK password: ")
 		stat, _ := os.Stdin.Stat()
@@ -173,34 +169,29 @@ func runHKMInit() {
 		log.Fatal("Password must be at least 8 characters.")
 	}
 
-	// Generate salt + derive KEK
 	salt, err := crypto.GenerateSalt()
 	if err != nil {
 		log.Fatalf("Failed to generate salt: %v", err)
 	}
 	kek := crypto.DeriveKEK(password, salt)
 
-	// Initialize database
 	database, err := db.New(dbPath)
 	if err != nil {
 		log.Fatalf("Failed to initialize database: %v", err)
 	}
 	defer database.Close()
 
-	// Generate UUID + DEK
 	nodeID := crypto.GenerateUUID()
 	dek, err := crypto.GenerateKey()
 	if err != nil {
 		log.Fatalf("Failed to generate DEK: %v", err)
 	}
 
-	// Encrypt DEK with KEK
 	encDEK, encNonce, err := crypto.Encrypt(kek, dek)
 	if err != nil {
 		log.Fatalf("Failed to encrypt DEK: %v", err)
 	}
 
-	// Save node info
 	info := &db.NodeInfo{
 		NodeID:   nodeID,
 		DEK:      encDEK,
@@ -211,12 +202,10 @@ func runHKMInit() {
 		log.Fatalf("Failed to save node info: %v", err)
 	}
 
-	// Save salt
 	if err := os.WriteFile(saltFile, salt, 0600); err != nil {
 		log.Fatalf("Failed to save salt: %v", err)
 	}
 
-	// Store password as temp ref (auto-deletes after 1 hour)
 	pwCiphertext, pwNonce, pwErr := crypto.Encrypt(dek, []byte(password))
 	tempRef := ""
 	if pwErr == nil {

--- a/services/vaultcenter/internal/db/db.go
+++ b/services/vaultcenter/internal/db/db.go
@@ -19,18 +19,16 @@ type DB struct {
 func New(dbPath string) (*DB, error) {
 	dsn := dbPath + "?_journal_mode=wal&_busy_timeout=5000"
 
-	// SQLCipher: 환경변수로 DB 암호화 키가 설정된 경우 DSN에 _pragma_key 추가
 	if key := os.Getenv("VEILKEY_DB_KEY"); key != "" {
 		dsn += "&_pragma_key=" + url.QueryEscape(key)
 	}
 
-	// go-sqlcipher/v4가 등록한 "sqlite3" 드라이버로 직접 연결 후 GORM에 전달
+	// go-sqlcipher/v4 registers as "sqlite3"; open raw connection then hand to GORM
 	sqlDB, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, err
 	}
 
-	// SQLCipher 키가 설정된 경우, 드라이버 지원 여부와 DB 접근 가능 여부를 함께 검증
 	if os.Getenv("VEILKEY_DB_KEY") != "" {
 		version, verErr := sqlCipherVersion(sqlDB)
 		if verErr != nil {

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -37,7 +37,6 @@ func (d *DB) UpsertAgent(nodeID, label, vaultHash, vaultName, ip string, port, s
 	var existing Agent
 	err := d.conn.First(&existing, "node_id = ?", nodeID).Error
 	if err != nil {
-		// New agent
 		agent := Agent{
 			NodeID:       nodeID,
 			Label:        label,
@@ -58,7 +57,6 @@ func (d *DB) UpsertAgent(nodeID, label, vaultHash, vaultName, ip string, port, s
 		}
 		return d.UpsertVaultInventoryFromAgent(&agent)
 	}
-	// Update existing
 	if strings.TrimSpace(existing.AgentRole) == "" {
 		existing.AgentRole = "agent"
 	}

--- a/services/vaultcenter/internal/db/models.go
+++ b/services/vaultcenter/internal/db/models.go
@@ -2,7 +2,6 @@ package db
 
 import "time"
 
-// EncryptionKey — encryption_keys 테이블
 type EncryptionKey struct {
 	Version      int        `gorm:"primaryKey;autoIncrement;column:version" json:"version"`
 	EncryptedDEK []byte     `gorm:"column:encrypted_dek;not null" json:"encrypted_dek"`
@@ -15,7 +14,6 @@ type EncryptionKey struct {
 
 func (EncryptionKey) TableName() string { return "encryption_keys" }
 
-// TokenRef — token_refs 테이블
 type TokenRef struct {
 	RefCanonical  string     `gorm:"primaryKey;column:ref_canonical;size:96" json:"ref_canonical"`
 	RefFamily     string     `gorm:"column:ref_family;size:16;not null;index:idx_token_refs_family_scope" json:"ref_family"`
@@ -33,7 +31,6 @@ type TokenRef struct {
 
 func (TokenRef) TableName() string { return "token_refs" }
 
-// NodeInfo — node_info 테이블
 type NodeInfo struct {
 	NodeID         string    `gorm:"primaryKey;column:node_id" json:"node_id"`
 	ParentURL      string    `gorm:"column:parent_url" json:"parent_url"`
@@ -47,7 +44,6 @@ type NodeInfo struct {
 
 func (NodeInfo) TableName() string { return "node_info" }
 
-// Child — children 테이블
 type Child struct {
 	NodeID       string     `gorm:"primaryKey;column:node_id" json:"node_id"`
 	Label        string     `gorm:"column:label" json:"label"`
@@ -61,7 +57,6 @@ type Child struct {
 
 func (Child) TableName() string { return "children" }
 
-// Secret — secrets 테이블
 type Secret struct {
 	ID         string    `gorm:"primaryKey;column:id" json:"id"`
 	Name       string    `gorm:"column:name;uniqueIndex;not null" json:"name"`
@@ -74,7 +69,6 @@ type Secret struct {
 
 func (Secret) TableName() string { return "secrets" }
 
-// VaultInventory — vault_inventory 테이블
 type VaultInventory struct {
 	VaultNodeUUID    string     `gorm:"primaryKey;column:vault_node_uuid" json:"vault_node_uuid"`
 	VaultRuntimeHash string     `gorm:"column:vault_runtime_hash;not null;uniqueIndex" json:"vault_runtime_hash"`
@@ -98,7 +92,6 @@ type VaultInventory struct {
 
 func (VaultInventory) TableName() string { return "vault_inventory" }
 
-// SecretCatalog — secret_catalog 테이블
 type SecretCatalog struct {
 	SecretCanonicalID string     `gorm:"primaryKey;column:secret_canonical_id" json:"secret_canonical_id"`
 	SecretName        string     `gorm:"column:secret_name;not null;index" json:"secret_name"`
@@ -121,7 +114,6 @@ type SecretCatalog struct {
 
 func (SecretCatalog) TableName() string { return "secret_catalog" }
 
-// Binding — bindings 테이블
 type Binding struct {
 	BindingID    string    `gorm:"primaryKey;column:binding_id" json:"binding_id"`
 	BindingType  string    `gorm:"column:binding_type;not null;index:idx_bindings_target" json:"binding_type"`
@@ -137,7 +129,6 @@ type Binding struct {
 
 func (Binding) TableName() string { return "bindings" }
 
-// AuditEvent — audit_events 테이블
 type AuditEvent struct {
 	EventID             string    `gorm:"primaryKey;column:event_id" json:"event_id"`
 	EntityType          string    `gorm:"column:entity_type;not null;index:idx_audit_events_entity" json:"entity_type"`
@@ -155,7 +146,6 @@ type AuditEvent struct {
 
 func (AuditEvent) TableName() string { return "audit_events" }
 
-// KeyRegistryEntry — key_registry 테이블
 type KeyRegistryEntry struct {
 	NodeID   string    `gorm:"primaryKey;column:node_id" json:"node_id"`
 	SecretID string    `gorm:"primaryKey;column:secret_id" json:"secret_id"`
@@ -168,7 +158,6 @@ func (KeyRegistryEntry) TableName() string { return "key_registry" }
 
 const DefaultAgentPort = 10180
 
-// Agent — agents 테이블 (heartbeat + 중앙 DEK 관리)
 type Agent struct {
 	NodeID           string     `gorm:"primaryKey;column:node_id" json:"node_id"`
 	Label            string     `gorm:"column:label;not null" json:"label"`
@@ -201,7 +190,6 @@ type Agent struct {
 
 func (Agent) TableName() string { return "agents" }
 
-// GlobalFunction — global_functions 테이블
 type GlobalFunction struct {
 	Name         string    `gorm:"primaryKey;column:name" json:"name"`
 	FunctionHash string    `gorm:"column:function_hash;uniqueIndex;not null" json:"function_hash"`
@@ -214,7 +202,6 @@ type GlobalFunction struct {
 
 func (GlobalFunction) TableName() string { return "global_functions" }
 
-// InstallSession — install_sessions 테이블
 type InstallSession struct {
 	SessionID           string    `gorm:"primaryKey;column:session_id" json:"session_id"`
 	Version             int       `gorm:"column:version;not null;default:1" json:"version"`
@@ -234,7 +221,6 @@ type InstallSession struct {
 
 func (InstallSession) TableName() string { return "install_sessions" }
 
-// InstallCustodyChallenge — install_custody_challenges 테이블
 type InstallCustodyChallenge struct {
 	Token      string     `gorm:"primaryKey;column:token" json:"token"`
 	SessionID  string     `gorm:"column:session_id;not null;index" json:"session_id"`
@@ -250,7 +236,6 @@ type InstallCustodyChallenge struct {
 
 func (InstallCustodyChallenge) TableName() string { return "install_custody_challenges" }
 
-// SecretInputChallenge — secret_input_challenges 테이블
 type SecretInputChallenge struct {
 	Token      string     `gorm:"primaryKey;column:token" json:"token"`
 	Email      string     `gorm:"column:email;not null" json:"email"`
@@ -266,7 +251,6 @@ type SecretInputChallenge struct {
 
 func (SecretInputChallenge) TableName() string { return "secret_input_challenges" }
 
-// EmailOTPChallenge — email_otp_challenges 테이블
 type EmailOTPChallenge struct {
 	Token         string     `gorm:"primaryKey;column:token" json:"token"`
 	Email         string     `gorm:"column:email;not null" json:"email"`
@@ -281,7 +265,6 @@ type EmailOTPChallenge struct {
 
 func (EmailOTPChallenge) TableName() string { return "email_otp_challenges" }
 
-// ApprovalTokenChallenge — approval_token_challenges 테이블
 type ApprovalTokenChallenge struct {
 	Token       string     `gorm:"primaryKey;column:token" json:"token"`
 	Kind        string     `gorm:"column:kind;not null;index" json:"kind"`
@@ -300,7 +283,6 @@ type ApprovalTokenChallenge struct {
 
 func (ApprovalTokenChallenge) TableName() string { return "approval_token_challenges" }
 
-// AdminAuthConfig — admin_auth_configs 테이블
 type AdminAuthConfig struct {
 	ConfigID                string     `gorm:"primaryKey;column:config_id" json:"config_id"`
 	TOTPEnabled             bool       `gorm:"column:totp_enabled;not null;default:false" json:"totp_enabled"`
@@ -315,7 +297,6 @@ type AdminAuthConfig struct {
 
 func (AdminAuthConfig) TableName() string { return "admin_auth_configs" }
 
-// AdminSession — admin_sessions 테이블
 type AdminSession struct {
 	SessionID     string     `gorm:"primaryKey;column:session_id" json:"session_id"`
 	TokenHash     string     `gorm:"column:token_hash;not null;uniqueIndex" json:"token_hash"`
@@ -331,7 +312,6 @@ type AdminSession struct {
 
 func (AdminSession) TableName() string { return "admin_sessions" }
 
-// UIConfig — ui_configs 테이블
 type UIConfig struct {
 	ConfigID       string    `gorm:"primaryKey;column:config_id" json:"config_id"`
 	Locale         string    `gorm:"column:locale;not null;default:ko" json:"locale"`
@@ -372,7 +352,6 @@ type InstallRun struct {
 
 func (InstallRun) TableName() string { return "install_runs" }
 
-// Config — configs 테이블
 type Config struct {
 	Key       string    `gorm:"primaryKey;column:key" json:"key"`
 	Value     string    `gorm:"column:value;type:text;not null;default:''" json:"value"`
@@ -383,7 +362,6 @@ type Config struct {
 
 func (Config) TableName() string { return "configs" }
 
-// BulkApplyTemplate — bulk_apply_templates 테이블
 type BulkApplyTemplate struct {
 	TemplateID       string    `gorm:"primaryKey;column:template_id" json:"template_id"`
 	VaultRuntimeHash string    `gorm:"column:vault_runtime_hash;not null;index:idx_bulk_apply_templates_vault_name,priority:1" json:"vault_runtime_hash"`
@@ -399,7 +377,6 @@ type BulkApplyTemplate struct {
 
 func (BulkApplyTemplate) TableName() string { return "bulk_apply_templates" }
 
-// BulkApplyRun — bulk_apply_runs 테이블
 type BulkApplyRun struct {
 	RunID            string    `gorm:"primaryKey;column:run_id" json:"run_id"`
 	VaultRuntimeHash string    `gorm:"column:vault_runtime_hash;not null;index:idx_bulk_apply_runs_vault_workflow_created,priority:1" json:"vault_runtime_hash"`
@@ -412,7 +389,6 @@ type BulkApplyRun struct {
 
 func (BulkApplyRun) TableName() string { return "bulk_apply_runs" }
 
-// Migration — migrations 테이블 (레거시 호환)
 type Migration struct {
 	Version   int       `gorm:"primaryKey;column:version" json:"version"`
 	AppliedAt time.Time `gorm:"column:applied_at;autoCreateTime" json:"applied_at"`


### PR DESCRIPTION
## Summary
- `models.go`: struct마다 붙어있던 `// TypeName — table_name 테이블` 주석 제거 (아래 `TableName()` 함수로 충분)
- `db.go`: 코드를 그대로 설명하는 한국어 인라인 주석 2개 제거, go-sqlcipher 우회 설명 주석은 영어로 간결하게 유지
- `db_agent.go`: `// New agent`, `// Update existing` 제거 (코드에서 자명)
- `cmd/main.go`: `runHKMInit` 내 단계별 설명 주석 9개 제거 (각 코드 블록이 스스로 설명)

🤖 Generated with [Claude Code](https://claude.com/claude-code)