### PR TITLE
feat: add veil localvault command for one-click setup

### DIFF
--- a/scripts/install-localvault.sh
+++ b/scripts/install-localvault.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+set -euo pipefail
+
+# VeilKey LocalVault one-liner installer
+# Usage: curl -sL .../install-localvault.sh | bash
+#
+# 현재 디렉토리에 localvault를 설치합니다.
+# 이미 설치되어 있으면 업데이트 후 재시작합니다.
+#
+# Options (env vars):
+#   VEILKEY_CENTER_URL=http://10.87.40.2:10181   vaultcenter 주소
+#   VEILKEY_PORT=10180                            localvault 포트
+#   VEILKEY_NAME=my-vault                         볼트 이름 (기본: hostname)
+#
+# ⚠️  이 스크립트의 실행으로 발생하는 모든 결과에 대한
+#     귀책사유는 실행자 본인에게 있습니다.
+
+INSTALL_DIR="$(pwd)/.localvault"
+DATA_DIR="$INSTALL_DIR/data"
+PID_FILE="$INSTALL_DIR/localvault.pid"
+LOG_FILE="$INSTALL_DIR/localvault.log"
+BIN="$INSTALL_DIR/veilkey-localvault"
+ENV_FILE="$INSTALL_DIR/.env"
+
+PORT="${VEILKEY_PORT:-10180}"
+CENTER_URL="${VEILKEY_CENTER_URL:-}"
+VAULT_NAME="${VEILKEY_NAME:-$(hostname)}"
+
+REPO_URL="https://github.com/veilkey/veilkey-selfhosted.git"
+REPO_DIR="$INSTALL_DIR/src"
+
+echo "=== VeilKey LocalVault Installer ==="
+echo "설치 경로: $INSTALL_DIR"
+echo "포트:      $PORT"
+echo "볼트 이름: $VAULT_NAME"
+[[ -n "$CENTER_URL" ]] && echo "센터 URL:  $CENTER_URL"
+echo ""
+
+# 0. Check Go
+if ! command -v go &>/dev/null; then
+    echo "ERROR: Go가 설치되어 있지 않습니다."
+    echo "  brew install go  또는  https://go.dev/dl/"
+    exit 1
+fi
+GO_VER=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | sed 's/go//')
+echo "[0/5] Go $GO_VER OK"
+
+# 1. Clone or update source
+mkdir -p "$INSTALL_DIR"
+if [ -d "$REPO_DIR/.git" ]; then
+    echo "[1/5] 소스 업데이트..."
+    cd "$REPO_DIR"
+    git pull --quiet
+else
+    echo "[1/5] 소스 다운로드..."
+    git clone --quiet --depth 1 "$REPO_URL" "$REPO_DIR"
+fi
+
+# 2. Build
+echo "[2/5] 빌드 중..."
+cd "$REPO_DIR/services/localvault"
+CGO_ENABLED=1 go build -o "$BIN" ./cmd
+echo "  빌드 완료: $BIN"
+
+# 3. Setup data directory and env
+echo "[3/5] 데이터 디렉토리 설정..."
+mkdir -p "$DATA_DIR"
+
+cat > "$ENV_FILE" << ENVEOF
+VEILKEY_DB_PATH=$DATA_DIR/veilkey.db
+VEILKEY_ADDR=:$PORT
+VEILKEY_TRUSTED_IPS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1
+VEILKEY_MODE=root
+VEILKEY_VAULT_NAME=$VAULT_NAME
+ENVEOF
+
+if [[ -n "$CENTER_URL" ]]; then
+    echo "VEILKEY_VAULTCENTER_URL=$CENTER_URL" >> "$ENV_FILE"
+fi
+
+# Password file for auto-unlock
+PW_FILE="$DATA_DIR/password"
+if [ ! -f "$PW_FILE" ]; then
+    # Generate random password for first-time init
+    openssl rand -base64 24 > "$PW_FILE"
+    chmod 600 "$PW_FILE"
+    echo "  비밀번호 생성됨: $PW_FILE"
+fi
+echo "VEILKEY_PASSWORD_FILE=$PW_FILE" >> "$ENV_FILE"
+echo "  환경 설정: $ENV_FILE"
+
+# 4. Stop existing process if running
+echo "[4/5] 기존 프로세스 확인..."
+if [ -f "$PID_FILE" ]; then
+    OLD_PID=$(cat "$PID_FILE" 2>/dev/null || echo "")
+    if [[ -n "$OLD_PID" ]] && kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "  기존 프로세스 종료 (PID: $OLD_PID)"
+        kill "$OLD_PID" 2>/dev/null || true
+        sleep 2
+    fi
+    rm -f "$PID_FILE"
+fi
+
+# 5. Start
+echo "[5/5] LocalVault 시작..."
+cd "$INSTALL_DIR"
+set -a; source "$ENV_FILE"; set +a
+nohup "$BIN" server > "$LOG_FILE" 2>&1 &
+echo $! > "$PID_FILE"
+NEW_PID=$(cat "$PID_FILE")
+
+# Wait for startup
+sleep 2
+if kill -0 "$NEW_PID" 2>/dev/null; then
+    # Health check
+    if curl -s "http://localhost:$PORT/health" | grep -q '"ok"'; then
+        echo ""
+        echo "=== 설치 완료 ==="
+        echo ""
+        echo "  상태:    http://localhost:$PORT/health"
+        echo "  PID:     $NEW_PID"
+        echo "  로그:    $LOG_FILE"
+        echo "  데이터:  $DATA_DIR"
+        [[ -n "$CENTER_URL" ]] && echo "  센터:    $CENTER_URL (heartbeat 자동 연동)"
+        echo ""
+        echo "관리 명령:"
+        echo "  tail -f $LOG_FILE          # 로그 보기"
+        echo "  kill \$(cat $PID_FILE)      # 중지"
+        echo "  curl -sL ... | bash         # 업데이트 (같은 명령 재실행)"
+    else
+        echo ""
+        echo "⚠️  프로세스는 실행 중이지만 health check 실패"
+        echo "  로그 확인: tail -20 $LOG_FILE"
+    fi
+else
+    echo ""
+    echo "❌ 시작 실패"
+    echo "  로그 확인: tail -20 $LOG_FILE"
+    tail -20 "$LOG_FILE"
+    exit 1
+fi

