### PR TITLE
fix: restore dataDir password file fallback

### DIFF
--- a/services/localvault/internal/commands/server.go
+++ b/services/localvault/internal/commands/server.go
@@ -287,6 +287,13 @@ func mustLoadServer() (*api.Server, string, int) {
 		}
 		server.Unlock(kek)
 		log.Println("Server unlocked via VEILKEY_PASSWORD_FILE")
+	} else if pw := readDataDirPassword(dataDir); pw != "" {
+		kek := crypto.DeriveKEK(pw, salt)
+		if _, err := crypto.Decrypt(kek, info.DEK, info.DEKNonce); err != nil {
+			log.Fatalf("Failed to unlock with data dir password file: invalid password")
+		}
+		server.Unlock(kek)
+		log.Println("Server unlocked via data dir password file")
 	} else if os.Getenv("VEILKEY_PASSWORD") != "" {
 		log.Fatal("VEILKEY_PASSWORD env var is no longer supported (password exposed in process environment). Use VEILKEY_PASSWORD_FILE instead.")
 	} else {

--- a/services/localvault/internal/commands/util.go
+++ b/services/localvault/internal/commands/util.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/veilkey/veilkey-go-package/cmdutil"
@@ -10,6 +11,15 @@ import (
 
 func readPasswordFromFileEnv() string {
 	return cmdutil.ReadPasswordFromFileEnv()
+}
+
+func readDataDirPassword(dataDir string) string {
+	path := filepath.Join(dataDir, "password")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func readPassword(prompt string) string {

--- a/services/vaultcenter/internal/commands/server.go
+++ b/services/vaultcenter/internal/commands/server.go
@@ -79,6 +79,12 @@ func RunServer() {
 			log.Fatalf("Failed to unlock with VEILKEY_PASSWORD_FILE: %v", err)
 		}
 		log.Println("Server unlocked via VEILKEY_PASSWORD_FILE")
+	} else if pw := readDataDirPassword(dataDir); pw != "" {
+		kek := crypto.DeriveKEK(pw, salt)
+		if err := server.Unlock(kek); err != nil {
+			log.Fatalf("Failed to unlock with data dir password file: %v", err)
+		}
+		log.Println("Server unlocked via data dir password file")
 	} else if os.Getenv("VEILKEY_PASSWORD") != "" {
 		log.Fatal("VEILKEY_PASSWORD env var is no longer supported (password exposed in process environment). Use VEILKEY_PASSWORD_FILE instead.")
 	} else {

--- a/services/vaultcenter/internal/commands/util.go
+++ b/services/vaultcenter/internal/commands/util.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/veilkey/veilkey-go-package/cmdutil"
@@ -8,6 +11,15 @@ import (
 
 func readPasswordFromFileEnv() string {
 	return cmdutil.ReadPasswordFromFileEnv()
+}
+
+func readDataDirPassword(dataDir string) string {
+	path := filepath.Join(dataDir, "password")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func readPassword(prompt string) string {


### PR DESCRIPTION
PR #140에서 cmd/main.go → commands 통합 시 readDataDirPassword fallback 탈락. 셋업 후 재시작하면 LOCKED 모드 진입. 양쪽 서비스에 복원.