### PR TITLE
security: sanitize err.Error() in localvault HTTP responses

### DIFF
--- a/services/localvault/internal/api/configs/configs.go
+++ b/services/localvault/internal/api/configs/configs.go
@@ -52,7 +52,7 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 	config, err := h.deps.DB().GetConfig(key)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "config not found")
 		return
 	}
 	if config.Status == refStatusBlock {
@@ -92,7 +92,7 @@ func (h *Handler) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.deps.DB().SaveConfig(req.Key, *req.Value); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to save config: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to save config")
 		return
 	}
 
@@ -131,7 +131,7 @@ func (h *Handler) handleSaveConfigsBulk(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.deps.DB().SaveConfigs(req.Configs); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to save configs: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to save configs")
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *Handler) handleDeleteConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.deps.DB().DeleteConfig(key); err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "config not found")
 		return
 	}
 

--- a/services/localvault/internal/api/functions/functions.go
+++ b/services/localvault/internal/api/functions/functions.go
@@ -77,7 +77,7 @@ func (h *Handler) handleFunctions(w http.ResponseWriter, r *http.Request) {
 		scope := strings.TrimSpace(r.URL.Query().Get("scope"))
 		functions, err := h.deps.DB().ListFunctionsByScope(scope)
 		if err != nil {
-			respondError(w, http.StatusBadRequest, err.Error())
+			respondError(w, http.StatusBadRequest, "invalid scope")
 			return
 		}
 		respondJSON(w, http.StatusOK, map[string]any{
@@ -99,7 +99,7 @@ func (h *Handler) handleFunctions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.deps.DB().SaveFunction(&req); err != nil {
-			respondError(w, http.StatusBadRequest, err.Error())
+			respondError(w, http.StatusBadRequest, "failed to save function")
 			return
 		}
 		respondJSON(w, http.StatusOK, req)
@@ -118,14 +118,14 @@ func (h *Handler) handleFunction(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		fn, err := h.deps.DB().GetFunction(name)
 		if err != nil {
-			respondError(w, http.StatusNotFound, err.Error())
+			respondError(w, http.StatusNotFound, "function not found")
 			return
 		}
 		respondJSON(w, http.StatusOK, fn)
 	case http.MethodDelete:
 		fn, err := h.deps.DB().GetFunction(name)
 		if err != nil {
-			respondError(w, http.StatusNotFound, err.Error())
+			respondError(w, http.StatusNotFound, "function not found")
 			return
 		}
 		if strings.EqualFold(fn.Scope, "GLOBAL") {
@@ -133,7 +133,7 @@ func (h *Handler) handleFunction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.deps.DB().DeleteFunction(name); err != nil {
-			respondError(w, http.StatusNotFound, err.Error())
+			respondError(w, http.StatusNotFound, "function not found")
 			return
 		}
 		respondJSON(w, http.StatusOK, map[string]any{"deleted": name})

--- a/services/localvault/internal/api/lifecycle.go
+++ b/services/localvault/internal/api/lifecycle.go
@@ -32,7 +32,7 @@ func (s *Server) handleReencrypt(w http.ResponseWriter, r *http.Request) {
 	}
 	parsed, err := ParseScopedVKRef(req.Ciphertext)
 	if err != nil {
-		s.respondError(w, http.StatusBadRequest, err.Error())
+		s.respondError(w, http.StatusBadRequest, "invalid ref format")
 		return
 	}
 	if _, err := s.db.GetSecretByRef(parsed.ID); err != nil {
@@ -62,7 +62,7 @@ func (s *Server) handleActivate(w http.ResponseWriter, r *http.Request) {
 
 	parsed, err := ParseScopedRef(req.Ciphertext)
 	if err != nil {
-		s.respondError(w, http.StatusBadRequest, err.Error())
+		s.respondError(w, http.StatusBadRequest, "invalid ref format")
 		return
 	}
 	if parsed.Scope != RefScopeTemp {
@@ -72,7 +72,7 @@ func (s *Server) handleActivate(w http.ResponseWriter, r *http.Request) {
 
 	targetScope, err := ParseActivationScope(req.Scope)
 	if err != nil {
-		s.respondError(w, http.StatusBadRequest, err.Error())
+		s.respondError(w, http.StatusBadRequest, "invalid ref format")
 		return
 	}
 	switch parsed.Family {
@@ -87,7 +87,7 @@ func (s *Server) handleActivate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := s.db.UpdateSecretLifecycle(parsed.ID, targetScope, db.RefStatusActive); err != nil {
-			s.respondError(w, http.StatusInternalServerError, "failed to update status: "+err.Error())
+			s.respondError(w, http.StatusInternalServerError, "failed to update status")
 			return
 		}
 		activated := ParsedRef{
@@ -108,7 +108,7 @@ func (s *Server) handleActivate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := s.db.UpdateConfigLifecycle(parsed.ID, targetScope, db.RefStatusActive); err != nil {
-			s.respondError(w, http.StatusInternalServerError, "failed to update status: "+err.Error())
+			s.respondError(w, http.StatusInternalServerError, "failed to update status")
 			return
 		}
 		activated := ParsedRef{
@@ -151,7 +151,7 @@ func (s *Server) handleStatusTransition(w http.ResponseWriter, r *http.Request, 
 
 	parsed, err := ParseScopedRef(req.Ciphertext)
 	if err != nil {
-		s.respondError(w, http.StatusBadRequest, err.Error())
+		s.respondError(w, http.StatusBadRequest, "invalid ref format")
 		return
 	}
 	if parsed.Scope == RefScopeTemp {
@@ -174,7 +174,7 @@ func (s *Server) handleStatusTransition(w http.ResponseWriter, r *http.Request, 
 			scope = parsed.Scope
 		}
 		if err := s.db.UpdateSecretLifecycle(parsed.ID, scope, status); err != nil {
-			s.respondError(w, http.StatusInternalServerError, "failed to update status: "+err.Error())
+			s.respondError(w, http.StatusInternalServerError, "failed to update status")
 			return
 		}
 		s.respondLifecycleJSON(w, parsed.CanonicalString(), status, false, s.syncTrackedRefWithVaultcenter(parsed.CanonicalString(), "", secret.Version, status))
@@ -190,7 +190,7 @@ func (s *Server) handleStatusTransition(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		if err := s.db.UpdateConfigLifecycle(parsed.ID, "", status); err != nil {
-			s.respondError(w, http.StatusInternalServerError, "failed to update status: "+err.Error())
+			s.respondError(w, http.StatusInternalServerError, "failed to update status")
 			return
 		}
 		s.respondLifecycleJSON(w, parsed.CanonicalString(), status, false, s.syncTrackedRefWithVaultcenter(parsed.CanonicalString(), "", 0, status))

--- a/services/localvault/internal/api/secrets/cipher_save.go
+++ b/services/localvault/internal/api/secrets/cipher_save.go
@@ -81,7 +81,7 @@ func (h *Handler) handleSaveCipher(w http.ResponseWriter, r *http.Request) {
 		Status:     status,
 	}
 	if err := h.deps.DB().SaveSecret(secret); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to save secret: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to save secret")
 		return
 	}
 
@@ -110,7 +110,7 @@ func (h *Handler) handleGetSecretMeta(w http.ResponseWriter, r *http.Request) {
 
 	secret, err := h.deps.DB().GetSecretByName(name)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "secret not found")
 		return
 	}
 

--- a/services/localvault/internal/api/secrets/fields.go
+++ b/services/localvault/internal/api/secrets/fields.go
@@ -48,7 +48,7 @@ func (h *Handler) handleSaveSecretFields(w http.ResponseWriter, r *http.Request)
 
 	secret, err := h.deps.DB().GetSecretByName(req.Name)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "secret not found")
 		return
 	}
 	if secret.Status != refStatusActive || (secret.Scope != refScopeLocal && secret.Scope != db.RefScopeExternal) {
@@ -79,7 +79,7 @@ func (h *Handler) handleSaveSecretFields(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := h.deps.DB().SaveSecretFields(req.Name, fields); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to save secret fields: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to save secret fields")
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *Handler) handleCipherField(w http.ResponseWriter, r *http.Request) {
 
 	field, err := h.deps.DB().GetSecretField(secret.Name, fieldKey)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "field not found")
 		return
 	}
 
@@ -147,7 +147,7 @@ func (h *Handler) handleDeleteSecretField(w http.ResponseWriter, r *http.Request
 
 	secret, err := h.deps.DB().GetSecretByName(name)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "secret not found")
 		return
 	}
 	if secret.Status != refStatusActive || (secret.Scope != refScopeLocal && secret.Scope != db.RefScopeExternal) {
@@ -155,7 +155,7 @@ func (h *Handler) handleDeleteSecretField(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if err := h.deps.DB().DeleteSecretField(name, fieldKey); err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "field not found")
 		return
 	}
 

--- a/services/localvault/internal/api/secrets/secrets.go
+++ b/services/localvault/internal/api/secrets/secrets.go
@@ -71,7 +71,7 @@ func (h *Handler) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.deps.DB().DeleteSecret(name); err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "secret not found")
 		return
 	}
 
@@ -104,7 +104,7 @@ func (h *Handler) handleRekey(w http.ResponseWriter, r *http.Request) {
 
 	oldDEK, err := h.deps.GetLocalDEK()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to get current DEK: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to get current DEK")
 		return
 	}
 	count, skipped, err := h.deps.DB().ReencryptMixedSecrets(
@@ -120,7 +120,7 @@ func (h *Handler) handleRekey(w http.ResponseWriter, r *http.Request) {
 		req.Version,
 	)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, fmt.Sprintf("re-encryption failed after %d secrets (skipped %d already-current): %v", count, skipped, err))
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("re-encryption failed after %d secrets (skipped %d already-current)", count, skipped))
 		return
 	}
 
@@ -130,7 +130,7 @@ func (h *Handler) handleRekey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.deps.DB().UpdateNodeDEK(encDEK, encNonce, req.Version); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to update node DEK: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to update node DEK")
 		return
 	}
 


### PR DESCRIPTION
## Summary
Replace 27 raw `err.Error()` exposures in localvault HTTP responses with generic messages across 6 files (configs, functions, lifecycle, secrets, fields, cipher_save).

## Test plan
- [x] `go build ./...` passes
- [ ] API responses return generic errors instead of internal details

🤖 Generated with [Claude Code](https://claude.com/claude-code)