### PR TITLE
fix(chain): add chain wiring to cmd/main.go

### DIFF
--- a/services/vaultcenter/cmd/main.go
+++ b/services/vaultcenter/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"veilkey-vaultcenter/internal/api"
+	"veilkey-vaultcenter/internal/chain"
 	"veilkey-vaultcenter/internal/commands"
 	"github.com/veilkey/veilkey-go-package/cmdutil"
 	"github.com/veilkey/veilkey-go-package/crypto"
@@ -105,6 +106,19 @@ func runServer() {
 		log.Fatal("VEILKEY_PASSWORD env var is no longer supported (password exposed in process environment). Use VEILKEY_PASSWORD_FILE instead.")
 	} else {
 		log.Println("Server started in LOCKED mode. POST /api/unlock with password to unlock.")
+	}
+
+	// CometBFT chain node (optional — set VEILKEY_CHAIN_HOME to enable)
+	if chainHome := os.Getenv("VEILKEY_CHAIN_HOME"); chainHome != "" {
+		cometNode, chainErr := chain.StartNode(database, chainHome)
+		if chainErr != nil {
+			log.Fatalf("Failed to start chain node: %v", chainErr)
+		}
+		defer chain.StopNode(cometNode)
+		server.SetChainClient(chain.NewClient(cometNode))
+		log.Printf("CometBFT chain node started (home=%s)", chainHome)
+	} else {
+		log.Println("Chain disabled (VEILKEY_CHAIN_HOME not set, using DB direct mode)")
 	}
 
 	gcStop := make(chan struct{})


### PR DESCRIPTION
cmd/main.go runServer()에도 VEILKEY_CHAIN_HOME 체인 와이어링 추가 (commands/server.go와 동일).\n\nE2E 테스트 통과: chain TX → executor → DB cache + auto audit 동작 확인.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)