### PR TITLE
security(chain): remove DEK/key material from chain TX payloads

### DIFF
--- a/services/localvault/go.mod
+++ b/services/localvault/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.33
-	github.com/veilkey/veilkey-chain v0.1.0
+	github.com/veilkey/veilkey-chain v0.2.0
 	github.com/veilkey/veilkey-go-package v0.3.1
 	golang.org/x/crypto v0.49.0
 	gorm.io/driver/sqlite v1.6.0

--- a/services/localvault/go.sum
+++ b/services/localvault/go.sum
@@ -172,6 +172,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/veilkey/veilkey-chain v0.1.0 h1:20uRnqhtYb2i10SQlF4omJSl9G+aO6wKixhFFqVSou0=
 github.com/veilkey/veilkey-chain v0.1.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.2.0 h1:tU2pfn5h+RYa9LXHZJgjNnuC5p9Kz57dy+EFUflzFnQ=
+github.com/veilkey/veilkey-chain v0.2.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.3.0 h1:BvGydDA3pQsHEEBw/FzmVw2Nhk8OqGZzjA7CgH3Xd2g=
 github.com/veilkey/veilkey-go-package v0.3.0/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=

--- a/services/localvault/internal/db/chain_store.go
+++ b/services/localvault/internal/db/chain_store.go
@@ -40,7 +40,7 @@ func (a *ChainStoreAdapter) UpsertAgent(_, _, _, _, _ string, _, _, _, _, _ int)
 	return nil
 }
 
-// RegisterChild is a no-op on localvault.
+// RegisterChild is a no-op on localvault (identity-only record, no DEK).
 func (a *ChainStoreAdapter) RegisterChild(_ *chain.ChildRecord) error {
 	return nil
 }

--- a/services/vaultcenter/go.mod
+++ b/services/vaultcenter/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
-	github.com/veilkey/veilkey-chain v0.1.0 // indirect
+	github.com/veilkey/veilkey-chain v0.2.0 // indirect
 	go.etcd.io/bbolt v1.4.0-alpha.0.0.20240404170359-43604f3112c5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/services/vaultcenter/go.sum
+++ b/services/vaultcenter/go.sum
@@ -230,6 +230,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/veilkey/veilkey-chain v0.1.0 h1:20uRnqhtYb2i10SQlF4omJSl9G+aO6wKixhFFqVSou0=
 github.com/veilkey/veilkey-chain v0.1.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.2.0 h1:tU2pfn5h+RYa9LXHZJgjNnuC5p9Kz57dy+EFUflzFnQ=
+github.com/veilkey/veilkey-chain v0.2.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=
 github.com/veilkey/veilkey-go-package v0.3.1/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=

--- a/services/vaultcenter/internal/api/hkm/hkm_register.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_register.go
@@ -64,15 +64,19 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Record child registration on chain (identity only — no key material)
 	if _, err := h.deps.SubmitTx(r.Context(), chain.TxRegisterChild, chain.RegisterChildPayload{
-		NodeID:       nodeID,
-		Label:        req.Label,
-		URL:          req.URL,
-		EncryptedDEK: encryptedChildDEK,
-		Nonce:        childNonce,
-		Version:      1,
+		NodeID:  nodeID,
+		Label:   req.Label,
+		URL:     req.URL,
+		Version: 1,
 	}); err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to register child: "+err.Error())
+		return
+	}
+	// DEK delivery via direct DB write (never on chain)
+	if err := h.deps.DB().UpdateChildDEK(nodeID, encryptedChildDEK, childNonce, 1); err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to save child DEK: "+err.Error())
 		return
 	}
 

--- a/services/vaultcenter/internal/db/chain_store.go
+++ b/services/vaultcenter/internal/db/chain_store.go
@@ -35,13 +35,12 @@ func (a *ChainStoreAdapter) UpsertAgent(nodeID, label, vaultHash, vaultName, ip 
 }
 
 func (a *ChainStoreAdapter) RegisterChild(child *chain.ChildRecord) error {
+	// Chain TX only records node identity — DEK delivery is out-of-band via REST.
 	return a.DB.RegisterChild(&Child{
-		NodeID:       child.NodeID,
-		Label:        child.Label,
-		URL:          child.URL,
-		EncryptedDEK: child.EncryptedDEK,
-		Nonce:        child.Nonce,
-		Version:      child.Version,
+		NodeID:  child.NodeID,
+		Label:   child.Label,
+		URL:     child.URL,
+		Version: child.Version,
 	})
 }
 


### PR DESCRIPTION
## 🔴 Security Fix

Chain blocks are visible to all full nodes. DEK/key material was included in
UpsertAgent and RegisterChild TX payloads — this would expose encrypted keys
to any node replicating the chain.

### Changes
- **veilkey-chain v0.2.0**: DEK/DEKNonce removed from UpsertAgentPayload,
  EncryptedDEK/Nonce removed from RegisterChildPayload and ChildRecord
- **hkm_register.go**: chain TX records identity only, DEK delivery via
  direct DB write (UpdateChildDEK) — never on chain
- **Commit error logging**: errors no longer silently ignored

### Principle
Key material (DEK, KEK, nonce) → DB direct write only
Identity/metadata (nodeID, label, URL, version) → chain TX

## Test plan
- [x] vaultcenter `go build ./...` 통과
- [x] localvault `go build ./...` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)