### PR TITLE
chore: document VEIL_WORK_DIR in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ VEILKEY_AGENT_SCHEME=https
 LOCALVAULT_LABEL=localvault-01
 # CometBFT persistent peers (set after vaultcenter starts — nodeID@host:port)
 LOCALVAULT_CHAIN_PEERS=
+
+# veil CLI container: host directory to mount as /host (default: /Users for macOS)
+# Linux: set to /home or /root
+# VEIL_WORK_DIR=/home


### PR DESCRIPTION
Add comment for Linux users who need to override the macOS default /Users mount.