### PR TITLE
fix: set localvault gist ID + add install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,34 @@ source ~/.bashrc
 veil
 ```
 
+### LocalVault 별도 설치
+
+이미 VaultCenter가 돌고 있는 환경에서 LocalVault만 추가:
+
+```bash
+curl -sL "https://gist.githubusercontent.com/dalsoop/11e00346263678340189cdfdc79644b5/raw/install-localvault.sh?$(date +%s)" | \
+  VEILKEY_CENTER_URL=https://your-vaultcenter:11181 bash
+```
+
+현재 디렉토리에 `.localvault/`를 만들고 Docker로 실행합니다. heartbeat로 VaultCenter에 자동 등록됩니다.
+
+```bash
+# 커스텀 이름/포트
+VEILKEY_CENTER_URL=https://10.0.0.1:11181 VEILKEY_HOST_PORT=11182 VEILKEY_NAME=dev-vault \
+  curl -sL "...?$(date +%s)" | bash
+
+# 업데이트 (같은 명령 재실행)
+curl -sL "...?$(date +%s)" | VEILKEY_CENTER_URL=... bash
+```
+
+`veil` CLI에서도 가능:
+```bash
+veil localvault init      # 설치 + 시작
+veil localvault stop      # 중지
+veil localvault log       # 로그
+veil localvault status    # health check
+```
+
 ### Setup (공통)
 
 설치 후 VaultCenter 셋업:

--- a/services/veil-cli/src/bin/veil.rs
+++ b/services/veil-cli/src/bin/veil.rs
@@ -98,7 +98,7 @@ export PS1="\[\033[36m\](VEIL)\[\033[0m\] \h:\W \u\$ "
                         process::exit(1);
                     }
 
-                    let gist_url = "https://gist.githubusercontent.com/dalsoop/LOCALVAULT_GIST_ID/raw/install-localvault.sh";
+                    let gist_url = "https://gist.githubusercontent.com/dalsoop/11e00346263678340189cdfdc79644b5/raw/install-localvault.sh";
                     let script = format!(
                         "VEILKEY_CENTER_URL='{}' VEILKEY_PORT='{}' curl -sL '{}?{}' | bash",
                         center_url,


### PR DESCRIPTION
## Summary
- Replace `LOCALVAULT_GIST_ID` placeholder in veil.rs with actual gist ID
- Add LocalVault standalone install section to README.md

Gist: https://gist.github.com/dalsoop/11e00346263678340189cdfdc79644b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)