### PR TITLE
fix: add missing localvault secrets package and scope gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ data/
 
 # Secrets
 .env
-secrets/
-!secrets/.gitkeep
+/secrets/
+!/secrets/.gitkeep
 
 # macOS
 .DS_Store

--- a/services/localvault/internal/api/secrets/cipher_save.go
+++ b/services/localvault/internal/api/secrets/cipher_save.go
@@ -1,0 +1,152 @@
+package secrets
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+	"veilkey-localvault/internal/db"
+)
+
+func (h *Handler) handleSaveCipher(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name       string `json:"name"`
+		Ref        string `json:"ref"`
+		Ciphertext []byte `json:"ciphertext"`
+		Nonce      []byte `json:"nonce"`
+		Version    int    `json:"version"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" || len(req.Ciphertext) == 0 || len(req.Nonce) == 0 {
+		respondError(w, http.StatusBadRequest, "name, ciphertext, and nonce are required")
+		return
+	}
+	if !isValidResourceName(req.Name) {
+		respondError(w, http.StatusBadRequest, "name must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+
+	nodeInfo, err := h.deps.DB().GetNodeInfo()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "node info not available")
+		return
+	}
+	if req.Version == 0 {
+		req.Version = nodeInfo.Version
+	}
+
+	existing, _ := h.deps.DB().GetSecretByName(req.Name)
+	id := crypto.GenerateUUID()
+	ref := req.Ref
+	action := "created"
+	scope := refScopeTemp
+	status := refStatusTemp
+	if existing != nil {
+		id = existing.ID
+		ref = existing.Ref
+		action = "updated"
+		if existing.Scope != "" {
+			scope = existing.Scope
+		}
+		if existing.Status != "" {
+			status = existing.Status
+		}
+	}
+	if ref == "" {
+		ref, err = generateSecretRef(8)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to generate ref")
+			return
+		}
+	}
+
+	secret := &db.Secret{
+		ID:         id,
+		Name:       req.Name,
+		Ref:        ref,
+		Ciphertext: req.Ciphertext,
+		Nonce:      req.Nonce,
+		Version:    req.Version,
+		Scope:      scope,
+		Status:     status,
+	}
+	if err := h.deps.DB().SaveSecret(secret); err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to save secret: "+err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"id":      id,
+		"name":    req.Name,
+		"ref":     ref,
+		"token":   vkRef(scope, ref),
+		"version": req.Version,
+		"scope":   scope,
+		"status":  status,
+		"action":  action,
+	})
+}
+
+func (h *Handler) handleGetSecretMeta(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		respondError(w, http.StatusBadRequest, "secret name is required")
+		return
+	}
+	if !isValidResourceName(name) {
+		respondError(w, http.StatusBadRequest, "name must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+
+	secret, err := h.deps.DB().GetSecretByName(name)
+	if err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	resp := map[string]interface{}{
+		"name":             secret.Name,
+		"display_name":     secret.DisplayName,
+		"description":      secret.Description,
+		"tags_json":        secret.TagsJSON,
+		"origin":           secret.Origin,
+		"class":            secret.Class,
+		"version":          secret.Version,
+		"status":           secret.Status,
+		"last_rotated_at":  nullableNullTime(secret.LastRotatedAt),
+		"last_revealed_at": nullableNullTime(secret.LastRevealedAt),
+	}
+	if fields, err := h.deps.DB().ListSecretFields(secret.Name); err == nil && len(fields) > 0 {
+		meta := make([]map[string]interface{}, 0, len(fields))
+		for _, field := range fields {
+			meta = append(meta, map[string]interface{}{
+				"key":               field.FieldKey,
+				"type":              field.FieldType,
+				"field_role":        field.FieldRole,
+				"display_name":      field.DisplayName,
+				"masked_by_default": field.MaskedByDefault,
+				"required":          field.Required,
+				"sort_order":        field.SortOrder,
+			})
+		}
+		resp["fields"] = meta
+		resp["fields_count"] = len(meta)
+	}
+	if secret.Ref != "" {
+		resp["ref"] = secret.Ref
+		resp["token"] = vkRef(secret.Scope, secret.Ref)
+		resp["scope"] = secret.Scope
+	}
+	respondJSON(w, http.StatusOK, resp)
+}
+
+func nullableNullTime(value *time.Time) interface{} {
+	if value == nil {
+		return nil
+	}
+	return value.UTC().Format(time.RFC3339)
+}

--- a/services/localvault/internal/api/secrets/constants.go
+++ b/services/localvault/internal/api/secrets/constants.go
@@ -1,0 +1,18 @@
+package secrets
+
+import "veilkey-localvault/internal/db"
+
+// Package-local aliases for db ref constants — keeps handler code concise.
+const (
+	refFamilyVK = db.RefFamilyVK
+
+	refScopeLocal = db.RefScopeLocal
+	refScopeTemp  = db.RefScopeTemp
+
+	refStatusActive = db.RefStatusActive
+	refStatusTemp   = db.RefStatusTemp
+	refStatusBlock  = db.RefStatusBlock
+)
+
+// makeRef constructs a canonical ref string from its components.
+func makeRef(family string, scope db.RefScope, id string) string { return db.MakeRef(family, scope, id) }

--- a/services/localvault/internal/api/secrets/decrypt.go
+++ b/services/localvault/internal/api/secrets/decrypt.go
@@ -1,0 +1,56 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+)
+
+func decodeOpaqueCipherToken(raw string) ([]byte, []byte, error) {
+	parts := strings.SplitN(strings.TrimSpace(raw), ":", 3)
+	if len(parts) != 3 || parts[0] != "VK" {
+		return nil, nil, fmt.Errorf("ciphertext must use VK:{version}:{payload}")
+	}
+	payload, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, nil, fmt.Errorf("ciphertext payload is not valid base64")
+	}
+	if len(payload) <= 12 {
+		return nil, nil, fmt.Errorf("ciphertext payload is too short")
+	}
+	nonce := append([]byte{}, payload[:12]...)
+	ciphertext := append([]byte{}, payload[12:]...)
+	return ciphertext, nonce, nil
+}
+
+func (h *Handler) handleDecrypt(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Ciphertext string `json:"ciphertext"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	ciphertext, nonce, err := decodeOpaqueCipherToken(req.Ciphertext)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	dek, err := h.deps.GetLocalDEK()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to load local DEK")
+		return
+	}
+	plaintext, err := crypto.Decrypt(dek, ciphertext, nonce)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, "decryption failed")
+		return
+	}
+	respondJSON(w, http.StatusOK, map[string]string{
+		"plaintext": string(plaintext),
+	})
+}

