### PR TITLE
ci: add UI build sync check to prevent stale ui_dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: services/vaultcenter/go.mod
+      - name: Check UI build is up to date
+        run: |
+          cd services/vaultcenter/frontend/admin
+          npm ci --silent
+          npm run build
+          if ! diff -qr dist/ ../../internal/api/admin/ui_dist/ > /dev/null 2>&1; then
+            echo "::error::ui_dist is out of date — run 'npm run build' in frontend/admin and copy dist/ to ui_dist/"
+            exit 1
+          fi
       - name: Lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -184,6 +184,20 @@ if [[ -n "$composite_key" || -n "$composite_key2" ]]; then
   found=1
 fi
 
+# 11. 프론트엔드 소스와 ui_dist 빌드 동기화 체크
+UI_SRC="services/vaultcenter/frontend/admin/src"
+UI_DIST="services/vaultcenter/internal/api/admin/ui_dist"
+if [[ -d "$UI_SRC" && -d "$UI_DIST" ]]; then
+  src_newest=$(find "$UI_SRC" -name "*.js" -o -name "*.vue" -o -name "*.css" 2>/dev/null | xargs stat -f %m 2>/dev/null | sort -rn | head -1)
+  dist_newest=$(find "$UI_DIST" -name "*.js" -o -name "*.css" -o -name "*.html" 2>/dev/null | xargs stat -f %m 2>/dev/null | sort -rn | head -1)
+  if [[ -n "$src_newest" && -n "$dist_newest" && "$src_newest" -gt "$dist_newest" ]]; then
+    echo "❌ UI 빌드 오래됨: frontend/admin/src가 ui_dist보다 최신입니다"
+    echo "   cd services/vaultcenter/frontend/admin && npm run build"
+    echo "   cp -r dist/* ../internal/api/admin/ui_dist/"
+    found=1
+  fi
+fi
+
 if [[ $found -eq 1 ]]; then
   echo ""
   echo "기본값은 .env.example에 추가하세요."


### PR DESCRIPTION
## Summary
Prevent stale `ui_dist` from being deployed (like the missing 키센터 menu issue):

- **pre-commit hook**: Fails if `frontend/admin/src` files are newer than `ui_dist` build
- **CI step**: Rebuilds UI with `npm run build` and diffs against `ui_dist`, fails if different

## Test plan
- [x] pre-commit detects stale ui_dist
- [ ] CI catches out-of-sync builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)