### PR TITLE
feat: enable CometBFT chain in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ DOCKER_MIRROR=
 # Host ports (change if conflicts with existing services)
 VAULTCENTER_HOST_PORT=11181
 LOCALVAULT_HOST_PORT=11180
+VAULTCENTER_P2P_PORT=26656
+VAULTCENTER_RPC_PORT=26657
 
 # Trusted IP ranges for the services (comma-separated CIDR)
 VEILKEY_TRUSTED_IPS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1
@@ -21,3 +23,5 @@ VEILKEY_AGENT_SCHEME=https
 
 # LocalVault
 LOCALVAULT_LABEL=localvault-01
+# CometBFT persistent peers (set after vaultcenter starts — nodeID@host:port)
+# LOCALVAULT_CHAIN_PEERS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     restart: unless-stopped
     ports:
       - "${VAULTCENTER_HOST_PORT:-11181}:10181"
+      - "${VAULTCENTER_P2P_PORT:-26656}:26656"
+      - "${VAULTCENTER_RPC_PORT:-26657}:26657"
     environment:
       VEILKEY_ADDR: ":10181"
       VEILKEY_DB_PATH: /data/veilkey.db
@@ -18,6 +20,8 @@ services:
       VEILKEY_AGENT_SCHEME: "${VEILKEY_AGENT_SCHEME}"
       VEILKEY_TRUSTED_IPS: "${VEILKEY_TRUSTED_IPS}"
       VEILKEY_TLS_INSECURE: "1"
+      VEILKEY_CHAIN_HOME: /data/chain
+      VEILKEY_CHAIN_P2P_ADDR: "vaultcenter:26656"
     volumes:
       - ${VAULTCENTER_DATA_DIR:-./data/vaultcenter}:/data
     healthcheck:
@@ -45,6 +49,8 @@ services:
       VEILKEY_VAULTCENTER_URL: "https://vaultcenter:10181"
       VEILKEY_TRUSTED_IPS: "${VEILKEY_TRUSTED_IPS}"
       VEILKEY_TLS_INSECURE: "1"
+      VEILKEY_CHAIN_HOME: /data/chain
+      VEILKEY_CHAIN_PERSISTENT_PEERS: "${LOCALVAULT_CHAIN_PEERS}"
     volumes:
       - ${LOCALVAULT_DATA_DIR:-./data/localvault}:/data
     depends_on:


### PR DESCRIPTION
docker-compose에 체인 활성화. vaultcenter: validator + P2P/RPC 포트 노출. localvault: full node + peers 연결. 체인 데이터는 /data/chain volume에 저장, restart 시 유지.