### PR TITLE
chore: add missing service READMEs + smoke disclaimer

### DIFF
--- a/services/vaultcenter/README.md
+++ b/services/vaultcenter/README.md
@@ -1,0 +1,32 @@
+# VaultCenter
+
+Central management server for VeilKey. Handles encryption keys (agentDEK), admin UI, CometBFT blockchain audit, and secret promotion.
+
+## Build
+
+```bash
+CGO_ENABLED=1 go build -o veilkey-vaultcenter ./cmd
+```
+
+## Docker
+
+```bash
+docker compose up --build -d vaultcenter
+```
+
+## Key responsibilities
+
+- Master password → KEK derivation → DEK management
+- Admin web UI (Vue.js SPA)
+- Keycenter: temp ref CRUD, promote to vault
+- Registration token management for LocalVault onboarding
+- CometBFT ABCI chain layer for audit trail
+- Bulk-apply: template rendering + workflow proxy to LocalVault
+
+## API
+
+See [docs/setup/](../../docs/setup/README.md) for usage guides.
+
+## Environment
+
+See [docs/setup/env-vars.md](../../docs/setup/env-vars.md).

--- a/services/veil-cli/README.md
+++ b/services/veil-cli/README.md
@@ -1,0 +1,46 @@
+# veil-cli
+
+Rust CLI tools for VeilKey. Provides PTY-level bidirectional masking so AI coding tools never see your secrets.
+
+## Binaries
+
+| Binary | Purpose |
+|--------|---------|
+| `veil` | Enter protected PTY session with masking |
+| `veilkey` | State control, crypto, policy |
+| `veilkey-cli` | scan, filter, wrap-pty, exec, resolve, status |
+| `veilkey-session-config` | Load TOML session configuration |
+
+## Build
+
+```bash
+cargo build --release
+```
+
+## Usage
+
+```bash
+# Enter protected shell
+veil
+
+# Resolve a secret
+veilkey-cli resolve VK:LOCAL:xxxxx
+
+# Execute with ref replacement
+veilkey-cli exec echo VK:LOCAL:xxxxx
+
+# Scan for secrets
+veilkey-cli scan file.env
+
+# Check connection
+veilkey-cli status
+```
+
+## Install
+
+- macOS: [`install/macos/veil-cli/`](../../install/macos/veil-cli/install.md)
+- Linux: [`install/common/install-veil-cli.sh`](../../install/common/install-veil-cli.md)
+
+## Documentation
+
+See [docs/setup/veil-cli/usage.md](../../docs/setup/veil-cli/usage.md).

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 # Smoke test runner
 # Runs specified test suites and saves results to tests/smoke/results/
 #
+# ⚠️  이 스크립트의 실행으로 발생하는 모든 결과에 대한
+#     귀책사유는 실행자 본인에게 있습니다.
+#
 # Usage:
 #   bash tests/smoke/run.sh <suite> [suite...]
 #


### PR DESCRIPTION
Add README.md for vaultcenter and veil-cli services. Add disclaimer to smoke test runner.