### PR TITLE
feat(chain): Step 1 — TxEnvelope actor fields + executor determinism + auto audit

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -39,7 +39,15 @@ if [[ -n "$ref_hardcoded" ]]; then
   found=1
 fi
 
-# 3. 매직 스트링 차단 — constants.go에 정의된 값이 다른 Go 파일에서 리터럴로 중복 사용
+# 3. executor 결정론 차단 — chain/executor.go에서 time.Now 호출 금지
+executor_time=$(grep -rn 'time\.Now' services/vaultcenter/internal/chain/executor.go 2>/dev/null | grep -v '// ' || true)
+if [[ -n "$executor_time" ]]; then
+  echo "❌ executor 결정론 위반: chain/executor.go에서 time.Now() 금지 — env.Timestamp를 사용하세요"
+  echo "$executor_time"
+  found=1
+fi
+
+# 4. 매직 스트링 차단 — constants.go에 정의된 값이 다른 Go 파일에서 리터럴로 중복 사용
 magic_found=""
 for cfile in $(find $GO_SERVICES -name "constants.go" -o -name "const.go" 2>/dev/null); do
   pkg_dir=$(dirname "$cfile")

--- a/services/vaultcenter/internal/chain/executor.go
+++ b/services/vaultcenter/internal/chain/executor.go
@@ -2,8 +2,10 @@ package chain
 
 import (
 	"fmt"
+	"log"
 	"time"
 
+	"github.com/veilkey/veilkey-go-package/crypto"
 	"github.com/veilkey/veilkey-go-package/refs"
 	"veilkey-vaultcenter/internal/db"
 )
