### PR TITLE
fix: bulk-apply resolve secret by name→ref lookup

### DIFF
--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -277,8 +277,22 @@ func (s *Server) ResolveTemplateValue(vaultHash, kind, name string) (string, boo
 }
 
 func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce []byte, name string) (string, bool) {
-	// Try to fetch the ciphertext directly and decrypt with the agent DEK.
-	_, ciphertext, nonce, err := s.FetchAgentCiphertext(agentURL, name)
+	// Resolve name → ref via agent's secret meta endpoint, then fetch ciphertext by ref.
+	ref := name
+	if metaResp, metaErr := s.httpClient.Get(httputil.JoinPath(agentURL, "/api/secrets/meta", name)); metaErr == nil {
+		defer metaResp.Body.Close()
+		if metaResp.StatusCode == 200 {
+			var meta struct {
+				Ref string `json:"ref"`
+			}
+			if json.NewDecoder(metaResp.Body).Decode(&meta) == nil && strings.TrimSpace(meta.Ref) != "" {
+				ref = strings.TrimSpace(meta.Ref)
+			}
+		}
+	}
+
+	// Fetch ciphertext by ref and decrypt with the agent DEK.
+	_, ciphertext, nonce, err := s.FetchAgentCiphertext(agentURL, ref)
 	if err == nil {
 		agentDEK, dekErr := s.DecryptAgentDEK(encDEK, encNonce)
 		if dekErr == nil {
@@ -288,7 +302,20 @@ func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce [
 			}
 		}
 	}
-	// Fall back to the agent's own resolve endpoint.
+	// Fall back: try with original name as ref (backward compatibility).
+	if ref != name {
+		_, ciphertext2, nonce2, err2 := s.FetchAgentCiphertext(agentURL, name)
+		if err2 == nil {
+			agentDEK, dekErr := s.DecryptAgentDEK(encDEK, encNonce)
+			if dekErr == nil {
+				plaintext, decErr := crypto.Decrypt(agentDEK, ciphertext2, nonce2)
+				if decErr == nil {
+					return string(plaintext), true
+				}
+			}
+		}
+	}
+	// Last resort: agent's own resolve endpoint.
 	resp, resolveErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathResolve, name))
 	if resolveErr != nil {
 		return "", false

--- a/services/vaultcenter/internal/api/bulk/workflows.go
+++ b/services/vaultcenter/internal/api/bulk/workflows.go
@@ -262,7 +262,7 @@ func (h *Handler) proxyAndRecordWorkflow(w http.ResponseWriter, r *http.Request,
 	}
 	statusCode, body, err := h.proxyBulkApplyWorkflow(r, vaultHash, workflowName, endpoint)
 	if err != nil {
-		httputil.RespondError(w, statusCode, "workflow execution failed")
+		httputil.RespondError(w, statusCode, fmt.Sprintf("workflow execution failed: %v", err))
 		return
 	}
 	var payload map[string]any


### PR DESCRIPTION
## Summary

Fix bulk-apply workflow failing with "workflow execution failed" when resolving `{{ VK.SECRET_NAME }}` placeholders.

## Root cause

`FetchAgentCiphertext` was called with the secret **name** (e.g. `GITLAB_ROOT_PASSWORD`), but LocalVault's `/api/cipher/{ref}` endpoint only accepts the **ref** (e.g. `d6e80e3b`).

## Fix

1. Call `/api/secrets/meta/{name}` first to get the ref
2. Then call `/api/cipher/{ref}` with the resolved ref
3. Fallback chain: meta→cipher → name-as-ref → agent resolve endpoint

Also: include `err.Error()` in the workflow error response for debugging.

## Tested

```
POST /api/vaults/7ef29030/bulk-apply/workflows/deploy-credentials/run → applied
cat /etc/veilkey/credentials.env →
  GITLAB_ROOT_PASSWORD=Ghdrhkdgh1@
  LXC_ROOT_PASSWORD=Ghdrhkdgh1@
```

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)