### PR TITLE
security: remove legacy LV decrypt paths — LV is storage-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ node_modules/
 /veilkey
 # Go build output inside service directories
 services/*/main
+.claude/

--- a/services/localvault/internal/api/secrets/handler.go
+++ b/services/localvault/internal/api/secrets/handler.go
@@ -55,8 +55,8 @@ func (h *Handler) Register(
 	mux.HandleFunc("GET /api/cipher/{ref}", trusted(ready(h.handleCipher)))
 	mux.HandleFunc("GET /api/cipher/{ref}/fields/{field}", trusted(ready(h.handleCipherField)))
 	mux.HandleFunc("POST /api/cipher", trusted(ready(h.handleSaveCipher)))
-	mux.HandleFunc("POST /api/decrypt", trusted(ready(h.handleDecrypt)))
-	mux.HandleFunc("POST /api/promote", trusted(ready(h.handlePromote)))
+	// POST /api/decrypt — removed (legacy encryption path)
+	// POST /api/promote — removed (legacy encryption path)
 
 	mux.HandleFunc("POST /api/encrypt", ready(h.handleEncrypt))
 

--- a/services/localvault/internal/api/secrets/secrets.go
+++ b/services/localvault/internal/api/secrets/secrets.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/veilkey/veilkey-go-package/crypto"
@@ -82,52 +81,7 @@ func (h *Handler) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleResolveSecret(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("X-VeilKey-Cascade") != "true" {
-		respondError(w, http.StatusForbidden, vaultcenterOnlyDecryptMessage)
-		return
-	}
-
-	ref := r.PathValue("ref")
-	if ref == "" {
-		respondError(w, http.StatusBadRequest, "ref is required")
-		return
-	}
-
-	secret, err := h.deps.DB().GetSecretByRef(ref)
-	if err != nil {
-		parts := strings.SplitN(ref, ":", 3)
-		if len(parts) == 3 {
-			secret, err = h.deps.DB().GetSecretByRef(parts[2])
-		}
-		if err != nil {
-			respondError(w, http.StatusNotFound, "ref not found")
-			return
-		}
-	}
-
-	info, err := h.deps.DB().GetNodeInfo()
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, "node info not available")
-		return
-	}
-
-	dek, err := crypto.Decrypt(h.deps.GetKEK(), info.DEK, info.DEKNonce)
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to decrypt DEK")
-		return
-	}
-
-	plaintext, err := crypto.Decrypt(dek, secret.Ciphertext, secret.Nonce)
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, "decryption failed")
-		return
-	}
-
-	respondJSON(w, http.StatusOK, map[string]any{
-		"ref":   ref,
-		"name":  secret.Name,
-		"value": string(plaintext),
-	})
+	respondError(w, http.StatusForbidden, "localvault direct plaintext resolution is disabled")
 }
 
 func (h *Handler) handleRekey(w http.ResponseWriter, r *http.Request) {

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
@@ -46,23 +46,17 @@ func (h *Handler) handleAgentGetSecret(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
-	plaintextValue := ""
 	cipher, err := h.fetchAgentCiphertext(agentURL, meta.Ref)
-	if err == nil {
-		plaintext, decErr := crypto.Decrypt(agentDEK, cipher.Ciphertext, cipher.Nonce)
-		if decErr == nil {
-			plaintextValue = string(plaintext)
-		}
+	if err != nil {
+		respondError(w, http.StatusBadGateway, "failed to fetch ciphertext: "+err.Error())
+		return
 	}
-	// Fallback: ask agent to resolve (uses agent's own DEK)
-	if plaintextValue == "" {
-		resolved, resolveErr := h.fetchAgentResolvedValue(agentURL, meta.Token)
-		if resolveErr != nil {
-			respondError(w, http.StatusBadGateway, "failed to resolve secret value")
-			return
-		}
-		plaintextValue = resolved.Value
+	plaintext, decErr := crypto.Decrypt(agentDEK, cipher.Ciphertext, cipher.Nonce)
+	if decErr != nil {
+		respondError(w, http.StatusInternalServerError, "decryption failed")
+		return
 	}
+	plaintextValue := string(plaintext)
 
 	payload := map[string]interface{}{
 		"name":         name,


### PR DESCRIPTION
## Summary
LV에서 레거시 복호화 경로 3개 제거. LV는 이제 순수 금고(저장만, 복호화 불가).

### 제거된 경로
| 경로 | 이전 | 이후 |
|------|------|------|
| `POST /api/promote` | LV DEK로 암호화 | 라우트 제거 |
| `POST /api/decrypt` | LV DEK로 복호화 | 라우트 제거 |
| `GET /api/resolve/{ref}` | 평문 반환 | 403 반환 |
| VC fallback resolve | LV에 평문 요청 | 에러 반환 (agentDEK만) |

### 보안 개선
- LV 탈취 시 시크릿 복호화 불가 (agentDEK가 없으므로)
- 네트워크에 평문 전송 경로 제거
- 모든 복호화는 VC에서만 agentDEK로 수행

## Test plan
- [x] VC build OK
- [x] LV build OK
- [ ] 새 키 promote → agentDEK로 저장 → VC에서 조회 정상
- [ ] LV에 직접 resolve 요청 → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)