### PR TITLE
security: remove plaintext password file auto-save

### DIFF
--- a/services/localvault/cmd/main.go
+++ b/services/localvault/cmd/main.go
@@ -238,15 +238,6 @@ func handleInstallInit(w http.ResponseWriter, r *http.Request, database *db.DB, 
 		log.Printf("install: vaultcenter URL saved: %s", normalized)
 	}
 
-	// Save password file BEFORE salt — salt existence signals "init complete"
-	passwordFile := filepath.Join(dataDir, "password")
-	if err := os.WriteFile(passwordFile, []byte(req.Password), 0600); err != nil {
-		log.Printf("install: failed to write password file: %v", err)
-		// non-fatal: server can still be unlocked manually
-	} else {
-		log.Printf("install: password file saved to %s", passwordFile)
-	}
-
 	// Write salt file (this is the trigger that switches from setup to normal mode)
 	if err := os.WriteFile(saltFile, salt, 0600); err != nil {
 		log.Printf("install: failed to write salt file: %v", err)
@@ -333,13 +324,6 @@ func mustLoadServer() (*api.Server, string, int) {
 		}
 		server.Unlock(kek)
 		log.Println("Server unlocked via VEILKEY_PASSWORD_FILE")
-	} else if pw := readDataDirPassword(dataDir); pw != "" {
-		kek := crypto.DeriveKEK(pw, salt)
-		if _, err := crypto.Decrypt(kek, info.DEK, info.DEKNonce); err != nil {
-			log.Fatalf("Failed to unlock with data dir password file: invalid password")
-		}
-		server.Unlock(kek)
-		log.Println("Server unlocked via data dir password file")
 	} else if os.Getenv("VEILKEY_PASSWORD") != "" {
 		log.Fatal("VEILKEY_PASSWORD env var is no longer supported (password exposed in process environment). Use VEILKEY_PASSWORD_FILE instead.")
 	} else {
@@ -612,12 +596,6 @@ func runInit() {
 		}
 	}
 
-	// Save password file for auto-unlock on restart
-	passwordFile := filepath.Join(dataDir, "password")
-	if err := os.WriteFile(passwordFile, []byte(password), 0600); err != nil {
-		log.Printf("Warning: failed to write password file: %v", err)
-	}
-
 	if err := os.WriteFile(saltFile, salt, 0600); err != nil {
 		log.Fatalf("Failed to save salt: %v", err)
 	}
@@ -638,14 +616,6 @@ func readPassword(prompt string) string {
 	return cmdutil.ReadPassword(prompt)
 }
 
-func readDataDirPassword(dataDir string) string {
-	path := filepath.Join(dataDir, "password")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
-}
 
 func decodeRegistrationToken(token string) (tokenID, vcURL, label string, err error) {
 	const prefix = "vk_reg_"

--- a/services/vaultcenter/cmd/main.go
+++ b/services/vaultcenter/cmd/main.go
@@ -96,12 +96,6 @@ func runServer() {
 			log.Fatalf("Failed to unlock with VEILKEY_PASSWORD_FILE: %v", err)
 		}
 		log.Println("Server unlocked via VEILKEY_PASSWORD_FILE")
-	} else if pw := readDataDirPassword(dataDir); pw != "" {
-		kek := crypto.DeriveKEK(pw, salt)
-		if err := server.Unlock(kek); err != nil {
-			log.Fatalf("Failed to unlock with data dir password file: %v", err)
-		}
-		log.Println("Server unlocked via data dir password file")
 	} else if os.Getenv("VEILKEY_PASSWORD") != "" {
 		log.Fatal("VEILKEY_PASSWORD env var is no longer supported (password exposed in process environment). Use VEILKEY_PASSWORD_FILE instead.")
 	} else {
@@ -142,15 +136,6 @@ func runServer() {
 			log.Fatalf("Server failed: %v", err)
 		}
 	}
-}
-
-func readDataDirPassword(dataDir string) string {
-	path := filepath.Join(dataDir, "password")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
 }
 
 // runHKMInit handles: veilkey-storage init --root

--- a/services/vaultcenter/internal/commands/setup_server.go
+++ b/services/vaultcenter/internal/commands/setup_server.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -161,16 +160,6 @@ func handleSetupInit(w http.ResponseWriter, r *http.Request, database *db.DB, sa
 				tempRef = parts.Canonical()
 			}
 		}
-	}
-
-	// Save password file BEFORE salt — salt existence signals "init complete",
-	// so password file must exist first for auto-unlock to work on restart.
-	passwordFile := filepath.Join(filepath.Dir(saltFile), "password")
-	if err := os.WriteFile(passwordFile, []byte(req.Password), 0600); err != nil {
-		log.Printf("setup: failed to write password file: %v", err)
-		// non-fatal: server can still be unlocked manually
-	} else {
-		log.Printf("setup: password file saved to %s", passwordFile)
 	}
 
 	if err := os.WriteFile(saltFile, salt, 0600); err != nil {


### PR DESCRIPTION
Setup was saving master password to dataDir/password in plaintext. Removed all password file write + readDataDirPassword fallback. Auto-unlock now requires VEILKEY_PASSWORD_FILE env var (externally managed).