--- a/services/veil-cli/src/bin/veil.rs
+++ b/services/veil-cli/src/bin/veil.rs
@@ -77,6 +77,88 @@ export PS1="\[\033[36m\](VEIL)\[\033[0m\] \h:\W \u\$ "
             full.extend_from_slice(&args[1..]);
             exec_replace(&cli_bin, &full);
         }
+        "localvault" => {
+            let sub = args.get(1).map(|s| s.as_str()).unwrap_or("init");
+            match sub {
+                "init" | "update" => {
+                    let center_url = env::var("VEILKEY_VAULTCENTER_URL")
+                        .or_else(|_| env::var("VEILKEY_KEYCENTER_URL"))
+                        .unwrap_or_default();
+                    let lv_url = env::var("VEILKEY_LOCALVAULT_URL").unwrap_or_default();
+                    // Extract port from LOCALVAULT_URL if set, else default
+                    let port = lv_url
+                        .rsplit(':')
+                        .next()
+                        .and_then(|p| p.trim_end_matches('/').parse::<u16>().ok())
+                        .unwrap_or(10180);
+
+                    if center_url.is_empty() {
+                        eprintln!("veil localvault: VEILKEY_VAULTCENTER_URL is not set");
+                        eprintln!("  Set it in your shell or ~/.veilkey.yml");
+                        process::exit(1);
+                    }
+
+                    let gist_url = "https://gist.githubusercontent.com/dalsoop/LOCALVAULT_GIST_ID/raw/install-localvault.sh";
+                    let script = format!(
+                        "VEILKEY_CENTER_URL='{}' VEILKEY_PORT='{}' curl -sL '{}?{}' | bash",
+                        center_url,
+                        port,
+                        gist_url,
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs()
+                    );
+                    let status = process::Command::new("bash")
+                        .arg("-c")
+                        .arg(&script)
+                        .status()
+                        .unwrap_or_else(|e| {
+                            eprintln!("veil localvault: failed to run installer: {}", e);
+                            process::exit(1);
+                        });
+                    process::exit(status.code().unwrap_or(1));
+                }
+                "stop" => {
+                    let pid_file = format!("{}/.localvault/localvault.pid", env::current_dir().unwrap().display());
+                    match std::fs::read_to_string(&pid_file) {
+                        Ok(pid) => {
+                            let pid = pid.trim();
+                            let _ = process::Command::new("kill").arg(pid).status();
+                            let _ = std::fs::remove_file(&pid_file);
+                            println!("localvault stopped (PID: {})", pid);
+                        }
+                        Err(_) => eprintln!("localvault is not running (no pid file)"),
+                    }
+                }
+                "log" | "logs" => {
+                    let log_file = format!("{}/.localvault/localvault.log", env::current_dir().unwrap().display());
+                    exec_replace("tail", &["-f".to_string(), log_file]);
+                }
+                "status" => {
+                    let lv_url = env::var("VEILKEY_LOCALVAULT_URL")
+                        .unwrap_or_else(|_| "http://localhost:10180".to_string());
+                    let health_url = format!("{}/health", lv_url.trim_end_matches('/'));
+                    let status = process::Command::new("curl")
+                        .args(["-s", &health_url])
+                        .status();
+                    if status.map(|s| s.success()).unwrap_or(false) {
+                        println!();
+                    } else {
+                        eprintln!("localvault is not reachable at {}", health_url);
+                        process::exit(1);
+                    }
+                }
+                _ => {
+                    eprintln!("Usage:");
+                    eprintln!("  veil localvault [init]    Install/update localvault in current directory");
+                    eprintln!("  veil localvault stop      Stop localvault");
+                    eprintln!("  veil localvault log       Tail localvault logs");
+                    eprintln!("  veil localvault status    Check localvault health");
+                    process::exit(1);
+                }
+            }
+        }
         "help" | "-h" | "--help" => {
             println!("Usage:");
             println!("  veil                     Enter protected session (PTY masking)");
@@ -84,6 +166,10 @@ export PS1="\[\033[36m\](VEIL)\[\033[0m\] \h:\W \u\$ "
             println!("  veil resolve <VK:ref>    Resolve a VK reference");
             println!("  veil exec <command...>   Resolve VK refs in args and execute");
             println!("  veil scan [file...]      Scan files for secrets");
+            println!("  veil localvault [init]   Install/update localvault here");
+            println!("  veil localvault stop     Stop localvault");
+            println!("  veil localvault log      Tail logs");
+            println!("  veil localvault status   Health check");
             println!("  veil help                Show this help");
         }
         _ => {


### PR DESCRIPTION
## Summary
Add `veil localvault` subcommand for one-click localvault installation and management.

### Commands
```bash
veil localvault init     # Install, build, start in current dir (.localvault/)
veil localvault stop     # Stop running localvault
veil localvault log      # Tail logs
veil localvault status   # Health check
veil localvault update   # Pull latest + rebuild + restart
```

### How it works
1. `veil localvault init` reads `VEILKEY_VAULTCENTER_URL` from env
2. Runs gist installer → clones source → Go build → starts localvault
3. First heartbeat auto-registers with vaultcenter (trusted IP, no token needed)
4. Re-running = update (git pull → rebuild → restart)

### Files
- `services/veil-cli/src/bin/veil.rs` — localvault subcommand
- `scripts/install-localvault.sh` — standalone installer script (gist-ready)

## Test plan
- [x] `cargo build` passes
- [ ] `veil localvault init` creates .localvault/ and starts server
- [ ] Heartbeat registers with vaultcenter automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)