### PR TITLE
fix: use configured HTTP client for agent TLS communication

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
@@ -220,7 +220,7 @@ func (h *Handler) fetchAgentFieldCiphertext(agentURL, ref, fieldKey string) (*ci
 }
 
 func (h *Handler) fetchAgentResolvedValue(agentURL, ref string) (*resolvedAgentSecret, error) {
-	resp, err := http.Get(joinPath(agentURL, agentPathResolve, ref))
+	resp, err := h.deps.HTTPClient().Get(joinPath(agentURL, agentPathResolve, ref))
 	if err != nil {
 		return nil, fmt.Errorf("agent unreachable: %w", err)
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_secret_fields.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_secret_fields.go
@@ -90,7 +90,7 @@ func (h *Handler) handleAgentSaveSecretFields(w http.ResponseWriter, r *http.Req
 		"name":   name,
 		"fields": payloadFields,
 	})
-	resp, err := http.Post(agent.URL()+agentPathSecretFields, "application/json", bytes.NewReader(reqBody))
+	resp, err := h.deps.HTTPClient().Post(agent.URL()+agentPathSecretFields, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
 		return

--- a/services/vaultcenter/internal/api/hkm/hkm_vault_keys.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_vault_keys.go
@@ -204,7 +204,7 @@ func (h *Handler) handleVaultList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) fetchAgentSecretMeta(agentURL, name string) (*agentSecretMeta, int, []byte, error) {
-	resp, err := http.Get(joinPath(agentURL, agentPathSecrets, "meta", name))
+	resp, err := h.deps.HTTPClient().Get(joinPath(agentURL, agentPathSecrets, "meta", name))
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -212,7 +212,7 @@ func (h *Handler) fetchAgentSecretMeta(agentURL, name string) (*agentSecretMeta,
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusNotFound {
-		fallbackResp, err := http.Get(joinPath(agentURL, agentPathSecrets, name))
+		fallbackResp, err := h.deps.HTTPClient().Get(joinPath(agentURL, agentPathSecrets, name))
 		if err != nil {
 			return nil, 0, nil, err
 		}
@@ -248,7 +248,7 @@ func (h *Handler) fetchAgentSecretMeta(agentURL, name string) (*agentSecretMeta,
 			}
 		}
 
-		listResp, err := http.Get(agentURL + agentPathSecrets)
+		listResp, err := h.deps.HTTPClient().Get(agentURL + agentPathSecrets)
 		if err != nil {
 			return nil, fallbackResp.StatusCode, fallbackBody, nil
 		}


### PR DESCRIPTION
## Summary
- `hkm_vault_keys.go`, `hkm_agent_common.go`, `hkm_agent_secret_fields.go` were using `http.Get`/`http.Post` (Go default client) instead of the configured `h.deps.HTTPClient()`
- This bypassed `VEILKEY_TLS_INSECURE=1` setting, causing TLS certificate validation failures when VaultCenter communicates with LocalVault over self-signed certs in Docker

## Test plan
- [ ] Open vault detail page — secrets/configs load without TLS error
- [ ] `docker compose` with self-signed certs works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)