### PR TITLE
refactor: convert remaining DB direct writes to chain TX

### DIFF
--- a/services/localvault/go.mod
+++ b/services/localvault/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.33
-	github.com/veilkey/veilkey-chain v0.5.0
+	github.com/veilkey/veilkey-chain v0.6.1
 	github.com/veilkey/veilkey-go-package v0.3.1
 	golang.org/x/crypto v0.49.0
 	gorm.io/driver/sqlite v1.6.0

--- a/services/localvault/go.sum
+++ b/services/localvault/go.sum
@@ -180,6 +180,8 @@ github.com/veilkey/veilkey-chain v0.4.0 h1:rGqrQT8cf8b4iHlBBOgKAtQ1PHHxD3klMN6a+
 github.com/veilkey/veilkey-chain v0.4.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-chain v0.5.0 h1:Tp/GF7BwFuUDoTGKf7eDbqdSCgIUfNGZD2dXy+hESac=
 github.com/veilkey/veilkey-chain v0.5.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.6.1 h1:a0zO2o3IlEDzGLuSZgY3iL3+SIzqPxqP63izNog+wZA=
+github.com/veilkey/veilkey-chain v0.6.1/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.3.0 h1:BvGydDA3pQsHEEBw/FzmVw2Nhk8OqGZzjA7CgH3Xd2g=
 github.com/veilkey/veilkey-go-package v0.3.0/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=

--- a/services/localvault/internal/db/chain_store.go
+++ b/services/localvault/internal/db/chain_store.go
@@ -40,16 +40,34 @@ func (a *ChainStoreAdapter) UpsertAgent(_, _, _, _, _ string, _, _, _, _, _ int)
 	return nil
 }
 
+// DeleteAgent is a no-op on localvault.
+func (a *ChainStoreAdapter) DeleteAgent(_ string) error { return nil }
+
 // RegisterChild is a no-op on localvault (identity-only record, no DEK).
 func (a *ChainStoreAdapter) RegisterChild(_ *chain.ChildRecord) error {
 	return nil
 }
+
+// DeleteChild is a no-op on localvault.
+func (a *ChainStoreAdapter) DeleteChild(_ string) error { return nil }
+
+// UpdateChildURL is a no-op on localvault.
+func (a *ChainStoreAdapter) UpdateChildURL(_, _ string) error { return nil }
 
 // SaveBinding is a no-op on localvault (vaultcenter manages bindings).
 func (a *ChainStoreAdapter) SaveBinding(_ *chain.BindingRecord) error { return nil }
 
 // DeleteBinding is a no-op on localvault.
 func (a *ChainStoreAdapter) DeleteBinding(_ string) error { return nil }
