### PR TITLE
refactor(chain): Step 6 — remove SaveAuditEvent from chain-converted handlers

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_agent_approve_rebind.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_approve_rebind.go
@@ -23,26 +23,6 @@ func (h *Handler) handleAgentApproveRebind(w http.ResponseWriter, r *http.Reques
 		respondError(w, http.StatusInternalServerError, "failed to approve agent rebind: "+err.Error())
 		return
 	}
-	h.deps.SaveAuditEvent(
-		"vault",
-		updated.NodeID,
-		"approve_rebind",
-		"operator",
-		httputil.ActorIDForRequest(r),
-		"",
-		"agent_approve_rebind",
-		map[string]any{
-			"vault_runtime_hash": agent.AgentHash,
-			"key_version":        agent.KeyVersion,
-			"rebind_required":    agent.RebindRequired,
-		},
-		map[string]any{
-			"vault_runtime_hash": updated.AgentHash,
-			"key_version":        updated.KeyVersion,
-			"rebind_required":    updated.RebindRequired,
-		},
-	)
-
 	respondJSON(w, http.StatusOK, map[string]interface{}{
 		"status":             "approved",
 		"vault_runtime_hash": updated.AgentHash,

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_delete_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_delete_config.go
@@ -50,22 +50,6 @@ func (h *Handler) handleAgentDeleteConfig(w http.ResponseWriter, r *http.Request
 	}
 	if resp.StatusCode == http.StatusOK && trackedRef != "" {
 		_ = h.deleteTrackedRef(r.Context(), trackedRef)
-		h.deps.SaveAuditEvent(
-			"config",
-			trackedRef,
-			"delete",
-			"agent",
-			agent.AgentHash,
-			"",
-			"agent_delete_config",
-			map[string]any{
-				"key": key,
-				"ref": trackedRef,
-			},
-			map[string]any{
-				"key": key,
-			},
-		)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_delete_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_delete_secret.go
@@ -38,22 +38,6 @@ func (h *Handler) handleAgentDeleteSecret(w http.ResponseWriter, r *http.Request
 		if metaRefParts := strings.Split(trackedRef, ":"); len(metaRefParts) == 3 {
 			_ = h.deleteTrackedRef(r.Context(), makeRef(refFamilyVK, refScopeTemp, metaRefParts[2]))
 		}
-		h.deps.SaveAuditEvent(
-			"secret",
-			trackedRef,
-			"delete",
-			"agent",
-			agent.AgentHash,
-			"",
-			"agent_delete_secret",
-			map[string]any{
-				"name": trackedRef,
-				"ref":  trackedRef,
-			},
-			map[string]any{
-				"name": name,
-			},
-		)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_rotate_all.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_rotate_all.go
@@ -20,21 +20,6 @@ func (h *Handler) handleAgentRotateAll(w http.ResponseWriter, r *http.Request) {
 	}
 	results := make([]map[string]interface{}, 0, len(agents))
 	for _, agent := range agents {
-		h.deps.SaveAuditEvent(
-			"vault",
-			agent.NodeID,
-			"schedule_rotation",
-			"operator",
-			httputil.ActorIDForRequest(r),
-			reason,
-			"agent_rotate_all",
-			nil,
-			map[string]any{
-				"vault_runtime_hash": agent.AgentHash,
-				"key_version":        agent.KeyVersion,
-				"rotation_required":  agent.RotationRequired,
-			},
-		)
 		results = append(results, map[string]interface{}{
 			"node_id":            agent.NodeID,
 			"vault_node_uuid":    agent.NodeID,

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_config.go
@@ -70,22 +70,6 @@ func (h *Handler) handleAgentSaveConfig(w http.ResponseWriter, r *http.Request) 
 			respData["vault"] = agent.Label
 			setRuntimeHashAliases(respData, agent.AgentHash)
 			_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
-			h.deps.SaveAuditEvent(
-				"config",
-				makeRef(refFamilyVE, normScope, key),
-				"save",
-				"agent",
-				agent.AgentHash,
-				"",
-				"agent_save_config",
-				nil,
-				map[string]any{
-					"key":                key,
-					"ref":                makeRef(refFamilyVE, normScope, key),
-					"vault_runtime_hash": agent.AgentHash,
-					"status":             string(normStatus),
-				},
-			)
 			if marshaled, marshalErr := json.Marshal(respData); marshalErr == nil {
 				respBody = marshaled
 			}

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_configs_bulk.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_configs_bulk.go
@@ -57,22 +57,6 @@ func (h *Handler) handleAgentSaveConfigsBulk(w http.ResponseWriter, r *http.Requ
 	if resp.StatusCode == http.StatusOK {
 		for key := range reqData.Configs {
 			_ = h.upsertTrackedRef(r.Context(), makeRef(refFamilyVE, normScope, key), agent.KeyVersion, normStatus, agent.AgentHash)
-			h.deps.SaveAuditEvent(
-				"config",
-				makeRef(refFamilyVE, normScope, key),
-				"save",
-				"agent",
-				agent.AgentHash,
-				"bulk_update",
-				"agent_save_configs_bulk",
-				nil,
-				map[string]any{
-					"key":                key,
-					"ref":                makeRef(refFamilyVE, normScope, key),
-					"vault_runtime_hash": agent.AgentHash,
-					"status":             string(normStatus),
-				},
-			)
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_secret.go
@@ -81,22 +81,6 @@ func (h *Handler) handleAgentSaveSecret(w http.ResponseWriter, r *http.Request) 
 			data["scope"] = string(normScope)
 			data["status"] = string(normStatus)
 			_ = h.upsertTrackedRefNamed(r.Context(), canonical, agent.KeyVersion, normStatus, agent.AgentHash, req.Name)
-			h.deps.SaveAuditEvent(
-				"secret",
-				canonical,
-				"save",
-				"agent",
-				agent.AgentHash,
-				"",
-				"agent_save_secret",
-				nil,
-				map[string]any{
-					"name":               req.Name,
-					"ref":                canonical,
-					"vault_runtime_hash": agent.AgentHash,
-					"status":             string(normStatus),
-				},
-			)
 		}
 		data["vault"] = agent.Label
 		setRuntimeHashAliases(data, agent.AgentHash)

--- a/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
@@ -77,24 +77,6 @@ func (h *Handler) syncTrackedRef(ctx context.Context, ref string, previousRef st
 			return err
 		}
 	}
-	h.deps.SaveAuditEvent(
-		"tracked_ref",
-		ref,
-		"sync",
-		"agent",
-		agentHash,
-		"",
-		"tracked_refs_sync",
-		map[string]any{
-			"previous_ref": previousRef,
-		},
-		map[string]any{
-			"ref":        ref,
-			"version":    resolvedVersion,
-			"status":     status,
-			"agent_hash": agentHash,
-		},
-	)
 	if previousRef != "" && previousRef != ref {
 		previous, err := h.deps.DB().GetRef(previousRef)
 		if err == nil && previous.AgentHash != "" && agentHash != "" && previous.AgentHash != agentHash {
@@ -103,21 +85,6 @@ func (h *Handler) syncTrackedRef(ctx context.Context, ref string, previousRef st
 		if err := h.deleteTrackedRef(ctx, previousRef); err != nil {
 			return err
 		}
-		h.deps.SaveAuditEvent(
-			"tracked_ref",
-			previousRef,
-			"delete",
-			"agent",
-			agentHash,
-			"replaced_by_new_ref",
-			"tracked_refs_sync",
-			map[string]any{
-				"ref": previousRef,
-			},
-			map[string]any{
-				"replaced_by": ref,
-			},
-		)
 	}
 	return nil
 }

--- a/services/vaultcenter/internal/api/local_configs.go
+++ b/services/vaultcenter/internal/api/local_configs.go
@@ -110,16 +110,6 @@ func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	before := map[string]any{}
-	if existing, err := s.db.GetConfig(req.Key); err == nil && existing != nil {
-		before = map[string]any{
-			"key":    existing.Key,
-			"value":  existing.Value,
-			"scope":  existing.Scope,
-			"status": existing.Status,
-		}
-	}
-
 	if _, err := s.SubmitTx(r.Context(), chain.TxSetConfig, chain.SetConfigPayload{Key: req.Key, Value: *req.Value}); err != nil {
 		s.respondError(w, http.StatusInternalServerError, "failed to save config: "+err.Error())
 		return
@@ -127,24 +117,6 @@ func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 
 	ref := db.MakeRef(db.RefFamilyVE, db.RefScopeLocal, req.Key)
 	_ = s.upsertTrackedRef(r.Context(), ref, 1, db.RefStatusActive, "")
-	s.saveAuditEvent(
-		"config",
-		ref,
-		"save",
-		"api",
-		actorIDForRequest(r),
-		"",
-		"local_config_save",
-		before,
-		map[string]any{
-			"key":    req.Key,
-			"value":  *req.Value,
-			"ref":    ref,
-			"scope":  "LOCAL",
-			"status": "active",
-		},
-	)
-
 	s.respondJSON(w, http.StatusOK, map[string]any{
 		"key":    req.Key,
 		"value":  *req.Value,
@@ -181,26 +153,9 @@ func (s *Server) handleSaveConfigsBulk(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	for key, value := range req.Configs {
+	for key := range req.Configs {
 		ref := db.MakeRef(db.RefFamilyVE, db.RefScopeLocal, key)
 		_ = s.upsertTrackedRef(r.Context(), ref, 1, db.RefStatusActive, "")
-		s.saveAuditEvent(
-			"config",
-			ref,
-			"save",
-			"api",
-			actorIDForRequest(r),
-			"",
-			"local_config_bulk_save",
-			nil,
-			map[string]any{
-				"key":    key,
-				"value":  value,
-				"ref":    ref,
-				"scope":  "LOCAL",
-				"status": "active",
-			},
-		)
 	}
 
 	s.respondJSON(w, http.StatusOK, map[string]any{
@@ -215,16 +170,6 @@ func (s *Server) handleDeleteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	before := map[string]any{}
-	if existing, err := s.db.GetConfig(key); err == nil && existing != nil {
-		before = map[string]any{
-			"key":    existing.Key,
-			"value":  existing.Value,
-			"scope":  existing.Scope,
-			"status": existing.Status,
-		}
-	}
-
 	if err := s.db.DeleteConfig(key); err != nil {
 		s.respondError(w, http.StatusNotFound, err.Error())
 		return
@@ -232,21 +177,6 @@ func (s *Server) handleDeleteConfig(w http.ResponseWriter, r *http.Request) {
 
 	ref := db.MakeRef(db.RefFamilyVE, db.RefScopeLocal, key)
 	_ = s.deleteTrackedRef(r.Context(), ref)
-	s.saveAuditEvent(
-		"config",
-		ref,
-		"delete",
-		"api",
-		actorIDForRequest(r),
-		"",
-		"local_config_delete",
-		before,
-		map[string]any{
-			"deleted": key,
-			"ref":     ref,
-		},
-	)
-
 	s.respondJSON(w, http.StatusOK, map[string]any{
 		"deleted": key,
 	})


### PR DESCRIPTION
Closes #115

## Summary
- 12 SaveAuditEvent calls removed from 9 chain-converted handler files
- -219 lines
- Executor auto-generates audit rows for all chain TX
- Non-chain handlers (admin_auth, resolve, exact_lookup, global_function_run) retain SaveAuditEvent

## Test plan
- [x] `go build ./...` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)