### PR TITLE
fix: fallback to agent resolve when agentDEK decryption fails

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
@@ -47,15 +47,15 @@ func (h *Handler) handleAgentGetSecret(w http.ResponseWriter, r *http.Request) {
 	cipher, err := h.fetchAgentCiphertext(agentURL, meta.Ref)
 	if err == nil {
 		plaintext, decErr := crypto.Decrypt(agentDEK, cipher.Ciphertext, cipher.Nonce)
-		if decErr != nil {
-			respondError(w, http.StatusInternalServerError, "decryption failed")
-			return
+		if decErr == nil {
+			plaintextValue = string(plaintext)
 		}
-		plaintextValue = string(plaintext)
-	} else {
+	}
+	// Fallback: ask agent to resolve (uses agent's own DEK)
+	if plaintextValue == "" {
 		resolved, resolveErr := h.fetchAgentResolvedValue(agentURL, meta.Token)
 		if resolveErr != nil {
-			respondError(w, http.StatusBadGateway, "upstream unavailable")
+			respondError(w, http.StatusBadGateway, "failed to resolve secret value")
 			return
 		}
 		plaintextValue = resolved.Value


### PR DESCRIPTION
agentDEK 복호화 실패 시 500 반환 대신 LV resolve fallback. 볼트 상세에서 시크릿 값 조회 가능.