### PR TITLE
feat(chain): Phase 4 Step 5+6 — genesis sharing + localvault chain bootstrap

### DIFF
--- a/services/localvault/go.mod
+++ b/services/localvault/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.33
-	github.com/veilkey/veilkey-chain v0.3.0
+	github.com/veilkey/veilkey-chain v0.4.0
 	github.com/veilkey/veilkey-go-package v0.3.1
 	golang.org/x/crypto v0.49.0
 	gorm.io/driver/sqlite v1.6.0

--- a/services/localvault/go.sum
+++ b/services/localvault/go.sum
@@ -176,6 +176,8 @@ github.com/veilkey/veilkey-chain v0.2.0 h1:tU2pfn5h+RYa9LXHZJgjNnuC5p9Kz57dy+EFU
 github.com/veilkey/veilkey-chain v0.2.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-chain v0.3.0 h1:oP9tO4Or44r/YLqvU3nOyo/45rggPL7CPLpre+Zyb5s=
 github.com/veilkey/veilkey-chain v0.3.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.4.0 h1:rGqrQT8cf8b4iHlBBOgKAtQ1PHHxD3klMN6a++FhwLs=
+github.com/veilkey/veilkey-chain v0.4.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.3.0 h1:BvGydDA3pQsHEEBw/FzmVw2Nhk8OqGZzjA7CgH3Xd2g=
 github.com/veilkey/veilkey-go-package v0.3.0/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=

