### PR TITLE
fix: add X-VeilKey-Cascade header to agent resolve fallback

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
@@ -220,7 +220,12 @@ func (h *Handler) fetchAgentFieldCiphertext(agentURL, ref, fieldKey string) (*ci
 }
 
 func (h *Handler) fetchAgentResolvedValue(agentURL, ref string) (*resolvedAgentSecret, error) {
-	resp, err := h.deps.HTTPClient().Get(joinPath(agentURL, agentPathResolve, ref))
+	req, err := http.NewRequest(http.MethodGet, joinPath(agentURL, agentPathResolve, ref), nil)
+	if err != nil {
+		return nil, fmt.Errorf("agent resolve request: %w", err)
+	}
+	req.Header.Set("X-VeilKey-Cascade", "true")
+	resp, err := h.deps.HTTPClient().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("agent unreachable: %w", err)
 	}


### PR DESCRIPTION
VC가 LV의 /api/resolve/{ref}를 호출할 때 X-VeilKey-Cascade 헤더 누락으로 403 반환. 볼트 상세에서 시크릿 값 조회 불가했던 #127 해결.

agentDEK 복호화 실패 → fallback resolve → 이제 헤더 포함 → LV가 로컬 DEK로 복호화 → 값 반환.