### PR TITLE
fix: chain executor determinism + TxEnvelope actor fields

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -148,6 +148,14 @@ fi
 check_env_documented "localvault"
 check_env_documented "vaultcenter"
 
+# 6. executor에서 time.Now() 사용 금지 (리플레이 결정론)
+executor_time_now=$(grep -n 'time\.Now()' services/vaultcenter/internal/chain/executor.go 2>/dev/null || true)
+if [[ -n "$executor_time_now" ]]; then
+  echo "❌ chain/executor.go에서 time.Now() 사용 금지 — blockTime 파라미터를 사용하세요"
+  echo "$executor_time_now"
+  found=1
+fi
+
 if [[ $found -eq 1 ]]; then
   echo ""
   echo "기본값은 .env.example에 추가하세요."

--- a/services/vaultcenter/internal/chain/app.go
+++ b/services/vaultcenter/internal/chain/app.go
@@ -73,7 +73,7 @@ func (app *Application) FinalizeBlock(_ context.Context, req *abcitypes.RequestF
 			txResults[i] = &abcitypes.ExecTxResult{Code: 2, Log: err.Error()}
 			continue
 		}
-		code, log := Execute(app.db, env)
+		code, log := Execute(app.db, env, req.Time)
 		txResults[i] = &abcitypes.ExecTxResult{Code: code, Log: log}
 	}
 

--- a/services/vaultcenter/internal/chain/executor.go
+++ b/services/vaultcenter/internal/chain/executor.go
@@ -9,9 +9,11 @@ import (
 )
 
 // Execute applies a decoded TxEnvelope to the database.
+// blockTime is the CometBFT block timestamp — used for all time-dependent state changes
+// (e.g. default expiry). env.Timestamp is the client-side submission time (for audit only).
 // Returns (resultCode uint32, resultLog string).
 // Code 0 = success, 1 = unknown type, 2 = decode error, 3 = db error, 4 = validation error.
-func Execute(d *db.DB, env *TxEnvelope) (uint32, string) {
+func Execute(d *db.DB, env *TxEnvelope, blockTime time.Time) (uint32, string) {
 	switch env.Type {
 
 	// ── TokenRef operations ─────────────────────────────────────────────
@@ -35,7 +37,7 @@ func Execute(d *db.DB, env *TxEnvelope) (uint32, string) {
 		if p.ExpiresAt != nil {
 			expiresAt = *p.ExpiresAt
 		} else {
-			expiresAt = time.Now().UTC().Add(4 * time.Hour)
+			expiresAt = blockTime.UTC().Add(4 * time.Hour)
 		}
 		if err := d.SaveRefWithExpiryAndHash(
 			parts, p.Ciphertext, p.Version,

--- a/services/vaultcenter/internal/chain/tx.go
+++ b/services/vaultcenter/internal/chain/tx.go
@@ -26,6 +26,9 @@ type TxEnvelope struct {
 	Type      TxType          `json:"type"`
 	Nonce     string          `json:"nonce"`
 	Timestamp time.Time       `json:"timestamp"`
+	ActorType string          `json:"actor_type,omitempty"` // "agent", "operator", "system", "api"
+	ActorID   string          `json:"actor_id,omitempty"`   // remote IP or agent hash
+	Source    string          `json:"source,omitempty"`     // route path or handler name
 	Payload   json.RawMessage `json:"payload"`
 }
 


### PR DESCRIPTION
## Summary
Addresses #108 Step 1 items — executor determinism and TxEnvelope extension.

- `Execute()` now takes `blockTime time.Time` from CometBFT `FinalizeBlock`
- Removed `time.Now()` from executor — default expiry now uses `blockTime.Add(4h)` instead
- `TxEnvelope`: added `ActorType`, `ActorID`, `Source` fields for automatic audit trail
- `FinalizeBlock` passes `req.Time` (consensus timestamp) to executor
- pre-commit lint: detects `time.Now()` usage in `executor.go`

## Motivation
- Replay determinism: executor must not use wall-clock time
- Audit fields in envelope enable executor to auto-generate audit events per TX (Step 3)

## Test plan
- [ ] `go build ./...` passes for vaultcenter
- [ ] pre-commit detects if someone adds `time.Now()` back to executor.go

Refs: #108, #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)