### PR TITLE
fix: pre-commit violations — hardcoded port + missing env doc

### DIFF
--- a/services/localvault/.env.example
+++ b/services/localvault/.env.example
@@ -70,3 +70,7 @@ VEILKEY_MODE=root
 # VEILKEY_CHAIN_P2P_LISTEN=
 # Persistent peers for connecting to validator (format: nodeID@host:port)
 # VEILKEY_CHAIN_PERSISTENT_PEERS=
+
+# --- Registration ---
+# One-time registration token from VaultCenter (consumed on first heartbeat)
+# VEILKEY_REGISTRATION_TOKEN=

--- a/services/vaultcenter/internal/api/admin/handler.go
+++ b/services/vaultcenter/internal/api/admin/handler.go
@@ -24,7 +24,7 @@ type Deps interface {
 	// FetchAgentCiphertext retrieves the named secret ciphertext from the agent.
 	FetchAgentCiphertext(agentURL, ref string) (name string, ciphertext []byte, nonce []byte, err error)
 
-	// AgentURL builds the HTTP base URL for an agent (e.g. "http://1.2.3.4:10180").
+	// AgentURL builds the HTTP base URL for an agent.
 	AgentURL(ip string, port int) string
 
 	// SaveAuditEvent records an audit event.


### PR DESCRIPTION
pre-commit 위반 2건 수정: handler.go 주석의 하드코딩 포트 제거, localvault .env.example에 VEILKEY_REGISTRATION_TOKEN 등록.