### PR TITLE
security: sanitize all err.Error() in vaultcenter HTTP responses

### DIFF
--- a/services/vaultcenter/internal/api/admin/admin_auth.go
+++ b/services/vaultcenter/internal/api/admin/admin_auth.go
@@ -394,7 +394,7 @@ func (h *Handler) handleAdminReveal(w http.ResponseWriter, r *http.Request) {
 	}
 	payload, err := h.resolveAdminReveal(req.Ref)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	_ = h.deps.DB().MarkSecretCatalogRevealed(payload["ref"].(string), now)
@@ -444,7 +444,7 @@ func (h *Handler) handleAdminRebindApprovalsList(w http.ResponseWriter, r *http.
 func (h *Handler) handleAdminRebindPlan(w http.ResponseWriter, r *http.Request) {
 	agent, err := h.deps.FindAgentRecord(r.PathValue("agent"))
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if !agent.RebindRequired && agent.BlockedAt == nil {
@@ -489,7 +489,7 @@ func (h *Handler) handleAdminApproveRebind(w http.ResponseWriter, r *http.Reques
 	session, _ := h.currentAdminSession(r)
 	agent, err := h.deps.FindAgentRecord(r.PathValue("agent"))
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	requiredConfirm := "APPROVE " + strings.ToUpper(strings.TrimSpace(agent.AgentHash))
@@ -513,7 +513,7 @@ func (h *Handler) handleAdminApproveRebind(w http.ResponseWriter, r *http.Reques
 	}
 	updated, err := h.deps.DB().ApproveAgentRebind(agent.NodeID)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to approve agent rebind: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to approve agent rebind")
 		return
 	}
 	h.deps.SaveAuditEvent(
@@ -574,12 +574,12 @@ func (h *Handler) handleAdminScheduleAllRotations(w http.ResponseWriter, r *http
 	session, _ := h.currentAdminSession(r)
 	_, err := h.deps.DB().AdvancePendingRotations(time.Now().UTC())
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to advance pending rotations: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to advance pending rotations")
 		return
 	}
 	agents, err := h.deps.DB().ScheduleAllAgentRotations(reason)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to schedule agent rotation: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to schedule agent rotation")
 		return
 	}
 	results := make([]map[string]any, 0, len(agents))
@@ -620,7 +620,7 @@ func (h *Handler) handleAdminScheduleRotation(w http.ResponseWriter, r *http.Req
 	session, _ := h.currentAdminSession(r)
 	agent, err := h.deps.FindAgentRecord(r.PathValue("agent"))
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	requiredConfirm := "ROTATE " + strings.ToUpper(strings.TrimSpace(agent.AgentHash))
@@ -639,7 +639,7 @@ func (h *Handler) handleAdminScheduleRotation(w http.ResponseWriter, r *http.Req
 	}
 	updated, err := h.deps.DB().ScheduleAgentRotation(agent.NodeID, reason)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to schedule agent rotation: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to schedule agent rotation")
 		return
 	}
 	h.deps.SaveAuditEvent("vault", updated.NodeID, "admin_schedule_rotation_single", "admin_session", session.SessionID, reason, "admin_rotate_single", map[string]any{

--- a/services/vaultcenter/internal/api/bulk/templates.go
+++ b/services/vaultcenter/internal/api/bulk/templates.go
@@ -163,7 +163,7 @@ func (h *Handler) handleBulkApplyTemplates(w http.ResponseWriter, r *http.Reques
 		}
 		tmpl, err := h.saveBulkApplyTemplateFile(vaultHash, "", &req)
 		if err != nil {
-			httputil.RespondError(w, http.StatusBadRequest, err.Error())
+			httputil.RespondError(w, http.StatusBadRequest, "invalid request")
 			return
 		}
 		httputil.RespondJSON(w, http.StatusOK, bulkApplyTemplateResponse(tmpl))
@@ -183,7 +183,7 @@ func (h *Handler) handleBulkApplyTemplate(w http.ResponseWriter, r *http.Request
 	case http.MethodGet:
 		tmpl, err := h.loadBulkApplyTemplateRecord(vaultHash, name)
 		if err != nil {
-			httputil.RespondError(w, http.StatusNotFound, err.Error())
+			httputil.RespondError(w, http.StatusNotFound, "not found")
 			return
 		}
 		httputil.RespondJSON(w, http.StatusOK, bulkApplyTemplateResponse(tmpl))
@@ -195,13 +195,13 @@ func (h *Handler) handleBulkApplyTemplate(w http.ResponseWriter, r *http.Request
 		}
 		current, err := h.saveBulkApplyTemplateFile(vaultHash, name, &req)
 		if err != nil {
-			httputil.RespondError(w, http.StatusBadRequest, err.Error())
+			httputil.RespondError(w, http.StatusBadRequest, "invalid request")
 			return
 		}
 		httputil.RespondJSON(w, http.StatusOK, bulkApplyTemplateResponse(current))
 	case http.MethodDelete:
 		if err := h.deleteBulkApplyTemplateFile(vaultHash, name); err != nil {
-			httputil.RespondError(w, http.StatusNotFound, err.Error())
+			httputil.RespondError(w, http.StatusNotFound, "not found")
 			return
 		}
 		httputil.RespondJSON(w, http.StatusOK, map[string]any{
@@ -223,7 +223,7 @@ func (h *Handler) handleBulkApplyTemplatePreview(w http.ResponseWriter, r *http.
 	}
 	tmpl, err := h.loadBulkApplyTemplateRecord(vaultHash, name)
 	if err != nil {
-		httputil.RespondError(w, http.StatusNotFound, err.Error())
+		httputil.RespondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if tmpl.ValidationStatus != "valid" {

--- a/services/vaultcenter/internal/api/bulk/workflows.go
+++ b/services/vaultcenter/internal/api/bulk/workflows.go
@@ -262,7 +262,7 @@ func (h *Handler) proxyAndRecordWorkflow(w http.ResponseWriter, r *http.Request,
 	}
 	statusCode, body, err := h.proxyBulkApplyWorkflow(r, vaultHash, workflowName, endpoint)
 	if err != nil {
-		httputil.RespondError(w, statusCode, err.Error())
+		httputil.RespondError(w, statusCode, "workflow execution failed")
 		return
 	}
 	var payload map[string]any
@@ -313,7 +313,7 @@ func (h *Handler) handleBulkApplyWorkflow(w http.ResponseWriter, r *http.Request
 	}
 	summary, err := h.buildBulkApplyWorkflowSummary(vaultHash, workflowName)
 	if err != nil {
-		httputil.RespondError(w, http.StatusNotFound, err.Error())
+		httputil.RespondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	rows, err := h.deps.DB().ListBulkApplyRuns(vaultHash, workflowName, 10)
@@ -358,7 +358,7 @@ func (h *Handler) handleBulkApplyRun(w http.ResponseWriter, r *http.Request) {
 	}
 	run, err := h.deps.DB().GetBulkApplyRun(runID)
 	if err != nil {
-		httputil.RespondError(w, http.StatusNotFound, err.Error())
+		httputil.RespondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	httputil.RespondJSON(w, http.StatusOK, decodeBulkApplyRunSummary(run))

--- a/services/vaultcenter/internal/api/handle_keycenter.go
+++ b/services/vaultcenter/internal/api/handle_keycenter.go
@@ -151,14 +151,14 @@ func (s *Server) handleKeycenterPromoteToVault(w http.ResponseWriter, r *http.Re
 	}
 	plaintext, err := s.resolveTempRef(tracked)
 	if err != nil {
-		s.respondError(w, http.StatusInternalServerError, "failed to resolve ref: "+err.Error())
+		s.respondError(w, http.StatusInternalServerError, "failed to resolve ref")
 		return
 	}
 
 	// 2. Find agent and decrypt agentDEK
 	agent, err := s.FindAgentRecord(req.VaultHash)
 	if err != nil {
-		s.respondError(w, http.StatusNotFound, "vault not found: "+err.Error())
+		s.respondError(w, http.StatusNotFound, "vault not found")
 		return
 	}
 	agentDEK, err := s.DecryptAgentDEK(agent.DEK, agent.DEKNonce)
@@ -192,7 +192,7 @@ func (s *Server) handleKeycenterPromoteToVault(w http.ResponseWriter, r *http.Re
 		bytes.NewReader(cipherBody),
 	)
 	if err != nil {
-		s.respondError(w, http.StatusBadGateway, "failed to reach vault: "+err.Error())
+		s.respondError(w, http.StatusBadGateway, "failed to reach vault")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_approve_rebind.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_approve_rebind.go
@@ -10,7 +10,7 @@ func (h *Handler) handleAgentApproveRebind(w http.ResponseWriter, r *http.Reques
 	hashOrLabel := r.PathValue("agent")
 	agent, err := h.findAgentRecord(hashOrLabel)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if !agent.RebindRequired && agent.BlockedAt == nil {
@@ -20,7 +20,7 @@ func (h *Handler) handleAgentApproveRebind(w http.ResponseWriter, r *http.Reques
 
 	updated, err := h.deps.DB().ApproveAgentRebind(agent.NodeID)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to approve agent rebind: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to approve agent rebind")
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]interface{}{

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
@@ -153,7 +153,7 @@ func (h *Handler) respondAgentLookupError(w http.ResponseWriter, err error) {
 		respondError(w, stateErr.statusCode, stateErr.message)
 		return
 	}
-	respondError(w, http.StatusNotFound, err.Error())
+	respondError(w, http.StatusNotFound, "not found")
 }
 
 func (h *Handler) fetchAgentCiphertext(agentURL, ref string) (*cipherSecret, error) {

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_configs.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_configs.go
@@ -20,7 +20,7 @@ func (h *Handler) handleAgentConfigs(w http.ResponseWriter, r *http.Request) {
 	req, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, agent.URL()+agentPathConfigs, nil)
 	resp, err := h.deps.HTTPClient().Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_delete_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_delete_config.go
@@ -40,7 +40,7 @@ func (h *Handler) handleAgentDeleteConfig(w http.ResponseWriter, r *http.Request
 	req, _ := http.NewRequestWithContext(r.Context(), http.MethodDelete, joinPath(agent.URL(), agentPathConfigs, key), nil)
 	resp, err := h.deps.HTTPClient().Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_delete_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_delete_secret.go
@@ -29,7 +29,7 @@ func (h *Handler) handleAgentDeleteSecret(w http.ResponseWriter, r *http.Request
 	req, _ := http.NewRequest(http.MethodDelete, joinPath(agent.URL(), agentPathSecrets, name), nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_get_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_get_config.go
@@ -21,7 +21,7 @@ func (h *Handler) handleAgentGetConfig(w http.ResponseWriter, r *http.Request) {
 	req, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, joinPath(agent.URL(), agentPathConfigs, key), nil)
 	resp, err := h.deps.HTTPClient().Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_get_secret.go
@@ -27,7 +27,7 @@ func (h *Handler) handleAgentGetSecret(w http.ResponseWriter, r *http.Request) {
 	agentURL := agent.URL()
 	meta, status, body, err := h.fetchAgentSecretMeta(agentURL, name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if status != http.StatusOK {
@@ -41,14 +41,14 @@ func (h *Handler) handleAgentGetSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
 
 	cipher, err := h.fetchAgentCiphertext(agentURL, meta.Ref)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "failed to fetch ciphertext: "+err.Error())
+		respondError(w, http.StatusBadGateway, "failed to fetch ciphertext")
 		return
 	}
 	plaintext, decErr := crypto.Decrypt(agentDEK, cipher.Ciphertext, cipher.Nonce)

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_heartbeat.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_heartbeat.go
@@ -104,11 +104,11 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		if agent.BlockedAt != nil && agent.BlockReason == "key_version_mismatch" && agent.KeyVersion == req.KeyVersion {
 			if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateAgentState, clearRebindPayload(nodeID)); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to clear blocked rebind state: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to clear blocked rebind state")
 				return
 			}
 			if agent, err = h.deps.DB().GetAgentByNodeID(nodeID); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to reload agent: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to reload agent")
 				return
 			}
 		}
@@ -119,11 +119,11 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 		if agent.RotationRequired {
 			if agent.KeyVersion == req.KeyVersion {
 				if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateAgentState, clearRotationPayload(nodeID)); err != nil {
-					respondError(w, http.StatusInternalServerError, "failed to clear rotation state: "+err.Error())
+					respondError(w, http.StatusInternalServerError, "failed to clear rotation state")
 					return
 				}
 				if agent, err = h.deps.DB().GetAgentByNodeID(nodeID); err != nil {
-					respondError(w, http.StatusInternalServerError, "failed to reload agent: "+err.Error())
+					respondError(w, http.StatusInternalServerError, "failed to reload agent")
 					return
 				}
 			} else {
@@ -136,21 +136,21 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}
 		if agent.RebindRequired && agent.RebindReason == "key_version_mismatch" && agent.KeyVersion == req.KeyVersion {
 			if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateAgentState, clearRebindPayload(nodeID)); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to clear rebind state: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to clear rebind state")
 				return
 			}
 			if agent, err = h.deps.DB().GetAgentByNodeID(nodeID); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to reload agent: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to reload agent")
 				return
 			}
 		}
 		if agent.RebindRequired {
 			if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateAgentState, advanceRebindPayload(nodeID, agent.RebindReason, agent.RetryStage, time.Now().UTC())); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to update rebind state: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to update rebind state")
 				return
 			}
 			if agent, err = h.deps.DB().GetAgentByNodeID(nodeID); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to reload agent: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to reload agent")
 				return
 			}
 			if agent.BlockedAt != nil {
@@ -162,11 +162,11 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}
 		if agent.AgentHash != "" && agent.KeyVersion != 0 && agent.KeyVersion != req.KeyVersion {
 			if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateAgentState, advanceRebindPayload(nodeID, "key_version_mismatch", agent.RetryStage, time.Now().UTC())); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to update rebind state: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to update rebind state")
 				return
 			}
 			if agent, err = h.deps.DB().GetAgentByNodeID(nodeID); err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to reload agent: "+err.Error())
+				respondError(w, http.StatusInternalServerError, "failed to reload agent")
 				return
 			}
 			if agent.BlockedAt != nil {
@@ -231,13 +231,13 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 	// Both new and existing agents use Commit to avoid read-after-write race.
 	if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpsertAgent, upsertPayload); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to upsert agent: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to upsert agent")
 		return
 	}
 
 	agent, err = h.deps.DB().GetAgentByNodeID(nodeID)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to get agent: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to get agent")
 		return
 	}
 
@@ -269,7 +269,7 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := h.deps.DB().UpdateAgentDEK(nodeID, agentHash, encDEK, encNonce); err != nil {
-			respondError(w, http.StatusInternalServerError, "failed to store agent DEK: "+err.Error())
+			respondError(w, http.StatusInternalServerError, "failed to store agent DEK")
 			return
 		}
 

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_migrate.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_migrate.go
@@ -41,7 +41,7 @@ func (h *Handler) handleAgentMigrate(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.deps.HTTPClient().Post(agent.URL()+agentPathRekey, httputil.ContentTypeJSON, bytes.NewReader(rekeyBody))
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_rebind_plan.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_rebind_plan.go
@@ -10,7 +10,7 @@ func (h *Handler) handleAgentRebindPlan(w http.ResponseWriter, r *http.Request) 
 	hashOrLabel := r.PathValue("agent")
 	agent, err := h.findAgentRecord(hashOrLabel)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if !agent.RebindRequired && agent.BlockedAt == nil {

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_resolve.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_resolve.go
@@ -40,7 +40,7 @@ func (h *Handler) handleAgentResolve(w http.ResponseWriter, r *http.Request) {
 	ai := agentToInfo(agent)
 	cipherSecret, err := h.fetchAgentCiphertext(ai.URL(), secretRef)
 	if err != nil {
-		respondError(w, http.StatusNotFound, "failed to fetch secret from agent: "+err.Error())
+		respondError(w, http.StatusNotFound, "failed to fetch secret from agent")
 		return
 	}
 

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_rotate_all.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_rotate_all.go
@@ -11,7 +11,7 @@ func (h *Handler) handleAgentRotateAll(w http.ResponseWriter, r *http.Request) {
 	h.advancePendingRotationsViaChain(r)
 	agents, err := h.deps.DB().ScheduleAllAgentRotations(reason)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to schedule agent rotation: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to schedule agent rotation")
 		return
 	}
 	results := make([]map[string]interface{}, 0, len(agents))

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_config.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_config.go
@@ -45,7 +45,7 @@ func (h *Handler) handleAgentSaveConfig(w http.ResponseWriter, r *http.Request) 
 	req.Header.Set("Content-Type", httputil.ContentTypeJSON)
 	resp, err := h.deps.HTTPClient().Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_configs_bulk.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_configs_bulk.go
@@ -46,7 +46,7 @@ func (h *Handler) handleAgentSaveConfigsBulk(w http.ResponseWriter, r *http.Requ
 	req.Header.Set("Content-Type", httputil.ContentTypeJSON)
 	resp, err := h.deps.HTTPClient().Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_save_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_save_secret.go
@@ -56,7 +56,7 @@ func (h *Handler) handleAgentSaveSecret(w http.ResponseWriter, r *http.Request) 
 	}
 	resp, err := h.deps.HTTPClient().Post(agent.URL()+agentPathCipher, httputil.ContentTypeJSON, bytes.NewReader(body))
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_secret_fields.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_secret_fields.go
@@ -36,7 +36,7 @@ func (h *Handler) handleAgentSaveSecretFields(w http.ResponseWriter, r *http.Req
 
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -50,7 +50,7 @@ func (h *Handler) handleAgentSaveSecretFields(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	if meta.Status != string(refStatusActive) || (meta.Scope != string(refScopeLocal) && meta.Scope != string(refScopeExternal)) {
@@ -92,7 +92,7 @@ func (h *Handler) handleAgentSaveSecretFields(w http.ResponseWriter, r *http.Req
 	})
 	resp, err := h.deps.HTTPClient().Post(agent.URL()+agentPathSecretFields, httputil.ContentTypeJSON, bytes.NewReader(reqBody))
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()
@@ -131,7 +131,7 @@ func (h *Handler) handleAgentGetSecretField(w http.ResponseWriter, r *http.Reque
 
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -145,7 +145,7 @@ func (h *Handler) handleAgentGetSecretField(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 
@@ -155,7 +155,7 @@ func (h *Handler) handleAgentGetSecretField(w http.ResponseWriter, r *http.Reque
 			respondError(w, http.StatusNotFound, "secret field not found")
 			return
 		}
-		respondError(w, http.StatusInternalServerError, "failed to fetch secret field ciphertext: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to fetch secret field ciphertext")
 		return
 	}
 
@@ -201,7 +201,7 @@ func (h *Handler) handleAgentDeleteSecretField(w http.ResponseWriter, r *http.Re
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_secrets.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_secrets.go
@@ -20,7 +20,7 @@ func (h *Handler) handleAgentSecrets(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.deps.HTTPClient().Get(agent.URL() + agentPathSecrets)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	defer resp.Body.Close()

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
@@ -14,7 +14,7 @@ func (h *Handler) handleAgentUnregisterByNode(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteAgent, chain.DeleteAgentPayload{NodeID: nodeID}); err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	log.Printf("agent: unregistered node=%s", nodeID)

--- a/services/vaultcenter/internal/api/hkm/hkm_configs_bulk_set.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_configs_bulk_set.go
@@ -48,7 +48,7 @@ func (h *Handler) handleConfigsBulkSet(w http.ResponseWriter, r *http.Request) {
 	}
 	normScopeVal, normStatusVal, err := normalizeScopeStatus(refFamilyVE, refScope(req.Scope), refStatus(req.Status), refScopeLocal)
 	if err != nil {
-		respondError(w, http.StatusBadRequest, err.Error())
+		respondError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	scope, status := string(normScopeVal), string(normStatusVal)

--- a/services/vaultcenter/internal/api/hkm/hkm_delete_child.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_delete_child.go
@@ -15,7 +15,7 @@ func (h *Handler) handleDeleteChild(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteChild, chain.DeleteChildPayload{NodeID: nodeID}); err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 	log.Printf("Deleted child node: %s", nodeID)

--- a/services/vaultcenter/internal/api/hkm/hkm_federated_rotate.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_federated_rotate.go
@@ -84,7 +84,7 @@ func (h *Handler) handleFederatedRotate(w http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			results = append(results, rotateResult{
 				NodeID: child.NodeID, Label: child.Label,
-				Status: "error", Error: "rekey request failed: " + err.Error(),
+				Status: "error", Error: "rekey request failed",
 			})
 			failCount++
 			continue
@@ -133,7 +133,7 @@ func (h *Handler) handleFederatedRotate(w http.ResponseWriter, r *http.Request) 
 				NodeID: child.NodeID, Label: child.Label,
 				Status: "partial", OldVersion: child.Version, NewVersion: newVersion,
 				SecretsUpdated: rekeyResp.SecretsUpdated,
-				Error:          "child rekeyed but parent record update failed: " + err.Error(),
+				Error:          "child rekeyed but parent record update failed",
 			})
 			failCount++
 			continue

--- a/services/vaultcenter/internal/api/hkm/hkm_global_function_run.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_global_function_run.go
@@ -213,7 +213,7 @@ func (h *Handler) handleGlobalFunctionRun(w http.ResponseWriter, r *http.Request
 	}
 	fn, err := h.deps.DB().GetGlobalFunction(name)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 
@@ -233,13 +233,13 @@ func (h *Handler) handleGlobalFunctionRun(w http.ResponseWriter, r *http.Request
 
 	rendered, err := h.renderGlobalFunctionCommand(fn)
 	if err != nil {
-		respondError(w, http.StatusBadRequest, err.Error())
+		respondError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 
 	env, appliedEnvKeys, err := h.buildGlobalFunctionRunEnv(req)
 	if err != nil {
-		respondError(w, http.StatusBadRequest, err.Error())
+		respondError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 

--- a/services/vaultcenter/internal/api/hkm/hkm_global_functions.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_global_functions.go
@@ -39,7 +39,7 @@ func (h *Handler) handleGlobalFunctions(w http.ResponseWriter, r *http.Request) 
 			Command:      req.Command,
 			VarsJSON:     req.VarsJSON,
 		}); err != nil {
-			respondError(w, http.StatusBadRequest, err.Error())
+			respondError(w, http.StatusBadRequest, "invalid request")
 			return
 		}
 		respondJSON(w, http.StatusOK, req)
@@ -58,13 +58,13 @@ func (h *Handler) handleGlobalFunction(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		fn, err := h.deps.DB().GetGlobalFunction(name)
 		if err != nil {
-			respondError(w, http.StatusNotFound, err.Error())
+			respondError(w, http.StatusNotFound, "not found")
 			return
 		}
 		respondJSON(w, http.StatusOK, fn)
 	case http.MethodDelete:
 		if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteGlobalFunction, chain.DeleteGlobalFunctionPayload{Name: name}); err != nil {
-			respondError(w, http.StatusNotFound, err.Error())
+			respondError(w, http.StatusNotFound, "not found")
 			return
 		}
 		respondJSON(w, http.StatusOK, map[string]any{"deleted": name})

--- a/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_ref_tracking.go
@@ -173,12 +173,12 @@ func (h *Handler) handleTrackedRefSync(w http.ResponseWriter, r *http.Request) {
 		}
 		agent, err = h.findAgent(target)
 		if err != nil {
-			respondError(w, http.StatusBadRequest, err.Error())
+			respondError(w, http.StatusBadRequest, "invalid request")
 			return
 		}
 	}
 	if err := h.syncTrackedRef(r.Context(), req.Ref, req.PreviousRef, req.Version, resolvedStatus, agent.AgentHash); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to sync tracked ref: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to sync tracked ref")
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]interface{}{

--- a/services/vaultcenter/internal/api/hkm/hkm_register.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_register.go
@@ -72,12 +72,12 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		URL:     req.URL,
 		Version: 1,
 	}); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to register child: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to register child")
 		return
 	}
 	// DEK delivery via direct DB write (never on chain)
 	if err := h.deps.DB().UpdateChildDEK(nodeID, encryptedChildDEK, childNonce, 1); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to save child DEK: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to save child DEK")
 		return
 	}
 

--- a/services/vaultcenter/internal/api/hkm/hkm_rekey.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_rekey.go
@@ -60,7 +60,7 @@ func (h *Handler) handleRekey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.deps.DB().UpdateNodeDEK(encDEK, encNonce, req.Version); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to update node DEK: "+err.Error())
+		respondError(w, http.StatusInternalServerError, "failed to update node DEK")
 		return
 	}
 

--- a/services/vaultcenter/internal/api/hkm/hkm_vault_keys.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_vault_keys.go
@@ -378,7 +378,7 @@ func (h *Handler) handleVaultKeyMeta(w http.ResponseWriter, r *http.Request) {
 
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -392,7 +392,7 @@ func (h *Handler) handleVaultKeyMeta(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
@@ -423,7 +423,7 @@ func (h *Handler) handleVaultKeyUsage(w http.ResponseWriter, r *http.Request) {
 	}
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -437,7 +437,7 @@ func (h *Handler) handleVaultKeyUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
@@ -479,7 +479,7 @@ func (h *Handler) handleVaultKeyBindings(w http.ResponseWriter, r *http.Request)
 	}
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -493,7 +493,7 @@ func (h *Handler) handleVaultKeyBindings(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
@@ -534,7 +534,7 @@ func (h *Handler) handleVaultKeyBindingSave(w http.ResponseWriter, r *http.Reque
 	}
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -548,7 +548,7 @@ func (h *Handler) handleVaultKeyBindingSave(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
@@ -763,7 +763,7 @@ func (h *Handler) handleVaultKeyAudit(w http.ResponseWriter, r *http.Request) {
 	}
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -777,7 +777,7 @@ func (h *Handler) handleVaultKeyAudit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
@@ -823,7 +823,7 @@ func (h *Handler) handleVaultKeyBindingDelete(w http.ResponseWriter, r *http.Req
 	}
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -837,7 +837,7 @@ func (h *Handler) handleVaultKeyBindingDelete(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	row, err := h.deps.DB().GetBinding(bindingID)
@@ -872,7 +872,7 @@ func (h *Handler) lookupVaultKeyForBindingWrite(ctx context.Context, w http.Resp
 	}
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return nil, nil, false
 	}
 	if statusCode != http.StatusOK {
@@ -886,7 +886,7 @@ func (h *Handler) lookupVaultKeyForBindingWrite(ctx context.Context, w http.Resp
 		return nil, nil, false
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return nil, nil, false
 	}
 	_ = h.upsertTrackedRef(ctx, meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)
@@ -1063,7 +1063,7 @@ func (h *Handler) handleVaultKeyFields(w http.ResponseWriter, r *http.Request) {
 
 	meta, statusCode, body, err := h.fetchAgentSecretMeta(agent.URL(), name)
 	if err != nil {
-		respondError(w, http.StatusBadGateway, "agent unreachable: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent unreachable")
 		return
 	}
 	if statusCode != http.StatusOK {
@@ -1077,7 +1077,7 @@ func (h *Handler) handleVaultKeyFields(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := normalizeMeta(meta); err != nil {
-		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope: "+err.Error())
+		respondError(w, http.StatusBadGateway, "agent returned unsupported secret scope")
 		return
 	}
 	_ = h.upsertTrackedRef(r.Context(), meta.Token, agent.KeyVersion, refStatus(meta.Status), agent.AgentHash)

--- a/services/vaultcenter/internal/api/local_configs.go
+++ b/services/vaultcenter/internal/api/local_configs.go
@@ -68,7 +68,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 	config, err := s.db.GetConfig(key)
 	if err != nil {
-		s.respondError(w, http.StatusNotFound, err.Error())
+		s.respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 
@@ -112,7 +112,7 @@ func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := s.SubmitTx(r.Context(), chain.TxSetConfig, chain.SetConfigPayload{Key: req.Key, Value: *req.Value}); err != nil {
-		s.respondError(w, http.StatusInternalServerError, "failed to save config: "+err.Error())
+		s.respondError(w, http.StatusInternalServerError, "failed to save config")
 		return
 	}
 
@@ -149,7 +149,7 @@ func (s *Server) handleSaveConfigsBulk(w http.ResponseWriter, r *http.Request) {
 
 	for key, value := range req.Configs {
 		if _, err := s.SubmitTx(r.Context(), chain.TxSetConfig, chain.SetConfigPayload{Key: key, Value: value}); err != nil {
-			s.respondError(w, http.StatusInternalServerError, "failed to save configs: "+err.Error())
+			s.respondError(w, http.StatusInternalServerError, "failed to save configs")
 			return
 		}
 	}
@@ -172,7 +172,7 @@ func (s *Server) handleDeleteConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := s.SubmitTx(r.Context(), chain.TxDeleteConfig, chain.DeleteConfigPayload{Key: key}); err != nil {
-		s.respondError(w, http.StatusNotFound, err.Error())
+		s.respondError(w, http.StatusNotFound, "not found")
 		return
 	}
 


### PR DESCRIPTION
## Summary
Replace 91 raw `err.Error()` exposures in vaultcenter HTTP responses across 32 files with generic messages. Combined with PR #179 (localvault), no internal error details are now leaked to any HTTP client.

## Test plan
- [x] `go build ./...` passes
- [x] Zero `err.Error()` in HTTP responses (verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)