### PR TITLE
ci: upgrade golangci-lint-action v6 → v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           go-version-file: services/vaultcenter/go.mod
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           working-directory: services/vaultcenter
           version: "v2.1.6"
@@ -78,7 +78,7 @@ jobs:
         with:
           go-version-file: services/localvault/go.mod
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           working-directory: services/localvault
           version: "v2.1.6"


### PR DESCRIPTION
## Summary
- golangci-lint v2.1.6 is not supported by action v6, upgrade to v7

## Test plan
- [x] CI should pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)