+
+// DeleteBindingsByTarget is a no-op on localvault.
+func (a *ChainStoreAdapter) DeleteBindingsByTarget(_, _ string) error { return nil }
+
+// SaveGlobalFunction is a no-op on localvault.
+func (a *ChainStoreAdapter) SaveGlobalFunction(_ *chain.GlobalFunctionRecord) error { return nil }
+
+// DeleteGlobalFunction is a no-op on localvault.
+func (a *ChainStoreAdapter) DeleteGlobalFunction(_ string) error { return nil }
 
 // SaveConfig applies config changes from chain blocks.
 func (a *ChainStoreAdapter) SaveConfig(key, value string) error {

--- a/services/vaultcenter/go.mod
+++ b/services/vaultcenter/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
-	github.com/veilkey/veilkey-chain v0.5.0 // indirect
+	github.com/veilkey/veilkey-chain v0.6.1 // indirect
 	go.etcd.io/bbolt v1.4.0-alpha.0.0.20240404170359-43604f3112c5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/services/vaultcenter/go.sum
+++ b/services/vaultcenter/go.sum
@@ -238,6 +238,10 @@ github.com/veilkey/veilkey-chain v0.4.0 h1:rGqrQT8cf8b4iHlBBOgKAtQ1PHHxD3klMN6a+
 github.com/veilkey/veilkey-chain v0.4.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-chain v0.5.0 h1:Tp/GF7BwFuUDoTGKf7eDbqdSCgIUfNGZD2dXy+hESac=
 github.com/veilkey/veilkey-chain v0.5.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.6.0 h1:C3t4g3JIS9NsgTtKqsWsrOicAF+Q8e89XVFTO6p60XM=
+github.com/veilkey/veilkey-chain v0.6.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
+github.com/veilkey/veilkey-chain v0.6.1 h1:a0zO2o3IlEDzGLuSZgY3iL3+SIzqPxqP63izNog+wZA=
+github.com/veilkey/veilkey-chain v0.6.1/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.3.1 h1:TgDHcA1wc/e7JwYZNaSRbzqVex0WZxCAvZ73Jb7uooY=
 github.com/veilkey/veilkey-go-package v0.3.1/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
@@ -3,6 +3,8 @@ package hkm
 import (
 	"log"
 	"net/http"
+
+	chain "github.com/veilkey/veilkey-chain"
 )
 
 func (h *Handler) handleAgentUnregisterByNode(w http.ResponseWriter, r *http.Request) {
@@ -11,7 +13,9 @@ func (h *Handler) handleAgentUnregisterByNode(w http.ResponseWriter, r *http.Req
 		respondError(w, http.StatusBadRequest, "node_id is required")
 		return
 	}
-	if err := h.deps.DB().DeleteAgentByNodeID(nodeID); err != nil {
+	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteAgent, chain.DeleteAgentPayload{
+		NodeID: nodeID,
+	}); err != nil {
 		respondError(w, http.StatusNotFound, err.Error())
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_delete_child.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_delete_child.go
@@ -3,6 +3,8 @@ package hkm
 import (
 	"log"
 	"net/http"
+
+	chain "github.com/veilkey/veilkey-chain"
 )
 
 // handleDeleteChild removes a child node by node_id
@@ -12,7 +14,9 @@ func (h *Handler) handleDeleteChild(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "node_id is required")
 		return
 	}
-	if err := h.deps.DB().DeleteChild(nodeID); err != nil {
+	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteChild, chain.DeleteChildPayload{
+		NodeID: nodeID,
+	}); err != nil {
 		respondError(w, http.StatusNotFound, err.Error())
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_global_functions.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_global_functions.go
@@ -2,9 +2,11 @@ package hkm
 
 import (
 	"net/http"
-	"veilkey-vaultcenter/internal/httputil"
 	"strings"
+
+	chain "github.com/veilkey/veilkey-chain"
 	"veilkey-vaultcenter/internal/db"
+	"veilkey-vaultcenter/internal/httputil"
 )
 
 func (h *Handler) handleGlobalFunctions(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +31,13 @@ func (h *Handler) handleGlobalFunctions(w http.ResponseWriter, r *http.Request) 
 			respondError(w, http.StatusBadRequest, "function name is required")
 			return
 		}
-		if err := h.deps.DB().SaveGlobalFunction(&req); err != nil {
+		if _, err := h.deps.SubmitTx(r.Context(), chain.TxSaveGlobalFunction, chain.SaveGlobalFunctionPayload{
+			Name:         req.Name,
+			FunctionHash: req.FunctionHash,
+			Category:     req.Category,
+			Command:      req.Command,
+			VarsJSON:     req.VarsJSON,
+		}); err != nil {
 			respondError(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -54,7 +62,9 @@ func (h *Handler) handleGlobalFunction(w http.ResponseWriter, r *http.Request) {
 		}
 		respondJSON(w, http.StatusOK, fn)
 	case http.MethodDelete:
-		if err := h.deps.DB().DeleteGlobalFunction(name); err != nil {
+		if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteGlobalFunction, chain.DeleteGlobalFunctionPayload{
+			Name: name,
+		}); err != nil {
 			respondError(w, http.StatusNotFound, err.Error())
 			return
 		}

--- a/services/vaultcenter/internal/api/hkm/hkm_heartbeat.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_heartbeat.go
@@ -3,6 +3,8 @@ package hkm
 import (
 	"log"
 	"net/http"
+
+	chain "github.com/veilkey/veilkey-chain"
 	"veilkey-vaultcenter/internal/httputil"
 )
 
@@ -39,7 +41,9 @@ func (h *Handler) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if req.Version > 0 && req.Version != child.Version {
 		log.Printf("heartbeat: VERSION MISMATCH child %s (%s) — reported v%d, expected v%d. Disconnecting.",
 			nodeID, child.Label, req.Version, child.Version)
-		if err := h.deps.DB().DeleteChild(nodeID); err != nil {
+		if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteChild, chain.DeleteChildPayload{
+			NodeID: nodeID,
+		}); err != nil {
 			log.Printf("heartbeat: failed to delete child %s: %v", nodeID, err)
 		}
 		respondJSON(w, http.StatusForbidden, map[string]interface{}{
@@ -51,7 +55,10 @@ func (h *Handler) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.deps.DB().UpdateChildURL(nodeID, req.URL); err != nil {
+	if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateChildURL, chain.UpdateChildURLPayload{
+		NodeID: nodeID,
+		URL:    req.URL,
+	}); err != nil {
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/services/vaultcenter/internal/api/hkm/hkm_target_bindings.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_target_bindings.go
@@ -115,7 +115,10 @@ func (h *Handler) handleTargetBindingsReplace(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	if err := h.deps.DB().DeleteBindingsByTarget(bindingType, targetName); err != nil {
+	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteBindingsByTarget, chain.DeleteBindingsByTargetPayload{
+		BindingType: bindingType,
+		TargetName:  targetName,
+	}); err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to clear existing target bindings")
 		return
 	}
@@ -189,7 +192,10 @@ func (h *Handler) handleTargetBindingsDeleteAll(w http.ResponseWriter, r *http.R
 		respondError(w, http.StatusInternalServerError, "failed to list target bindings")
 		return
 	}
-	if err := h.deps.DB().DeleteBindingsByTarget(bindingType, targetName); err != nil {
+	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteBindingsByTarget, chain.DeleteBindingsByTargetPayload{
+		BindingType: bindingType,
+		TargetName:  targetName,
+	}); err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to delete target bindings")
 		return
 	}

--- a/services/vaultcenter/internal/db/chain_store.go
+++ b/services/vaultcenter/internal/db/chain_store.go
@@ -34,6 +34,10 @@ func (a *ChainStoreAdapter) UpsertAgent(nodeID, label, vaultHash, vaultName, ip 
 	return a.DB.UpsertAgent(nodeID, label, vaultHash, vaultName, ip, port, secretsCount, configsCount, version, keyVersion)
 }
 
+func (a *ChainStoreAdapter) DeleteAgent(nodeID string) error {
+	return a.DB.DeleteAgentByNodeID(nodeID)
+}
+
 func (a *ChainStoreAdapter) RegisterChild(child *chain.ChildRecord) error {
 	// Chain TX only records node identity — DEK delivery is out-of-band via REST.
 	return a.DB.RegisterChild(&Child{
@@ -42,6 +46,14 @@ func (a *ChainStoreAdapter) RegisterChild(child *chain.ChildRecord) error {
 		URL:     child.URL,
 		Version: child.Version,
 	})
+}
+
+func (a *ChainStoreAdapter) DeleteChild(nodeID string) error {
+	return a.DB.DeleteChild(nodeID)
+}
+
+func (a *ChainStoreAdapter) UpdateChildURL(nodeID, url string) error {
+	return a.DB.UpdateChildURL(nodeID, url)
 }
 
 func (a *ChainStoreAdapter) SaveBinding(binding *chain.BindingRecord) error {
@@ -59,6 +71,24 @@ func (a *ChainStoreAdapter) SaveBinding(binding *chain.BindingRecord) error {
 
 func (a *ChainStoreAdapter) DeleteBinding(bindingID string) error {
 	return a.DB.DeleteBinding(bindingID)
+}
+
+func (a *ChainStoreAdapter) DeleteBindingsByTarget(bindingType, targetName string) error {
+	return a.DB.DeleteBindingsByTarget(bindingType, targetName)
+}
+
+func (a *ChainStoreAdapter) SaveGlobalFunction(fn *chain.GlobalFunctionRecord) error {
+	return a.DB.SaveGlobalFunction(&GlobalFunction{
+		Name:         fn.Name,
+		FunctionHash: fn.FunctionHash,
+		Category:     fn.Category,
+		Command:      fn.Command,
+		VarsJSON:     fn.VarsJSON,
+	})
+}
+
+func (a *ChainStoreAdapter) DeleteGlobalFunction(name string) error {
+	return a.DB.DeleteGlobalFunction(name)
 }
 
 func (a *ChainStoreAdapter) SaveConfig(key, value string) error {


### PR DESCRIPTION
## Summary
- Convert 7 remaining DB direct writes to chain transactions (9 call sites total)
- Add 6 new TX types to veilkey-chain v0.6.1: `TxDeleteAgent`, `TxDeleteChild`, `TxUpdateChildURL`, `TxDeleteBindingsByTarget`, `TxSaveGlobalFunction`, `TxDeleteGlobalFunction`
- Update Store interface and both vaultcenter/localvault chain store adapters

## Converted operations
| Operation | TX Type | Files |
|-----------|---------|-------|
| DeleteAgentByNodeID | TxDeleteAgent | hkm_agent_unregister.go |
| DeleteChild | TxDeleteChild | hkm_delete_child.go, hkm_heartbeat.go |
| UpdateChildURL | TxUpdateChildURL | hkm_heartbeat.go |
| SaveGlobalFunction | TxSaveGlobalFunction | hkm_global_functions.go |
| DeleteGlobalFunction | TxDeleteGlobalFunction | hkm_global_functions.go |
| DeleteBindingsByTarget | TxDeleteBindingsByTarget | hkm_target_bindings.go (×2) |

## Intentional DB-only writes (unchanged)
- DEK operations (UpdateAgentDEK, UpdateChildDEK, UpdateNodeDEK) — crypto material must not go on chain
- Metadata cache (UpdateVaultInventoryMeta, UpdateSecretCatalogMeta) — read-only cache

## Test plan
- [ ] Both services compile cleanly
- [ ] `scripts/chain-e2e-test.sh` passes
- [ ] Agent unregister, child delete, heartbeat, global function CRUD, binding delete operations work via chain TX

Refs #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)