### PR TITLE
fix: smoke CI healthcheck timeout

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Start VeilKey services
         run: |
-          # Start vaultcenter only, wait for health
+          # Start all services with --no-deps to skip depends_on healthcheck
           docker compose up -d --no-deps vaultcenter
           echo "Waiting for VaultCenter..."
           for i in $(seq 1 90); do
@@ -55,8 +55,8 @@ jobs:
             fi
             sleep 3
           done
-          # Start dependents (images already built, healthcheck should pass now)
-          docker compose up -d
+          # Start localvault and veil independently (skip depends_on healthcheck)
+          docker compose up -d --no-deps localvault veil
 
       - name: Unlock VaultCenter
         run: |


### PR DESCRIPTION
## Summary

Fix smoke test CI failing at `Start VeilKey services` step.

## Problem

`docker compose up -d` re-evaluates `depends_on` healthcheck even when images are pre-built. VaultCenter in `setup` state doesn't pass the healthcheck (`curl -fsk .../health` returns non-zero for `{"status":"setup"}`), causing localvault/veil to fail with "dependency failed to start: unhealthy".

## Fix

Use `--no-deps` for all service starts. VaultCenter is confirmed healthy via manual polling before starting dependents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)