@@ -11,7 +13,34 @@ import (
 // Execute applies a decoded TxEnvelope to the database.
 // Returns (resultCode uint32, resultLog string).
 // Code 0 = success, 1 = unknown type, 2 = decode error, 3 = db error, 4 = validation error.
+//
+// IMPORTANT: This function must be deterministic for chain replay.
+// Never use time.Now() — all time references must come from env.Timestamp.
 func Execute(d *db.DB, env *TxEnvelope) (uint32, string) {
+	code, resultLog, entityType, entityID := executeTx(d, env)
+
+	// Auto-generate audit row on successful TX execution
+	if code == 0 && env.ActorType != "" {
+		auditErr := d.SaveAuditEvent(&db.AuditEvent{
+			EventID:    crypto.GenerateUUID(),
+			EntityType: entityType,
+			EntityID:   entityID,
+			Action:     string(env.Type),
+			ActorType:  env.ActorType,
+			ActorID:    env.ActorID,
+			Source:     env.Source,
+		})
+		if auditErr != nil {
+			log.Printf("chain: auto-audit failed for %s: %v", env.Type, auditErr)
+		}
+	}
+
+	return code, resultLog
+}
+
+// executeTx dispatches the TX to the appropriate db method.
+// Returns (code, log, entityType, entityID) for audit generation.
+func executeTx(d *db.DB, env *TxEnvelope) (uint32, string, string, string) {
 	switch env.Type {
 
 	// ── TokenRef operations ─────────────────────────────────────────────
@@ -19,103 +48,93 @@ func Execute(d *db.DB, env *TxEnvelope) (uint32, string) {
 	case TxSaveTokenRef:
 		p, err := DecodePayload[SaveTokenRefPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode SaveTokenRef: %v", err)
+			return 2, fmt.Sprintf("decode SaveTokenRef: %v", err), "", ""
 		}
 
-		// Normalize scope/status via shared refs package
 		normScope, normStatus, normErr := refs.NormalizeScopeStatus(
 			p.RefFamily, p.RefScope, p.Status, refs.RefScopeTemp,
 		)
 		if normErr != nil {
-			return 4, fmt.Sprintf("validate SaveTokenRef: %v", normErr)
+			return 4, fmt.Sprintf("validate SaveTokenRef: %v", normErr), "", ""
 		}
 
 		parts := db.RefParts{Family: p.RefFamily, Scope: db.RefScope(normScope), ID: p.RefID}
-		var expiresAt time.Time
+		expiresAt := env.Timestamp.Add(4 * time.Hour) // deterministic — based on TX timestamp
 		if p.ExpiresAt != nil {
 			expiresAt = *p.ExpiresAt
-		} else {
-			expiresAt = time.Now().UTC().Add(4 * time.Hour)
 		}
 		if err := d.SaveRefWithExpiryAndHash(
 			parts, p.Ciphertext, p.Version,
 			db.RefStatus(normStatus), expiresAt,
 			p.SecretName, p.PlaintextHash,
 		); err != nil {
-			return 3, fmt.Sprintf("db SaveTokenRef: %v", err)
+			return 3, fmt.Sprintf("db SaveTokenRef: %v", err), "", ""
 		}
-		return 0, refs.MakeRef(p.RefFamily, normScope, p.RefID)
+		canonical := refs.MakeRef(p.RefFamily, normScope, p.RefID)
+		return 0, canonical, "tracked_ref", canonical
 
 	case TxUpdateTokenRef:
 		p, err := DecodePayload[UpdateTokenRefPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode UpdateTokenRef: %v", err)
+			return 2, fmt.Sprintf("decode UpdateTokenRef: %v", err), "", ""
 		}
-
-		// Validate canonical ref format
 		if _, _, _, parseErr := refs.ParseRef(p.RefCanonical); parseErr != nil {
-			return 4, fmt.Sprintf("validate UpdateTokenRef: %v", parseErr)
+			return 4, fmt.Sprintf("validate UpdateTokenRef: %v", parseErr), "", ""
 		}
-
 		if err := d.UpdateRefWithName(
 			p.RefCanonical, p.Ciphertext, p.Version,
 			db.RefStatus(p.Status), "",
 		); err != nil {
-			return 3, fmt.Sprintf("db UpdateTokenRef: %v", err)
+			return 3, fmt.Sprintf("db UpdateTokenRef: %v", err), "", ""
 		}
-		return 0, p.RefCanonical
+		return 0, p.RefCanonical, "tracked_ref", p.RefCanonical
 
 	case TxDeleteTokenRef:
 		p, err := DecodePayload[DeleteTokenRefPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode DeleteTokenRef: %v", err)
+			return 2, fmt.Sprintf("decode DeleteTokenRef: %v", err), "", ""
 		}
-
-		// Validate canonical ref format
 		if _, _, _, parseErr := refs.ParseRef(p.RefCanonical); parseErr != nil {
-			return 4, fmt.Sprintf("validate DeleteTokenRef: %v", parseErr)
+			return 4, fmt.Sprintf("validate DeleteTokenRef: %v", parseErr), "", ""
 		}
-
 		if err := d.DeleteRef(p.RefCanonical); err != nil {
-			return 3, fmt.Sprintf("db DeleteTokenRef: %v", err)
+			return 3, fmt.Sprintf("db DeleteTokenRef: %v", err), "", ""
 		}
-		return 0, p.RefCanonical
+		return 0, p.RefCanonical, "tracked_ref", p.RefCanonical
 
 	case TxIncrementRefVersion:
 		p, err := DecodePayload[IncrementRefVersionPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode IncrementRefVersion: %v", err)
+			return 2, fmt.Sprintf("decode IncrementRefVersion: %v", err), "", ""
 		}
-
 		if _, _, _, parseErr := refs.ParseRef(p.RefCanonical); parseErr != nil {
-			return 4, fmt.Sprintf("validate IncrementRefVersion: %v", parseErr)
+			return 4, fmt.Sprintf("validate IncrementRefVersion: %v", parseErr), "", ""
 		}
-
 		if err := d.UpdateRefWithName(p.RefCanonical, "", p.NewVersion, "", ""); err != nil {
-			return 3, fmt.Sprintf("db IncrementRefVersion: %v", err)
+			return 3, fmt.Sprintf("db IncrementRefVersion: %v", err), "", ""
 		}
-		return 0, fmt.Sprintf("%s@v%d", p.RefCanonical, p.NewVersion)
+		return 0, fmt.Sprintf("%s@v%d", p.RefCanonical, p.NewVersion), "tracked_ref", p.RefCanonical
 
 	// ── Agent operations ────────────────────────────────────────────────
 
 	case TxUpsertAgent:
 		p, err := DecodePayload[UpsertAgentPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode UpsertAgent: %v", err)
+			return 2, fmt.Sprintf("decode UpsertAgent: %v", err), "", ""
 		}
 		if err := d.UpsertAgent(
 			p.NodeID, p.Label, p.VaultHash, p.VaultName,
 			p.IP, p.Port, p.SecretsCount, p.ConfigsCount,
 			p.Version, p.KeyVersion,
 		); err != nil {
-			return 3, fmt.Sprintf("db UpsertAgent: %v", err)
+			return 3, fmt.Sprintf("db UpsertAgent: %v", err), "", ""
 		}
-		return 0, p.NodeID
+		return 0, p.NodeID, "agent", p.NodeID
 
 	case TxRegisterChild:
 		p, err := DecodePayload[RegisterChildPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode RegisterChild: %v", err)
+			return 2, fmt.Sprintf("decode RegisterChild: %v", err), "", ""
 		}
 		child := &db.Child{
 			NodeID:       p.NodeID,
@@ -126,59 +145,72 @@ func Execute(d *db.DB, env *TxEnvelope) (uint32, string) {
 			Version:      p.Version,
 		}
 		if err := d.RegisterChild(child); err != nil {
-			return 3, fmt.Sprintf("db RegisterChild: %v", err)
+			return 3, fmt.Sprintf("db RegisterChild: %v", err), "", ""
 		}
-		return 0, p.NodeID
+		return 0, p.NodeID, "child", p.NodeID
 
 	// ── Config operations ───────────────────────────────────────────────
 
 	case TxSetConfig:
 		p, err := DecodePayload[SetConfigPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode SetConfig: %v", err)
+			return 2, fmt.Sprintf("decode SetConfig: %v", err), "", ""
 		}
 		if err := d.SaveConfig(p.Key, p.Value); err != nil {
-			return 3, fmt.Sprintf("db SetConfig: %v", err)
+			return 3, fmt.Sprintf("db SetConfig: %v", err), "", ""
 		}
-		return 0, p.Key
+		return 0, p.Key, "config", p.Key
 
 	// ── Binding operations ──────────────────────────────────────────────
 
 	case TxSaveBinding:
 		p, err := DecodePayload[SaveBindingPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode SaveBinding: %v", err)
+			return 2, fmt.Sprintf("decode SaveBinding: %v", err), "", ""
 		}
-
-		// Validate ref canonical if provided
 		if p.RefCanonical != "" {
 			if _, _, _, parseErr := refs.ParseRef(p.RefCanonical); parseErr != nil {
-				return 4, fmt.Sprintf("validate SaveBinding ref: %v", parseErr)
+				return 4, fmt.Sprintf("validate SaveBinding ref: %v", parseErr), "", ""
 			}
 		}
-
 		// TODO: implement d.SaveBinding() when binding DB methods are refactored
-		return 0, p.BindingID
+		return 0, p.BindingID, "binding", p.BindingID
 
 	case TxDeleteBinding:
 		p, err := DecodePayload[DeleteBindingPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode DeleteBinding: %v", err)
+			return 2, fmt.Sprintf("decode DeleteBinding: %v", err), "", ""
 		}
 		// TODO: implement d.DeleteBinding() when binding DB methods are refactored
-		return 0, p.BindingID
+		return 0, p.BindingID, "binding", p.BindingID
 
-	// ── Audit operations ────────────────────────────────────────────────
+	// ── Audit operations (explicit metadata) ────────────────────────────
 
 	case TxRecordAuditEvent:
 		p, err := DecodePayload[RecordAuditEventPayload](env)
 		if err != nil {
-			return 2, fmt.Sprintf("decode RecordAuditEvent: %v", err)
+			return 2, fmt.Sprintf("decode RecordAuditEvent: %v", err), "", ""
 		}
-		// TODO: implement d.SaveAuditEvent() when audit DB methods are refactored
-		return 0, p.EventID
+		auditErr := d.SaveAuditEvent(&db.AuditEvent{
+			EventID:             p.EventID,
+			EntityType:          p.EntityType,
+			EntityID:            p.EntityID,
+			Action:              p.Action,
+			ActorType:           p.ActorType,
+			ActorID:             p.ActorID,
+			Reason:              p.Reason,
+			Source:              p.Source,
+			ApprovalChallengeID: p.ApprovalChallengeID,
+			BeforeJSON:          p.BeforeJSON,
+			AfterJSON:           p.AfterJSON,
+		})
+		if auditErr != nil {
+			return 3, fmt.Sprintf("db RecordAuditEvent: %v", auditErr), "", ""
+		}
+		// Skip auto-audit for explicit audit TX (avoid double-write)
+		return 0, p.EventID, "", ""
 
 	default:
-		return 1, fmt.Sprintf("unknown tx type: %s", env.Type)
+		return 1, fmt.Sprintf("unknown tx type: %s", env.Type), "", ""
 	}
 }

--- a/services/vaultcenter/internal/chain/tx.go
+++ b/services/vaultcenter/internal/chain/tx.go
@@ -26,7 +26,17 @@ type TxEnvelope struct {
 	Type      TxType          `json:"type"`
 	Nonce     string          `json:"nonce"`
 	Timestamp time.Time       `json:"timestamp"`
+	ActorType string          `json:"actor_type,omitempty"`
+	ActorID   string          `json:"actor_id,omitempty"`
+	Source    string          `json:"source,omitempty"`
 	Payload   json.RawMessage `json:"payload"`
+}
+
+// TxActor carries actor context extracted from HTTP requests.
+type TxActor struct {
+	ActorType string // "agent", "operator", "system"
+	ActorID   string // remote IP or agent hash
+	Source    string // "heartbeat", "api_save_secret", etc.
 }
 
 // SaveTokenRefPayload carries the data for a SaveTokenRef transaction.

--- a/services/vaultcenter/internal/chain/tx_encode.go
+++ b/services/vaultcenter/internal/chain/tx_encode.go
@@ -22,8 +22,9 @@ var validTxTypes = map[TxType]bool{
 	TxRecordAuditEvent:    true,
 }
 
-// EncodeTx creates a TxEnvelope, marshals the payload, and returns the full JSON bytes.
-func EncodeTx(txType TxType, payload any) ([]byte, error) {
+// BuildEnvelope creates a TxEnvelope without marshaling to bytes.
+// Used by SubmitTx to stamp actor info before encoding.
+func BuildEnvelope(txType TxType, payload any, actor TxActor) (*TxEnvelope, error) {
 	if !validTxTypes[txType] {
 		return nil, fmt.Errorf("chain: unknown tx type %q", txType)
 	}
@@ -33,18 +34,34 @@ func EncodeTx(txType TxType, payload any) ([]byte, error) {
 		return nil, fmt.Errorf("chain: marshal payload: %w", err)
 	}
 
-	env := TxEnvelope{
+	return &TxEnvelope{
 		Type:      txType,
 		Nonce:     crypto.GenerateUUID(),
 		Timestamp: time.Now().UTC(),
+		ActorType: actor.ActorType,
+		ActorID:   actor.ActorID,
+		Source:    actor.Source,
 		Payload:   raw,
-	}
+	}, nil
+}
 
+// MarshalEnvelope encodes a TxEnvelope to JSON bytes.
+func MarshalEnvelope(env *TxEnvelope) ([]byte, error) {
 	out, err := json.Marshal(env)
 	if err != nil {
 		return nil, fmt.Errorf("chain: marshal envelope: %w", err)
 	}
 	return out, nil
+}
+
+// EncodeTx creates a TxEnvelope and marshals it to bytes in one step.
+// Convenience for broadcast paths that don't need to inspect the envelope.
+func EncodeTx(txType TxType, payload any) ([]byte, error) {
+	env, err := BuildEnvelope(txType, payload, TxActor{})
+	if err != nil {
+		return nil, err
+	}
+	return MarshalEnvelope(env)
 }
 
 // DecodeTx unmarshals raw bytes into a TxEnvelope. Returns an error if the type is unknown.


### PR DESCRIPTION
Closes #110

## Summary
- **TxEnvelope 확장**: ActorType, ActorID, Source 필드 추가 — 블록 자체가 감사 기록
- **BuildEnvelope/MarshalEnvelope 분리**: SubmitTx가 actor 스탬프 후 인코딩 가능
- **executor 결정론**: `time.Now()` 제거 → `env.Timestamp.Add(4h)` 기반 계산
- **자동 audit**: 모든 TX 성공 시 executor가 `db.SaveAuditEvent()` 자동 호출
- **RecordAuditEvent**: before/after 메타데이터 전용, auto-audit 스킵 (이중 방지)
- **pre-commit lint**: `chain/executor.go`에서 `time.Now` 호출 감지

## Test plan
- [x] `go build ./...` 통과
- [x] executor에 `time.Now()` 0건 (주석 제외)
- [x] pre-commit lint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)