### PR TITLE
feat(chain): Step 3 — CometBFT node wiring

### DIFF
--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -517,7 +517,7 @@ func (s *Server) SetupRoutes() http.Handler {
 		mux.HandleFunc("POST /api/admin/tracked-refs/cleanup", s.requireReadyForOps(s.adminHandler.RequireAdminSession(s.hkmHandler.HandleTrackedRefCleanup)))
 	}
 
-	return logMiddleware(mux)
+	return logMiddleware(TxActorMiddleware(mux))
 }
 
 func logMiddleware(next http.Handler) http.Handler {

--- a/services/vaultcenter/internal/commands/server.go
+++ b/services/vaultcenter/internal/commands/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"veilkey-vaultcenter/internal/api"
+	"veilkey-vaultcenter/internal/chain"
 	"github.com/veilkey/veilkey-go-package/crypto"
 	"veilkey-vaultcenter/internal/db"
 )
@@ -82,6 +83,19 @@ func RunServer() {
 		log.Fatal("VEILKEY_PASSWORD env var is no longer supported (password exposed in process environment). Use VEILKEY_PASSWORD_FILE instead.")
 	} else {
 		log.Println("Server started in LOCKED mode. POST /api/unlock with password to unlock.")
+	}
+
+	// CometBFT chain node (optional — set VEILKEY_CHAIN_HOME to enable)
+	if chainHome := os.Getenv("VEILKEY_CHAIN_HOME"); chainHome != "" {
+		cometNode, chainErr := chain.StartNode(database, chainHome)
+		if chainErr != nil {
+			log.Fatalf("Failed to start chain node: %v", chainErr)
+		}
+		defer chain.StopNode(cometNode)
+		server.SetChainClient(chain.NewClient(cometNode))
+		log.Printf("CometBFT chain node started (home=%s)", chainHome)
+	} else {
+		log.Println("Chain disabled (VEILKEY_CHAIN_HOME not set, using DB direct mode)")
 	}
 
 	gcStop := make(chan struct{})


### PR DESCRIPTION
Closes #112

## Summary
- `commands/server.go`: `VEILKEY_CHAIN_HOME` 환경변수로 체인 활성화
- 설정 시: `chain.StartNode()` → `chain.NewClient()` → `server.SetChainClient()`
- 미설정 시: 체인 비활성화, DB direct mode (기존 동작)
- `SetupRoutes()`: `TxActorMiddleware` 추가 — 모든 요청에 actor context 주입
- graceful shutdown: `defer chain.StopNode()`

## Test plan
- [x] `go build ./...` 통과
- [ ] `VEILKEY_CHAIN_HOME=/tmp/vc-chain` 으로 서버 기동 테스트 (Step 4에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)