### PR TITLE
fix: default install dir ~/veilkey

### DIFF
--- a/scripts/install-veil-mac.sh
+++ b/scripts/install-veil-mac.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 BIN_DIR="${VEILKEY_BIN_DIR:-$HOME/.local/bin}"
 VEILKEY_URL="${VEILKEY_URL:-https://localhost:11181}"
-INSTALL_DIR="${VEILKEY_INSTALL_DIR:-$HOME/.veilkey}"
+INSTALL_DIR="${VEILKEY_INSTALL_DIR:-$HOME/veilkey}"
 REPO_URL="https://github.com/veilkey/veilkey-selfhosted.git"
 
 echo "=== VeilKey installer (macOS) ==="


### PR DESCRIPTION
~/.veilkey → ~/veilkey, .veilkey/.veilkey 이중 경로 방지