### PR TITLE
refactor: deduplicate normalizeScopeStatus via shared refs package

### DIFF
--- a/services/vaultcenter/go.mod
+++ b/services/vaultcenter/go.mod
@@ -3,7 +3,7 @@ module veilkey-vaultcenter
 go 1.25.0
 
 require (
-	github.com/veilkey/veilkey-go-package v0.3.0
+	github.com/veilkey/veilkey-go-package v0.3.1
 	github.com/wneessen/go-mail v0.7.2
 	gorm.io/gorm v1.31.1
 )

--- a/services/vaultcenter/go.sum
+++ b/services/vaultcenter/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/veilkey/veilkey-go-package v0.3.0 h1:BvGydDA3pQsHEEBw/FzmVw2Nhk8OqGZzjA7CgH3Xd2g=
 github.com/veilkey/veilkey-go-package v0.3.0/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
+github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=
+github.com/veilkey/veilkey-go-package v0.3.1/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
 github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=

--- a/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
@@ -13,25 +13,7 @@ func parseCanonicalRef(ref string) (db.RefParts, error) {
 }
 
 func normalizeScopeStatus(family string, scope db.RefScope, status db.RefStatus, fallbackScope db.RefScope) (db.RefScope, db.RefStatus, error) {
-	if scope == "" {
-		scope = fallbackScope
-	}
-	if scope == "" {
-		scope = db.RefScopeTemp
-	}
-	switch scope {
-	case db.RefScopeLocal, db.RefScopeExternal:
-		if status == "" {
-			status = db.RefStatusActive
-		}
-	case db.RefScopeTemp:
-		if status == "" {
-			status = db.RefStatusTemp
-		}
-	default:
-		return "", "", fmt.Errorf("unsupported %s scope: %s", family, scope)
-	}
-	return scope, status, nil
+	return db.NormalizeScopeStatus(family, scope, status, fallbackScope)
 }
 
 func (h *Handler) upsertTrackedRef(ref string, version int, status db.RefStatus, agentHash string) error {

--- a/services/vaultcenter/internal/api/local_configs.go
+++ b/services/vaultcenter/internal/api/local_configs.go
@@ -247,27 +247,9 @@ func (s *Server) handleDeleteConfig(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// normalizeScopeStatus normalizes scope and status for a given ref family.
+// normalizeScopeStatus delegates to the shared refs package.
 func normalizeScopeStatus(family string, scope db.RefScope, status db.RefStatus, fallbackScope db.RefScope) (db.RefScope, db.RefStatus, error) {
-	if scope == "" {
-		scope = fallbackScope
-	}
-	if scope == "" {
-		scope = db.RefScopeTemp
-	}
-	switch scope {
-	case db.RefScopeLocal, db.RefScopeExternal:
-		if status == "" {
-			status = db.RefStatusActive
-		}
-	case db.RefScopeTemp:
-		if status == "" {
-			status = db.RefStatusTemp
-		}
-	default:
-		return "", "", fmt.Errorf("unsupported %s scope: %s", family, scope)
-	}
-	return scope, status, nil
+	return db.NormalizeScopeStatus(family, scope, status, fallbackScope)
 }
 
 // upsertTrackedRef upserts a tracked ref directly via the DB.

--- a/services/vaultcenter/internal/db/ref_policy.go
+++ b/services/vaultcenter/internal/db/ref_policy.go
@@ -30,3 +30,7 @@ const (
 func MakeRef(family string, scope RefScope, id string) string {
 	return refs.MakeRef(family, scope, id)
 }
+
+func NormalizeScopeStatus(family string, scope RefScope, status RefStatus, fallbackScope RefScope) (RefScope, RefStatus, error) {
+	return refs.NormalizeScopeStatus(family, scope, status, fallbackScope)
+}


### PR DESCRIPTION
## Summary
- `normalizeScopeStatus()` was duplicated in `api/local_configs.go` and `hkm/hkm_ref_tracking.go`
- Extracted to `refs.NormalizeScopeStatus()` in veilkey-go-package v0.3.1
- Both call sites now delegate through `db.NormalizeScopeStatus()`
- -30 lines duplicated logic

## Test plan
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)