--- a/services/localvault/internal/commands/chain_genesis.go
+++ b/services/localvault/internal/commands/chain_genesis.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// fetchChainGenesis fetches genesis.json and persistent_peers from vaultcenter
+// and writes them to the chain home directory.
+func fetchChainGenesis(vaultcenterURL, chainHome string) {
+	url := strings.TrimRight(vaultcenterURL, "/") + "/api/chain/info"
+	log.Printf("Chain: fetching genesis from %s", url)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Printf("Chain: failed to fetch genesis: %v (will generate local genesis)", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Printf("Chain: vaultcenter returned %d for chain info (chain may not be enabled on vaultcenter)", resp.StatusCode)
+		return
+	}
+
+	var data struct {
+		Genesis         json.RawMessage `json:"genesis"`
+		PersistentPeers string          `json:"persistent_peers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		log.Printf("Chain: failed to decode chain info: %v", err)
+		return
+	}
+
+	if len(data.Genesis) == 0 {
+		log.Println("Chain: empty genesis from vaultcenter")
+		return
+	}
+
+	// Write genesis.json
+	configDir := filepath.Join(chainHome, "config")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		log.Printf("Chain: failed to create config dir: %v", err)
+		return
+	}
+	genesisFile := filepath.Join(configDir, "genesis.json")
+	if err := os.WriteFile(genesisFile, data.Genesis, 0600); err != nil {
+		log.Printf("Chain: failed to write genesis: %v", err)
+		return
+	}
+	log.Printf("Chain: genesis.json written to %s", genesisFile)
+
+	// Write persistent_peers to a config snippet for CometBFT
+	if data.PersistentPeers != "" {
+		peersFile := filepath.Join(configDir, "persistent_peers.txt")
+		_ = os.WriteFile(peersFile, []byte(data.PersistentPeers), 0600)
+		log.Printf("Chain: persistent_peers=%s", data.PersistentPeers)
+	}
+}

--- a/services/localvault/internal/commands/server.go
+++ b/services/localvault/internal/commands/server.go
@@ -36,21 +36,31 @@ func RunServer() {
 	}
 
 	server, addr, listenPort := mustLoadServer()
+	hubURL := server.LogResolvedVaultcenterURL("startup")
 
 	// CometBFT chain full node (optional — set VEILKEY_CHAIN_HOME to enable)
 	if chainHome := os.Getenv("VEILKEY_CHAIN_HOME"); chainHome != "" {
+		// Fetch genesis from vaultcenter if not already present
+		genesisFile := filepath.Join(chainHome, "config", "genesis.json")
+		if _, err := os.Stat(genesisFile); os.IsNotExist(err) {
+			if hubURL != "" {
+				fetchChainGenesis(hubURL, chainHome)
+			} else {
+				log.Println("Chain: no vaultcenter URL, skipping genesis fetch")
+			}
+		}
+
 		adapter := &db.ChainStoreAdapter{DB: server.DB()}
 		cometNode, chainErr := chain.StartNode(adapter, adapter, chainHome)
 		if chainErr != nil {
-			log.Fatalf("Failed to start chain node: %v", chainErr)
+			log.Printf("Failed to start chain node: %v (continuing without chain)", chainErr)
+		} else {
+			defer chain.StopNode(cometNode)
+			log.Printf("CometBFT full node started (home=%s)", chainHome)
 		}
-		defer chain.StopNode(cometNode)
-		log.Printf("CometBFT full node started (home=%s)", chainHome)
 	} else {
 		log.Println("Chain disabled (VEILKEY_CHAIN_HOME not set)")
 	}
-
-	hubURL := server.LogResolvedVaultcenterURL("startup")
 	hostname, _ := os.Hostname()
 	server.StartHeartbeat(hubURL, hostname, listenPort, 5*time.Minute)
 

--- a/services/vaultcenter/cmd/main.go
+++ b/services/vaultcenter/cmd/main.go
@@ -117,7 +117,9 @@ func runServer() {
 		}
 		defer chain.StopNode(cometNode)
 		server.SetChainClient(chain.NewClient(cometNode))
-		log.Printf("CometBFT chain node started (home=%s)", chainHome)
+		server.SetChainHome(chainHome)
+		server.SetChainNodeID(string(cometNode.NodeInfo().ID()))
+		log.Printf("CometBFT chain node started (home=%s, node=%s)", chainHome, cometNode.NodeInfo().ID())
 	} else {
 		log.Println("Chain disabled (VEILKEY_CHAIN_HOME not set, using DB direct mode)")
 	}

--- a/services/vaultcenter/go.mod
+++ b/services/vaultcenter/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
-	github.com/veilkey/veilkey-chain v0.3.0 // indirect
+	github.com/veilkey/veilkey-chain v0.4.0 // indirect
 	go.etcd.io/bbolt v1.4.0-alpha.0.0.20240404170359-43604f3112c5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/services/vaultcenter/go.sum
+++ b/services/vaultcenter/go.sum
@@ -234,6 +234,8 @@ github.com/veilkey/veilkey-chain v0.2.0 h1:tU2pfn5h+RYa9LXHZJgjNnuC5p9Kz57dy+EFU
 github.com/veilkey/veilkey-chain v0.2.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-chain v0.3.0 h1:oP9tO4Or44r/YLqvU3nOyo/45rggPL7CPLpre+Zyb5s=
 github.com/veilkey/veilkey-chain v0.3.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.4.0 h1:rGqrQT8cf8b4iHlBBOgKAtQ1PHHxD3klMN6a++FhwLs=
+github.com/veilkey/veilkey-chain v0.4.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=
 github.com/veilkey/veilkey-go-package v0.3.1/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -61,6 +62,8 @@ type Server struct {
 	httpClient     *http.Client
 	chainClient    *chain.Client
 	chainStore     chain.Store
+	chainHome      string
+	chainNodeID    string
 	bulkApplyDir   string
 	updateMu       sync.RWMutex
 	updateState    systemUpdateState
@@ -112,7 +115,30 @@ func (s *Server) SaveAuditEvent(entityType, entityID, action, actorType, actorID
 // ── chain TX submission ─────────────────────────────────────────────────────
 
 // SetChainClient sets the CometBFT chain client. nil disables chain mode (DB fallback).
-func (s *Server) SetChainClient(c *chain.Client) { s.chainClient = c }
+func (s *Server) SetChainClient(c *chain.Client)      { s.chainClient = c }
+func (s *Server) SetChainHome(home string)             { s.chainHome = home }
+func (s *Server) SetChainNodeID(nodeID string)         { s.chainNodeID = nodeID }
+
+// ChainInfo returns genesis JSON and persistent_peers for child nodes joining the chain.
+// Returns nil, "" if chain is not enabled.
+func (s *Server) ChainInfo() (genesisJSON []byte, persistentPeers string) {
+	if s.chainHome == "" {
+		return nil, ""
+	}
+	genesis, err := os.ReadFile(filepath.Join(s.chainHome, "config", "genesis.json"))
+	if err != nil {
+		return nil, ""
+	}
+	if s.chainNodeID != "" {
+		// peer format: nodeID@host:port — host is the vaultcenter's listen address
+		addr := strings.TrimSpace(os.Getenv("VEILKEY_CHAIN_P2P_ADDR"))
+		if addr == "" {
+			addr = "127.0.0.1:26656"
+		}
+		persistentPeers = s.chainNodeID + "@" + addr
+	}
+	return genesis, persistentPeers
+}
 
 // SubmitTx submits a write TX and blocks until committed.
 func (s *Server) SubmitTx(ctx context.Context, txType chain.TxType, payload any) (string, error) {
@@ -507,6 +533,7 @@ func (s *Server) SetupRoutes() http.Handler {
 
 	mux.HandleFunc("/health", s.Health)
 	mux.HandleFunc("/ready", s.Ready)
+	mux.HandleFunc("GET /api/chain/info", s.handleChainInfo)
 	mux.HandleFunc("POST /api/unlock", s.requireTrustedIP(s.unlockLimiter.Middleware(s.handleUnlock)))
 	s.approvalHandler.Register(mux, s.requireTrustedIP)
 	s.SetupAPIRoutes(mux)

--- a/services/vaultcenter/internal/api/handle_chain_info.go
+++ b/services/vaultcenter/internal/api/handle_chain_info.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"net/http"
+)
+
+// handleChainInfo returns genesis JSON and persistent_peers for child nodes
+// joining the CometBFT chain network.
+func (s *Server) handleChainInfo(w http.ResponseWriter, r *http.Request) {
+	genesis, peers := s.ChainInfo()
+	if genesis == nil {
+		s.respondError(w, http.StatusServiceUnavailable, "chain not enabled")
+		return
+	}
+
+	s.respondJSON(w, http.StatusOK, map[string]interface{}{
+		"genesis":          genesis,
+		"persistent_peers": peers,
+	})
+}

--- a/services/vaultcenter/internal/api/hkm/handler.go
+++ b/services/vaultcenter/internal/api/hkm/handler.go
@@ -46,6 +46,9 @@ type Deps interface {
 	// SubmitTxAsync submits a write TX without waiting for block inclusion.
 	// Used for high-frequency, loss-tolerant operations (heartbeat).
 	SubmitTxAsync(ctx context.Context, txType chain.TxType, payload any) error
+
+	// ChainInfo returns genesis JSON and persistent_peers for child nodes joining the chain.
+	ChainInfo() (genesisJSON []byte, persistentPeers string)
 }
 
 // Handler owns all HKM HTTP handlers.

--- a/services/vaultcenter/internal/api/hkm/hkm_register.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_register.go
@@ -82,8 +82,18 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Registered child node: %s (%s)", nodeID, req.Label)
 
-	respondJSON(w, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"dek":     childDEK,
 		"version": 1,
-	})
+	}
+
+	// Include chain genesis + peers if chain is enabled
+	if genesis, peers := h.deps.ChainInfo(); genesis != nil {
+		resp["chain_genesis"] = genesis
+		if peers != "" {
+			resp["chain_persistent_peers"] = peers
+		}
+	}
+
+	respondJSON(w, http.StatusOK, resp)
 }

--- a/services/vaultcenter/internal/commands/server.go
+++ b/services/vaultcenter/internal/commands/server.go
@@ -94,7 +94,9 @@ func RunServer() {
 		}
 		defer chain.StopNode(cometNode)
 		server.SetChainClient(chain.NewClient(cometNode))
-		log.Printf("CometBFT chain node started (home=%s)", chainHome)
+		server.SetChainHome(chainHome)
+		server.SetChainNodeID(string(cometNode.NodeInfo().ID()))
+		log.Printf("CometBFT chain node started (home=%s, node=%s)", chainHome, cometNode.NodeInfo().ID())
 	} else {
 		log.Println("Chain disabled (VEILKEY_CHAIN_HOME not set, using DB direct mode)")
 	}


### PR DESCRIPTION
Part of #124

## Summary
- **vaultcenter**: `GET /api/chain/info` endpoint, genesis + peers in register response
- **localvault**: auto-fetches genesis from vaultcenter before chain node start
- **veilkey-chain v0.4.0**: persistent_peers from env/file

Resolves 🔴 genesis sharing issue from review.

## Test plan
- [x] Both services build
- [ ] P2P connection test (Step 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)