### PR TITLE
feat(chain): Step 4 — convert 3 core handlers to chain TX

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_agent_configs.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_configs.go
@@ -44,7 +44,7 @@ func (h *Handler) handleAgentConfigs(w http.ResponseWriter, r *http.Request) {
 						cfg["ref"] = makeRef(refFamilyVE, normScope, key)
 						cfg["scope"] = string(normScope)
 						cfg["status"] = string(normStatus)
-						_ = h.upsertTrackedRef(makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
+						_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
 					}
 				}
 			}

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_delete_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_delete_config.go
@@ -49,7 +49,7 @@ func (h *Handler) handleAgentDeleteConfig(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if resp.StatusCode == http.StatusOK && trackedRef != "" {
-		_ = h.deleteTrackedRef(trackedRef)
+		_ = h.deleteTrackedRef(r.Context(), trackedRef)
 		h.deps.SaveAuditEvent(
 			"config",
 			trackedRef,

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_delete_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_delete_secret.go
@@ -34,9 +34,9 @@ func (h *Handler) handleAgentDeleteSecret(w http.ResponseWriter, r *http.Request
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusOK && trackedRef != "" {
-		_ = h.deleteTrackedRef(trackedRef)
+		_ = h.deleteTrackedRef(r.Context(), trackedRef)
 		if metaRefParts := strings.Split(trackedRef, ":"); len(metaRefParts) == 3 {
-			_ = h.deleteTrackedRef(makeRef(refFamilyVK, refScopeTemp, metaRefParts[2]))
+			_ = h.deleteTrackedRef(r.Context(), makeRef(refFamilyVK, refScopeTemp, metaRefParts[2]))
 		}
 		h.deps.SaveAuditEvent(
 			"secret",

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_get_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_get_config.go
@@ -44,7 +44,7 @@ func (h *Handler) handleAgentGetConfig(w http.ResponseWriter, r *http.Request) {
 			data["status"] = string(normStatus)
 			data["vault"] = agent.Label
 			setRuntimeHashAliases(data, agent.AgentHash)
-			_ = h.upsertTrackedRef(makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
+			_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
 			if marshaled, marshalErr := json.Marshal(data); marshalErr == nil {
 				body = marshaled
 			}

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
@@ -41,7 +41,7 @@ func (h *Handler) handleAgentGetSecret(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	plaintextValue := ""
 	cipher, err := h.fetchAgentCiphertext(agentURL, meta.Ref)

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_heartbeat.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_heartbeat.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"veilkey-vaultcenter/internal/chain"
 	"veilkey-vaultcenter/internal/httputil"
 	"strings"
 	"time"
@@ -183,7 +184,18 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := h.deps.DB().UpsertAgent(nodeID, req.Label, req.VaultHash, req.VaultName, req.IP, req.Port, req.SecretsCount, req.ConfigsCount, req.Version, req.KeyVersion); err != nil {
+	if err := h.deps.SubmitTxAsync(r.Context(), chain.TxUpsertAgent, chain.UpsertAgentPayload{
+		NodeID:       nodeID,
+		Label:        req.Label,
+		VaultHash:    req.VaultHash,
+		VaultName:    req.VaultName,
+		IP:           req.IP,
+		Port:         req.Port,
+		SecretsCount: req.SecretsCount,
+		ConfigsCount: req.ConfigsCount,
+		Version:      req.Version,
+		KeyVersion:   req.KeyVersion,
+	}); err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to upsert agent: "+err.Error())
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_config.go
@@ -69,7 +69,7 @@ func (h *Handler) handleAgentSaveConfig(w http.ResponseWriter, r *http.Request) 
 			respData["status"] = string(normStatus)
 			respData["vault"] = agent.Label
 			setRuntimeHashAliases(respData, agent.AgentHash)
-			_ = h.upsertTrackedRef(makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
+			_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
 			h.deps.SaveAuditEvent(
 				"config",
 				makeRef(refFamilyVE, normScope, key),

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_configs_bulk.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_configs_bulk.go
@@ -56,7 +56,7 @@ func (h *Handler) handleAgentSaveConfigsBulk(w http.ResponseWriter, r *http.Requ
 	}
 	if resp.StatusCode == http.StatusOK {
 		for key := range reqData.Configs {
-			_ = h.upsertTrackedRef(makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
+			_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
 			h.deps.SaveAuditEvent(
 				"config",
 				makeRef(refFamilyVE, normScope, key),

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_secret.go
@@ -80,7 +80,7 @@ func (h *Handler) handleAgentSaveSecret(w http.ResponseWriter, r *http.Request) 
 			data["token"] = canonical
 			data["scope"] = string(normScope)
 			data["status"] = string(normStatus)
-			_ = h.upsertTrackedRefNamed(canonical, agent.KeyVersion, normStatus, agent.AgentHash, req.Name)
+			_ = h.upsertTrackedRefNamed(r.Context(), canonical, agent.KeyVersion, normStatus, agent.AgentHash, req.Name)
 			h.deps.SaveAuditEvent(
 				"secret",
 				canonical,

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_secrets.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_secrets.go
@@ -66,7 +66,7 @@ func (h *Handler) handleAgentSecrets(w http.ResponseWriter, r *http.Request) {
 						sec["token"] = makeRef(refFamilyVK, normScope, canonicalRef)
 						sec["scope"] = string(normScope)
 						sec["status"] = string(normStatus)
-						_ = h.upsertTrackedRef(makeRef(refFamilyVK, normScope, canonicalRef), agent.KeyVersion, normStatus, agent.AgentHash)
+						_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVK, normScope, canonicalRef), agent.KeyVersion, normStatus, agent.AgentHash)
 					}
 				}
 			}

--- a/services/vaultcenter/internal/api/hkm/hkm_ref_cleanup.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_ref_cleanup.go
@@ -112,7 +112,7 @@ func (h *Handler) handleTrackedRefCleanup(w http.ResponseWriter, r *http.Request
 			continue
 		}
 		for _, ref := range action.Delete {
-			if err := h.deleteTrackedRef(ref); err == nil {
+			if err := h.deleteTrackedRef(r.Context(), ref); err == nil {
 				resp.Counts["deleted"]++
 			}
 		}

--- a/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
@@ -1,8 +1,10 @@
 package hkm
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"veilkey-vaultcenter/internal/chain"
 	"veilkey-vaultcenter/internal/httputil"
 	"strings"
 	"veilkey-vaultcenter/internal/db"
@@ -16,11 +18,11 @@ func normalizeScopeStatus(family string, scope db.RefScope, status db.RefStatus,
 	return db.NormalizeScopeStatus(family, scope, status, fallbackScope)
 }
 
-func (h *Handler) upsertTrackedRef(ref string, version int, status db.RefStatus, agentHash string) error {
-	return h.upsertTrackedRefNamed(ref, version, status, agentHash, "")
+func (h *Handler) upsertTrackedRef(ctx context.Context, ref string, version int, status db.RefStatus, agentHash string) error {
+	return h.upsertTrackedRefNamed(ctx, ref, version, status, agentHash, "")
 }
 
-func (h *Handler) upsertTrackedRefNamed(ref string, version int, status db.RefStatus, agentHash string, secretName string) error {
+func (h *Handler) upsertTrackedRefNamed(ctx context.Context, ref string, version int, status db.RefStatus, agentHash string, secretName string) error {
 	parts, err := parseCanonicalRef(ref)
 	if err != nil {
 		return err
@@ -37,9 +39,17 @@ func (h *Handler) upsertTrackedRefNamed(ref string, version int, status db.RefSt
 		if existing.AgentHash != "" && agentHash != "" && existing.AgentHash != agentHash {
 			return fmt.Errorf("ref %s belongs to different agent", ref)
 		}
-		return h.deps.DB().UpdateRefWithName(ref, ref, version, status, secretName)
 	}
-	return h.deps.DB().SaveRefWithName(parts, ref, version, status, agentHash, secretName)
+	_, err = h.deps.SubmitTx(ctx, chain.TxSaveTokenRef, chain.SaveTokenRefPayload{
+		RefFamily:  parts.Family,
+		RefScope:   parts.Scope,
+		RefID:      parts.ID,
+		SecretName: secretName,
+		AgentHash:  agentHash,
+		Version:    version,
+		Status:     status,
+	})
+	return err
 }
 
 func (h *Handler) resolveTrackedRefVersion(ref string, previousRef string, version int) int {
@@ -57,9 +67,9 @@ func (h *Handler) resolveTrackedRefVersion(ref string, previousRef string, versi
 	return 1
 }
 
-func (h *Handler) syncTrackedRef(ref string, previousRef string, version int, status db.RefStatus, agentHash string) error {
+func (h *Handler) syncTrackedRef(ctx context.Context, ref string, previousRef string, version int, status db.RefStatus, agentHash string) error {
 	resolvedVersion := h.resolveTrackedRefVersion(ref, previousRef, version)
-	if err := h.upsertTrackedRef(ref, resolvedVersion, status, agentHash); err != nil {
+	if err := h.upsertTrackedRef(ctx, ref, resolvedVersion, status, agentHash); err != nil {
 		return err
 	}
 	if previousRef != "" && previousRef != ref {
@@ -90,7 +100,7 @@ func (h *Handler) syncTrackedRef(ref string, previousRef string, version int, st
 		if err == nil && previous.AgentHash != "" && agentHash != "" && previous.AgentHash != agentHash {
 			return fmt.Errorf("previous ref %s belongs to different agent", previousRef)
 		}
-		if err := h.deleteTrackedRef(previousRef); err != nil {
+		if err := h.deleteTrackedRef(ctx, previousRef); err != nil {
 			return err
 		}
 		h.deps.SaveAuditEvent(
@@ -112,11 +122,14 @@ func (h *Handler) syncTrackedRef(ref string, previousRef string, version int, st
 	return nil
 }
 
-func (h *Handler) deleteTrackedRef(ref string) error {
+func (h *Handler) deleteTrackedRef(ctx context.Context, ref string) error {
 	if _, err := h.deps.DB().GetRef(ref); err != nil {
 		return err
 	}
-	return h.deps.DB().DeleteRef(ref)
+	_, err := h.deps.SubmitTx(ctx, chain.TxDeleteTokenRef, chain.DeleteTokenRefPayload{
+		RefCanonical: ref,
+	})
+	return err
 }
 
 // NormalizeScopeStatus is the exported wrapper for normalizeScopeStatus,
@@ -127,14 +140,14 @@ func NormalizeScopeStatus(family string, scope db.RefScope, status db.RefStatus,
 
 // UpsertTrackedRef is the exported wrapper for upsertTrackedRef,
 // used by the api package for local config ref tracking.
-func (h *Handler) UpsertTrackedRef(ref string, version int, status db.RefStatus, agentHash string) error {
-	return h.upsertTrackedRef(ref, version, status, agentHash)
+func (h *Handler) UpsertTrackedRef(ctx context.Context, ref string, version int, status db.RefStatus, agentHash string) error {
+	return h.upsertTrackedRef(ctx, ref, version, status, agentHash)
 }
 
 // DeleteTrackedRef is the exported wrapper for deleteTrackedRef,
 // used by the api package for local config ref tracking.
-func (h *Handler) DeleteTrackedRef(ref string) error {
-	return h.deleteTrackedRef(ref)
+func (h *Handler) DeleteTrackedRef(ctx context.Context, ref string) error {
+	return h.deleteTrackedRef(ctx, ref)
 }
 
 func (h *Handler) handleTrackedRefSync(w http.ResponseWriter, r *http.Request) {
@@ -196,7 +209,7 @@ func (h *Handler) handleTrackedRefSync(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := h.syncTrackedRef(req.Ref, req.PreviousRef, req.Version, resolvedStatus, agent.AgentHash); err != nil {
+	if err := h.syncTrackedRef(r.Context(), req.Ref, req.PreviousRef, req.Version, resolvedStatus, agent.AgentHash); err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to sync tracked ref: "+err.Error())
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_register.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_register.go
@@ -3,11 +3,11 @@ package hkm
 import (
 	"log"
 	"net/http"
+	"veilkey-vaultcenter/internal/chain"
 	"veilkey-vaultcenter/internal/httputil"
 	"net/url"
 	"strings"
 	"github.com/veilkey/veilkey-go-package/crypto"
-	"veilkey-vaultcenter/internal/db"
 )
 
 // handleRegister registers a new child node and issues a DEK
@@ -64,15 +64,14 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	child := &db.Child{
+	if _, err := h.deps.SubmitTx(r.Context(), chain.TxRegisterChild, chain.RegisterChildPayload{
 		NodeID:       nodeID,
 		Label:        req.Label,
 		URL:          req.URL,
 		EncryptedDEK: encryptedChildDEK,
 		Nonce:        childNonce,
 		Version:      1,
-	}
-	if err := h.deps.DB().RegisterChild(child); err != nil {
+	}); err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to register child: "+err.Error())
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_vault_keys.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_vault_keys.go
@@ -2,6 +2,7 @@ package hkm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -392,7 +393,7 @@ func (h *Handler) handleVaultKeyMeta(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	resp := map[string]any{
 		"name":               name,
@@ -437,7 +438,7 @@ func (h *Handler) handleVaultKeyUsage(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	limit, offset, errMsg := httputil.ParseListWindow(r)
 	if errMsg != "" {
@@ -493,7 +494,7 @@ func (h *Handler) handleVaultKeyBindings(w http.ResponseWriter, r *http.Request)
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	limit, offset, errMsg := httputil.ParseListWindow(r)
 	if errMsg != "" {
@@ -548,7 +549,7 @@ func (h *Handler) handleVaultKeyBindingSave(w http.ResponseWriter, r *http.Reque
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	var raw map[string]json.RawMessage
 	if err := httputil.DecodeJSON(r, &raw); err != nil {
@@ -624,7 +625,7 @@ func (h *Handler) handleVaultKeyBindingSave(w http.ResponseWriter, r *http.Reque
 func (h *Handler) handleVaultKeyBindingsReplace(w http.ResponseWriter, r *http.Request) {
 	hashOrLabel := r.PathValue("vault")
 	name := r.PathValue("name")
-	agent, meta, ok := h.lookupVaultKeyForBindingWrite(w, hashOrLabel, name)
+	agent, meta, ok := h.lookupVaultKeyForBindingWrite(r.Context(), w, hashOrLabel, name)
 	if !ok {
 		return
 	}
@@ -703,7 +704,7 @@ func (h *Handler) handleVaultKeyBindingsReplace(w http.ResponseWriter, r *http.R
 func (h *Handler) handleVaultKeyBindingsDeleteAll(w http.ResponseWriter, r *http.Request) {
 	hashOrLabel := r.PathValue("vault")
 	name := r.PathValue("name")
-	agent, meta, ok := h.lookupVaultKeyForBindingWrite(w, hashOrLabel, name)
+	agent, meta, ok := h.lookupVaultKeyForBindingWrite(r.Context(), w, hashOrLabel, name)
 	if !ok {
 		return
 	}
@@ -755,7 +756,7 @@ func (h *Handler) handleVaultKeyAudit(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	limit, offset, errMsg := httputil.ParseListWindow(r)
 	if errMsg != "" {
@@ -837,7 +838,7 @@ func (h *Handler) handleVaultKeyBindingDelete(w http.ResponseWriter, r *http.Req
 	})
 }
 
-func (h *Handler) lookupVaultKeyForBindingWrite(w http.ResponseWriter, hashOrLabel, name string) (*agentInfo, *agentSecretMeta, bool) {
+func (h *Handler) lookupVaultKeyForBindingWrite(ctx context.Context, w http.ResponseWriter, hashOrLabel, name string) (*agentInfo, *agentSecretMeta, bool) {
 	agent, err := h.findAgent(hashOrLabel)
 	if err != nil {
 		h.respondAgentLookupError(w, err)
@@ -862,7 +863,7 @@ func (h *Handler) lookupVaultKeyForBindingWrite(w http.ResponseWriter, hashOrLab
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return nil, nil, false
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(ctx, meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 	return agent, meta, true
 }
 
@@ -895,7 +896,7 @@ func (h *Handler) handleVaultPatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleVaultKeyMetaPatch(w http.ResponseWriter, r *http.Request) {
-	_, meta, ok := h.lookupVaultKeyForBindingWrite(w, r.PathValue("vault"), r.PathValue("name"))
+	_, meta, ok := h.lookupVaultKeyForBindingWrite(r.Context(), w, r.PathValue("vault"), r.PathValue("name"))
 	if !ok {
 		return
 	}
@@ -931,7 +932,7 @@ func (h *Handler) handleVaultKeyMetaPatch(w http.ResponseWriter, r *http.Request
 }
 
 func (h *Handler) handleVaultKeySummary(w http.ResponseWriter, r *http.Request) {
-	agent, meta, ok := h.lookupVaultKeyForBindingWrite(w, r.PathValue("vault"), r.PathValue("name"))
+	agent, meta, ok := h.lookupVaultKeyForBindingWrite(r.Context(), w, r.PathValue("vault"), r.PathValue("name"))
 	if !ok {
 		return
 	}
@@ -1053,7 +1054,7 @@ func (h *Handler) handleVaultKeyFields(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
 		return
 	}
-	_ = h.upsertTrackedRef(meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
+	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	respondJSON(w, http.StatusOK, map[string]any{
 		"name":               name,

--- a/services/vaultcenter/internal/api/local_configs.go
+++ b/services/vaultcenter/internal/api/local_configs.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -46,7 +47,7 @@ func (s *Server) handleListConfigs(w http.ResponseWriter, r *http.Request) {
 			Scope:  string(normScope),
 			Status: string(normStatus),
 		})
-		_ = s.upsertTrackedRef(ref, 1, normStatus, "")
+		_ = s.upsertTrackedRef(r.Context(), ref, 1, normStatus, "")
 	}
 
 	s.respondJSON(w, http.StatusOK, map[string]any{
@@ -74,7 +75,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ref := db.MakeRef(db.RefFamilyVE, normScope, config.Key)
-	_ = s.upsertTrackedRef(ref, 1, normStatus, "")
+	_ = s.upsertTrackedRef(r.Context(), ref, 1, normStatus, "")
 
 	s.respondJSON(w, http.StatusOK, map[string]any{
 		"key":    config.Key,
@@ -123,7 +124,7 @@ func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ref := db.MakeRef(db.RefFamilyVE, db.RefScopeLocal, req.Key)
-	_ = s.upsertTrackedRef(ref, 1, db.RefStatusActive, "")
+	_ = s.upsertTrackedRef(r.Context(), ref, 1, db.RefStatusActive, "")
 	s.saveAuditEvent(
 		"config",
 		ref,
@@ -178,7 +179,7 @@ func (s *Server) handleSaveConfigsBulk(w http.ResponseWriter, r *http.Request) {
 
 	for key, value := range req.Configs {
 		ref := db.MakeRef(db.RefFamilyVE, db.RefScopeLocal, key)
-		_ = s.upsertTrackedRef(ref, 1, db.RefStatusActive, "")
+		_ = s.upsertTrackedRef(r.Context(), ref, 1, db.RefStatusActive, "")
 		s.saveAuditEvent(
 			"config",
 			ref,
@@ -226,7 +227,7 @@ func (s *Server) handleDeleteConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ref := db.MakeRef(db.RefFamilyVE, db.RefScopeLocal, key)
-	_ = s.deleteTrackedRef(ref)
+	_ = s.deleteTrackedRef(r.Context(), ref)
 	s.saveAuditEvent(
 		"config",
 		ref,
@@ -253,9 +254,9 @@ func normalizeScopeStatus(family string, scope db.RefScope, status db.RefStatus,
 }
 
 // upsertTrackedRef upserts a tracked ref directly via the DB.
-func (s *Server) upsertTrackedRef(ref string, version int, status db.RefStatus, agentHash string) error {
+func (s *Server) upsertTrackedRef(ctx context.Context, ref string, version int, status db.RefStatus, agentHash string) error {
 	if s.hkmHandler != nil {
-		return s.hkmHandler.UpsertTrackedRef(ref, version, status, agentHash)
+		return s.hkmHandler.UpsertTrackedRef(ctx, ref, version, status, agentHash)
 	}
 	// Minimal inline fallback for non-HKM nodes.
 	parts, err := db.ParseCanonicalRef(ref)
@@ -272,9 +273,9 @@ func (s *Server) upsertTrackedRef(ref string, version int, status db.RefStatus, 
 }
 
 // deleteTrackedRef removes a tracked ref directly via the DB.
-func (s *Server) deleteTrackedRef(ref string) error {
+func (s *Server) deleteTrackedRef(ctx context.Context, ref string) error {
 	if s.hkmHandler != nil {
-		return s.hkmHandler.DeleteTrackedRef(ref)
+		return s.hkmHandler.DeleteTrackedRef(ctx, ref)
 	}
 	if _, err := s.db.GetRef(ref); err != nil {
 		return err


### PR DESCRIPTION
Closes #113

## Summary
- **handleTrackedRefSync**: upsertTrackedRef/deleteTrackedRef → chain TX
- **handleRegister**: RegisterChild → chain TX
- **handleAgentHeartbeat**: UpsertAgent → chain TX (async)
- ctx parameter propagated through 12+ caller files

## Test plan
- [x] `go build ./...` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)