--- a/services/localvault/internal/api/secrets/encrypt.go
+++ b/services/localvault/internal/api/secrets/encrypt.go
@@ -1,0 +1,21 @@
+package secrets
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (h *Handler) handleEncrypt(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Plaintext string `json:"plaintext"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Plaintext == "" {
+		respondError(w, http.StatusBadRequest, "plaintext is required")
+		return
+	}
+	respondError(w, http.StatusForbidden, vaultcenterOnlyDecryptMessage)
+}

--- a/services/localvault/internal/api/secrets/fields.go
+++ b/services/localvault/internal/api/secrets/fields.go
@@ -1,0 +1,165 @@
+package secrets
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"veilkey-localvault/internal/db"
+	"github.com/veilkey/veilkey-go-package/httputil"
+)
+
+type secretFieldMeta struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+}
+
+func normalizeSecretFieldType(raw string) string {
+	switch raw {
+	case "login", "otp", "password", "key", "url":
+		return raw
+	default:
+		return "text"
+	}
+}
+
+func (h *Handler) handleSaveSecretFields(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name   string `json:"name"`
+		Fields []struct {
+			Key        string `json:"key"`
+			Type       string `json:"type"`
+			Ciphertext []byte `json:"ciphertext"`
+			Nonce      []byte `json:"nonce"`
+		} `json:"fields"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" || len(req.Fields) == 0 {
+		respondError(w, http.StatusBadRequest, "name and fields are required")
+		return
+	}
+	if len(req.Fields) > httputil.MaxBulkItems {
+		respondError(w, http.StatusBadRequest, "too many fields (max 200)")
+		return
+	}
+
+	secret, err := h.deps.DB().GetSecretByName(req.Name)
+	if err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if secret.Status != refStatusActive || (secret.Scope != refScopeLocal && secret.Scope != db.RefScopeExternal) {
+		respondError(w, http.StatusConflict, "secret fields require VK:LOCAL or VK:EXTERNAL active lifecycle")
+		return
+	}
+
+	fields := make([]db.SecretField, 0, len(req.Fields))
+	meta := make([]secretFieldMeta, 0, len(req.Fields))
+	for _, field := range req.Fields {
+		if !isValidResourceName(field.Key) {
+			respondError(w, http.StatusBadRequest, "field key must match [A-Z_][A-Z0-9_]*")
+			return
+		}
+		if len(field.Ciphertext) == 0 || len(field.Nonce) == 0 {
+			respondError(w, http.StatusBadRequest, "field ciphertext and nonce are required")
+			return
+		}
+		fieldType := normalizeSecretFieldType(field.Type)
+		fields = append(fields, db.SecretField{
+			SecretName: req.Name,
+			FieldKey:   field.Key,
+			FieldType:  fieldType,
+			Ciphertext: field.Ciphertext,
+			Nonce:      field.Nonce,
+		})
+		meta = append(meta, secretFieldMeta{Key: field.Key, Type: fieldType})
+	}
+
+	if err := h.deps.DB().SaveSecretFields(req.Name, fields); err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to save secret fields: "+err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"name":   req.Name,
+		"fields": meta,
+		"saved":  len(meta),
+	})
+}
+
+func (h *Handler) handleCipherField(w http.ResponseWriter, r *http.Request) {
+	ref := r.PathValue("ref")
+	fieldKey := r.PathValue("field")
+	if ref == "" || fieldKey == "" {
+		respondError(w, http.StatusBadRequest, "ref and field are required")
+		return
+	}
+	if !isValidResourceName(fieldKey) {
+		respondError(w, http.StatusBadRequest, "field key must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+
+	secret, err := h.deps.DB().GetSecretByRef(ref)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "ref not found: "+ref)
+		return
+	}
+	if secret.Status == refStatusBlock {
+		respondError(w, http.StatusLocked, "ref is blocked: "+vkRef(secret.Scope, ref))
+		return
+	}
+
+	field, err := h.deps.DB().GetSecretField(secret.Name, fieldKey)
+	if err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"name":       secret.Name,
+		"field":      field.FieldKey,
+		"type":       field.FieldType,
+		"ciphertext": field.Ciphertext,
+		"nonce":      field.Nonce,
+		"version":    secret.Version,
+		"ref":        ref,
+	})
+}
+
+func (h *Handler) handleDeleteSecretField(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	fieldKey := r.PathValue("field")
+	if name == "" || fieldKey == "" {
+		respondError(w, http.StatusBadRequest, "name and field are required")
+		return
+	}
+	if !isValidResourceName(name) {
+		respondError(w, http.StatusBadRequest, "name must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+	if !isValidResourceName(fieldKey) {
+		respondError(w, http.StatusBadRequest, "field key must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+
+	secret, err := h.deps.DB().GetSecretByName(name)
+	if err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if secret.Status != refStatusActive || (secret.Scope != refScopeLocal && secret.Scope != db.RefScopeExternal) {
+		respondError(w, http.StatusConflict, "secret fields require VK:LOCAL or VK:EXTERNAL active lifecycle")
+		return
+	}
+	if err := h.deps.DB().DeleteSecretField(name, fieldKey); err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"name":    name,
+		"deleted": fieldKey,
+	})
+}

--- a/services/localvault/internal/api/secrets/handler.go
+++ b/services/localvault/internal/api/secrets/handler.go
@@ -1,0 +1,66 @@
+package secrets
+
+import (
+	"net/http"
+
+	"veilkey-localvault/internal/db"
+)
+
+// Deps is the interface that secrets.Handler requires from *api.Server.
+// It avoids a circular import by not importing the api package itself.
+type Deps interface {
+	// DB returns the underlying database handle.
+	DB() *db.DB
+
+	// GetKEK returns a copy of the current KEK bytes.
+	GetKEK() []byte
+
+	// GetLocalDEK decrypts and returns the local node's DEK using the KEK.
+	GetLocalDEK() ([]byte, error)
+
+	// VaultcenterURL returns the resolved vaultcenter base URL (empty if not configured).
+	VaultcenterURL() string
+
+	// HTTPClient returns the shared HTTP client.
+	HTTPClient() *http.Client
+}
+
+// Handler owns all secret-related HTTP handlers.
+type Handler struct {
+	deps Deps
+}
+
+// NewHandler creates a Handler backed by deps.
+func NewHandler(deps Deps) *Handler {
+	return &Handler{deps: deps}
+}
+
+// Register mounts all secret routes onto mux.
+func (h *Handler) Register(
+	mux *http.ServeMux,
+	requireUnlocked func(http.HandlerFunc) http.HandlerFunc,
+	requireTrustedIP func(http.HandlerFunc) http.HandlerFunc,
+) {
+	trusted := requireTrustedIP
+	ready := requireUnlocked
+
+	mux.HandleFunc("POST /api/secrets", trusted(ready(h.handleSaveSecret)))
+	mux.HandleFunc("GET /api/secrets", ready(h.handleListSecrets))
+	mux.HandleFunc("GET /api/secrets/{name}", ready(h.handleGetSecret))
+	mux.HandleFunc("DELETE /api/secrets/{name}", trusted(ready(h.handleDeleteSecret)))
+
+	mux.HandleFunc("GET /api/resolve/{ref}", ready(h.handleResolveSecret))
+	mux.HandleFunc("POST /api/rekey", trusted(ready(h.handleRekey)))
+
+	mux.HandleFunc("GET /api/cipher/{ref}", trusted(ready(h.handleCipher)))
+	mux.HandleFunc("GET /api/cipher/{ref}/fields/{field}", trusted(ready(h.handleCipherField)))
+	mux.HandleFunc("POST /api/cipher", trusted(ready(h.handleSaveCipher)))
+	mux.HandleFunc("POST /api/decrypt", trusted(ready(h.handleDecrypt)))
+	mux.HandleFunc("POST /api/promote", trusted(ready(h.handlePromote)))
+
+	mux.HandleFunc("POST /api/encrypt", ready(h.handleEncrypt))
+
+	mux.HandleFunc("GET /api/secrets/meta/{name}", ready(h.handleGetSecretMeta))
+	mux.HandleFunc("POST /api/secrets/fields", trusted(ready(h.handleSaveSecretFields)))
+	mux.HandleFunc("DELETE /api/secrets/{name}/fields/{field}", trusted(ready(h.handleDeleteSecretField)))
+}

--- a/services/localvault/internal/api/secrets/helpers.go
+++ b/services/localvault/internal/api/secrets/helpers.go
@@ -1,0 +1,35 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"veilkey-localvault/internal/db"
+	"github.com/veilkey/veilkey-go-package/httputil"
+)
+
+const vaultcenterOnlyDecryptMessage = "localvault direct plaintext handling is disabled; use vaultcenter"
+
+func respondJSON(w http.ResponseWriter, status int, data any) {
+	httputil.RespondJSON(w, status, data)
+}
+
+func respondError(w http.ResponseWriter, status int, msg string) {
+	httputil.RespondError(w, status, msg)
+}
+
+func isValidResourceName(name string) bool {
+	return httputil.IsValidResourceName(name)
+}
+
+// vkRef constructs a VK ref string.
+func vkRef(scope db.RefScope, id string) string { return makeRef(refFamilyVK, scope, id) }
+
+func generateSecretRef(length int) (string, error) {
+	b := make([]byte, (length+1)/2)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b)[:length], nil
+}

