### PR TITLE
feat(chain): Step 2 — Deps SubmitTx/SubmitTxAsync + Server impl + TxActor middleware

### DIFF
--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -14,6 +15,7 @@ import (
 	"veilkey-vaultcenter/internal/api/approval"
 	"veilkey-vaultcenter/internal/api/bulk"
 	"veilkey-vaultcenter/internal/api/hkm"
+	"veilkey-vaultcenter/internal/chain"
 	"github.com/veilkey/veilkey-go-package/agentapi"
 	"github.com/veilkey/veilkey-go-package/crypto"
 	"github.com/veilkey/veilkey-go-package/ratelimit"
@@ -57,6 +59,7 @@ type Server struct {
 	timeouts       Timeouts
 	unlockLimiter  *ratelimit.UnlockRateLimiter
 	httpClient     *http.Client
+	chainClient    *chain.Client
 	bulkApplyDir   string
 	updateMu       sync.RWMutex
 	updateState    systemUpdateState
@@ -103,6 +106,73 @@ func (s *Server) IsTrustedIPString(ip string) bool { return s.isTrustedIPString(
 
 func (s *Server) SaveAuditEvent(entityType, entityID, action, actorType, actorID, reason, source string, before, after map[string]any) {
 	s.saveAuditEvent(entityType, entityID, action, actorType, actorID, reason, source, before, after)
+}
+
+// ── chain TX submission ─────────────────────────────────────────────────────
+
+// SetChainClient sets the CometBFT chain client. nil disables chain mode (DB fallback).
+func (s *Server) SetChainClient(c *chain.Client) { s.chainClient = c }
+
+// SubmitTx submits a write TX and blocks until committed.
+func (s *Server) SubmitTx(ctx context.Context, txType chain.TxType, payload any) (string, error) {
+	actor := txActorFromCtx(ctx)
+	if s.chainClient != nil {
+		env, err := chain.BuildEnvelope(txType, payload, actor)
+		if err != nil {
+			return "", err
+		}
+		txBytes, err := chain.MarshalEnvelope(env)
+		if err != nil {
+			return "", err
+		}
+		result, err := s.chainClient.BroadcastTxCommitRaw(ctx, txBytes)
+		if err != nil {
+			return "", err
+		}
+		if result.CheckTx.Code != 0 {
+			return "", fmt.Errorf("chain check: %s", result.CheckTx.Log)
+		}
+		if result.TxResult.Code != 0 {
+			return "", fmt.Errorf("chain exec: %s", result.TxResult.Log)
+		}
+		return result.TxResult.Log, nil
+	}
+	// fallback: executor 직접 호출
+	env, err := chain.BuildEnvelope(txType, payload, actor)
+	if err != nil {
+		return "", err
+	}
+	code, resultLog := chain.Execute(s.db, env)
+	if code != 0 {
+		return "", fmt.Errorf(resultLog)
+	}
+	return resultLog, nil
+}
+
+// SubmitTxAsync submits a write TX without waiting for block inclusion.
+func (s *Server) SubmitTxAsync(ctx context.Context, txType chain.TxType, payload any) error {
+	actor := txActorFromCtx(ctx)
+	if s.chainClient != nil {
+		env, err := chain.BuildEnvelope(txType, payload, actor)
+		if err != nil {
+			return err
+		}
+		txBytes, err := chain.MarshalEnvelope(env)
+		if err != nil {
+			return err
+		}
+		return s.chainClient.BroadcastTxSyncRaw(ctx, txBytes)
+	}
+	// fallback
+	env, err := chain.BuildEnvelope(txType, payload, actor)
+	if err != nil {
+		return err
+	}
+	code, resultLog := chain.Execute(s.db, env)
+	if code != 0 {
+		return fmt.Errorf(resultLog)
+	}
+	return nil
 }
 
 // ── admin.Deps implementation ────────────────────────────────────────────────

--- a/services/vaultcenter/internal/api/hkm/handler.go
+++ b/services/vaultcenter/internal/api/hkm/handler.go
@@ -1,9 +1,11 @@
 package hkm
 
 import (
+	"context"
 	"net/http"
 	"time"
 
+	"veilkey-vaultcenter/internal/chain"
 	"veilkey-vaultcenter/internal/db"
 )
 
@@ -36,6 +38,14 @@ type Deps interface {
 
 	// SaveAuditEvent records an audit event.
 	SaveAuditEvent(entityType, entityID, action, actorType, actorID, reason, source string, before, after map[string]any)
+
+	// SubmitTx submits a write TX and blocks until committed.
+	// Returns the result log (e.g. canonical ref) or error.
+	SubmitTx(ctx context.Context, txType chain.TxType, payload any) (string, error)
+
+	// SubmitTxAsync submits a write TX without waiting for block inclusion.
+	// Used for high-frequency, loss-tolerant operations (heartbeat).
+	SubmitTxAsync(ctx context.Context, txType chain.TxType, payload any) error
 }
 
 // Handler owns all HKM HTTP handlers.

--- a/services/vaultcenter/internal/api/tx_context.go
+++ b/services/vaultcenter/internal/api/tx_context.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"veilkey-vaultcenter/internal/chain"
+)
+
+type txActorCtxKey struct{}
+
+// TxActorMiddleware extracts actor info from HTTP requests and stores it in context.
+// SubmitTx reads it back to stamp onto TxEnvelope.
+func TxActorMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actor := chain.TxActor{
+			ActorType: "api",
+			ActorID:   actorIDForRequest(r),
+			Source:    r.Method + " " + r.URL.Path,
+		}
+		ctx := context.WithValue(r.Context(), txActorCtxKey{}, actor)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// txActorFromCtx retrieves TxActor from context. Returns empty actor if not set.
+func txActorFromCtx(ctx context.Context) chain.TxActor {
+	if actor, ok := ctx.Value(txActorCtxKey{}).(chain.TxActor); ok {
+		return actor
+	}
+	return chain.TxActor{ActorType: "system"}
+}
+
+// chainErrorToHTTP translates chain result codes to HTTP status codes.
+func chainErrorToHTTP(resultLog string, err error) (int, string) {
+	if err != nil {
+		return http.StatusInternalServerError, err.Error()
+	}
+	return http.StatusOK, resultLog
+}

--- a/services/vaultcenter/internal/chain/client.go
+++ b/services/vaultcenter/internal/chain/client.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	rpclocal "github.com/cometbft/cometbft/rpc/client/local"
 	nm "github.com/cometbft/cometbft/node"
+	rpclocal "github.com/cometbft/cometbft/rpc/client/local"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
 // Client wraps the CometBFT local RPC client for TX submission.
@@ -40,6 +41,28 @@ func (c *Client) BroadcastTxCommit(ctx context.Context, txType TxType, payload a
 
 	// Then FinalizeBlock result
 	return result.TxResult.Code, result.TxResult.Log, nil
+}
+
+// BroadcastTxCommitRaw submits pre-encoded TX bytes and waits for block inclusion.
+// Returns the raw result for the caller to inspect codes.
+func (c *Client) BroadcastTxCommitRaw(ctx context.Context, txBytes []byte) (*ctypes.ResultBroadcastTxCommit, error) {
+	result, err := c.local.BroadcastTxCommit(ctx, txBytes)
+	if err != nil {
+		return nil, fmt.Errorf("chain: broadcast commit: %w", err)
+	}
+	return result, nil
+}
+
+// BroadcastTxSyncRaw submits pre-encoded TX bytes and waits for CheckTx only.
+func (c *Client) BroadcastTxSyncRaw(ctx context.Context, txBytes []byte) error {
+	result, err := c.local.BroadcastTxSync(ctx, txBytes)
+	if err != nil {
+		return fmt.Errorf("chain: broadcast sync: %w", err)
+	}
+	if result.Code != 0 {
+		return fmt.Errorf("chain: check tx failed: %s", result.Log)
+	}
+	return nil
 }
 
 // BroadcastTxSync submits a TX and waits for CheckTx only (not block inclusion).


### PR DESCRIPTION
Closes #111

## Summary
- **Deps 확장**: `SubmitTx(ctx, txType, payload) (string, error)` + `SubmitTxAsync(ctx, txType, payload) error`
- **Server 구현**: `chainClient != nil` → BroadcastTxCommitRaw, `nil` → chain.Execute fallback
- **TxActor 미들웨어**: HTTP request에서 actor info 추출 → context → SubmitTx가 TxEnvelope에 스탬프
- **chainErrorToHTTP 헬퍼**: chain result → HTTP status 번역
- **client.go**: `BroadcastTxCommitRaw`/`BroadcastTxSyncRaw` 추가 (pre-encoded bytes)

## Flow
```
Handler → h.deps.SubmitTx(ctx, TxSaveTokenRef, payload)
  → Server.SubmitTx
    → txActorFromCtx(ctx) → actor info
    → BuildEnvelope(txType, payload, actor)
    → chain mode: MarshalEnvelope → BroadcastTxCommitRaw
    → fallback:   chain.Execute(db, env) directly
```

## Test plan
- [x] `go build ./...` 통과
- [ ] Step 3에서 와이어링 후 실제 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)