--- a/services/localvault/internal/api/secrets/promote.go
+++ b/services/localvault/internal/api/secrets/promote.go
@@ -1,0 +1,116 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+	"veilkey-localvault/internal/db"
+)
+
+func (h *Handler) handlePromote(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Ref  string `json:"ref"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Ref == "" || req.Name == "" {
+		respondError(w, http.StatusBadRequest, "ref and name are required")
+		return
+	}
+	if !strings.HasPrefix(req.Ref, makeRef(refFamilyVK, refScopeTemp, "")) {
+		respondError(w, http.StatusBadRequest, "only VK:TEMP refs can be promoted")
+		return
+	}
+	if !isValidResourceName(req.Name) {
+		respondError(w, http.StatusBadRequest, "name must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+
+	vcURL := h.deps.VaultcenterURL()
+	if vcURL == "" {
+		respondError(w, http.StatusServiceUnavailable, "vaultcenter URL not configured")
+		return
+	}
+
+	resolveURL := vcURL + "/api/resolve/" + url.PathEscape(req.Ref)
+	resp, err := h.deps.HTTPClient().Get(resolveURL)
+	if err != nil {
+		respondError(w, http.StatusBadGateway, "failed to reach vaultcenter: "+err.Error())
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		respondError(w, http.StatusBadGateway, fmt.Sprintf("vaultcenter resolve failed (%d): %s", resp.StatusCode, string(body)))
+		return
+	}
+
+	var resolveResp struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&resolveResp); err != nil {
+		respondError(w, http.StatusBadGateway, "failed to parse vaultcenter response")
+		return
+	}
+	if resolveResp.Value == "" {
+		respondError(w, http.StatusBadGateway, "vaultcenter returned empty value")
+		return
+	}
+
+	nodeInfo, err := h.deps.DB().GetNodeInfo()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "node info not available")
+		return
+	}
+
+	dek, err := crypto.Decrypt(h.deps.GetKEK(), nodeInfo.DEK, nodeInfo.DEKNonce)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to decrypt DEK")
+		return
+	}
+
+	ciphertext, nonce, err := crypto.Encrypt(dek, []byte(resolveResp.Value))
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "encryption failed")
+		return
+	}
+
+	refID, err := generateSecretRef(8)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to generate ref")
+		return
+	}
+
+	secret := &db.Secret{
+		ID:         crypto.GenerateUUID(),
+		Name:       strings.ToUpper(req.Name),
+		Ref:        refID,
+		Ciphertext: ciphertext,
+		Nonce:      nonce,
+		Version:    nodeInfo.Version,
+		Scope:      refScopeLocal,
+		Status:     refStatusActive,
+	}
+	if err := h.deps.DB().SaveSecret(secret); err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to save secret: "+err.Error())
+		return
+	}
+
+	token := vkRef(refScopeLocal, refID)
+	respondJSON(w, http.StatusOK, map[string]any{
+		"ref":    token,
+		"token":  token,
+		"name":   secret.Name,
+		"status": refStatusActive,
+		"action": "promoted",
+	})
+}

--- a/services/localvault/internal/api/secrets/secrets.go
+++ b/services/localvault/internal/api/secrets/secrets.go
@@ -1,0 +1,216 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+)
+
+func (h *Handler) handleSaveSecret(w http.ResponseWriter, r *http.Request) {
+	respondError(w, http.StatusForbidden, vaultcenterOnlyDecryptMessage)
+}
+
+func (h *Handler) handleGetSecret(w http.ResponseWriter, r *http.Request) {
+	respondError(w, http.StatusForbidden, vaultcenterOnlyDecryptMessage)
+}
+
+func (h *Handler) handleListSecrets(w http.ResponseWriter, r *http.Request) {
+	secrets, err := h.deps.DB().ListSecrets()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to list secrets")
+		return
+	}
+
+	type secretResp struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Ref         string `json:"ref,omitempty"`
+		Token       string `json:"token,omitempty"`
+		Scope       string `json:"scope"`
+		Version     int    `json:"version"`
+		Status      string `json:"status"`
+		FieldsCount int    `json:"fields_count,omitempty"`
+	}
+	var result []secretResp
+	for _, secret := range secrets {
+		sr := secretResp{
+			ID:      secret.ID,
+			Name:    secret.Name,
+			Ref:     secret.Ref,
+			Scope:   string(secret.Scope),
+			Version: secret.Version,
+			Status:  string(secret.Status),
+		}
+		if secret.Ref != "" {
+			sr.Token = vkRef(secret.Scope, secret.Ref)
+		}
+		if fields, err := h.deps.DB().ListSecretFields(secret.Name); err == nil {
+			sr.FieldsCount = len(fields)
+		}
+		result = append(result, sr)
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"secrets": result,
+		"count":   len(result),
+	})
+}
+
+func (h *Handler) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		respondError(w, http.StatusBadRequest, "secret name is required")
+		return
+	}
+	if !isValidResourceName(name) {
+		respondError(w, http.StatusBadRequest, "name must match [A-Z_][A-Z0-9_]*")
+		return
+	}
+
+	if err := h.deps.DB().DeleteSecret(name); err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"deleted": name,
+	})
+}
+
+func (h *Handler) handleResolveSecret(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-VeilKey-Cascade") != "true" {
+		respondError(w, http.StatusForbidden, vaultcenterOnlyDecryptMessage)
+		return
+	}
+
+	ref := r.PathValue("ref")
+	if ref == "" {
+		respondError(w, http.StatusBadRequest, "ref is required")
+		return
+	}
+
+	secret, err := h.deps.DB().GetSecretByRef(ref)
+	if err != nil {
+		parts := strings.SplitN(ref, ":", 3)
+		if len(parts) == 3 {
+			secret, err = h.deps.DB().GetSecretByRef(parts[2])
+		}
+		if err != nil {
+			respondError(w, http.StatusNotFound, "ref not found")
+			return
+		}
+	}
+
+	info, err := h.deps.DB().GetNodeInfo()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "node info not available")
+		return
+	}
+
+	dek, err := crypto.Decrypt(h.deps.GetKEK(), info.DEK, info.DEKNonce)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to decrypt DEK")
+		return
+	}
+
+	plaintext, err := crypto.Decrypt(dek, secret.Ciphertext, secret.Nonce)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "decryption failed")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"ref":   ref,
+		"name":  secret.Name,
+		"value": string(plaintext),
+	})
+}
+
+func (h *Handler) handleRekey(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DEK     []byte `json:"dek"`
+		Version int    `json:"version"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(req.DEK) != 32 {
+		respondError(w, http.StatusBadRequest, "DEK must be 32 bytes")
+		return
+	}
+	if req.Version <= 0 {
+		respondError(w, http.StatusBadRequest, "version must be positive")
+		return
+	}
+
+	oldDEK, err := h.deps.GetLocalDEK()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to get current DEK: "+err.Error())
+		return
+	}
+	count, skipped, err := h.deps.DB().ReencryptMixedSecrets(
+		func(ciphertext, nonce []byte) ([]byte, error) {
+			return crypto.Decrypt(oldDEK, ciphertext, nonce)
+		},
+		func(ciphertext, nonce []byte) ([]byte, error) {
+			return crypto.Decrypt(req.DEK, ciphertext, nonce)
+		},
+		func(plaintext []byte) ([]byte, []byte, error) {
+			return crypto.Encrypt(req.DEK, plaintext)
+		},
+		req.Version,
+	)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("re-encryption failed after %d secrets (skipped %d already-current): %v", count, skipped, err))
+		return
+	}
+
+	encDEK, encNonce, err := crypto.Encrypt(h.deps.GetKEK(), req.DEK)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to re-encrypt DEK with KEK")
+		return
+	}
+	if err := h.deps.DB().UpdateNodeDEK(encDEK, encNonce, req.Version); err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to update node DEK: "+err.Error())
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"status":          "rekeyed",
+		"secrets_updated": count,
+		"secrets_skipped": skipped,
+		"version":         req.Version,
+	})
+}
+
+func (h *Handler) handleCipher(w http.ResponseWriter, r *http.Request) {
+	ref := r.PathValue("ref")
+	if ref == "" {
+		respondError(w, http.StatusBadRequest, "ref is required")
+		return
+	}
+
+	secret, err := h.deps.DB().GetSecretByRef(ref)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "ref not found: "+ref)
+		return
+	}
+	if secret.Status == refStatusBlock {
+		respondError(w, http.StatusLocked, "ref is blocked: "+vkRef(secret.Scope, ref))
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"ref":        ref,
+		"name":       secret.Name,
+		"ciphertext": secret.Ciphertext,
+		"nonce":      secret.Nonce,
+		"version":    secret.Version,
+	})
+	_ = h.deps.DB().MarkSecretRevealed(ref, time.Now().UTC())
+}


### PR DESCRIPTION
## Summary
- `.gitignore`의 `secrets/` 패턴이 루트 디렉토리뿐 아니라 모든 하위 `secrets/` 디렉토리를 무시하고 있었음
- PR #103에서 추출한 `services/localvault/internal/api/secrets/` Go 패키지 9개 파일이 커밋되지 않아 clean clone 시 localvault 빌드 실패
- `secrets/` → `/secrets/`로 변경하여 루트만 무시하도록 수정
- 누락된 secrets 서브패키지 파일 추가

## Test plan
- [ ] `go build ./...` in `services/localvault/` passes
- [ ] `docker compose build localvault` succeeds
- [ ] Fresh clone builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)