### PR TITLE
feat: Rust installer CLI + CI health check fix

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -112,6 +112,16 @@ jobs:
 
       - name: Create test secret
         run: |
+          # Wait for VaultCenter to be ready
+          for i in $(seq 1 10); do
+            if curl -sk --max-time 3 https://localhost:11181/health 2>/dev/null | grep -q '"ok"'; then
+              break
+            fi
+            echo "  Waiting for VaultCenter... [$i]"
+            sleep 3
+          done
+          echo "VaultCenter: $(curl -sk https://localhost:11181/health 2>/dev/null)"
+
           # Admin login — extract session cookie from Set-Cookie header
           LOGIN_HEADERS=$(curl -sk -X POST https://localhost:11181/api/admin/login \
             -H 'Content-Type: application/json' \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,12 +173,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -245,6 +351,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -392,6 +504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,7 +737,7 @@ dependencies = [
  "getrandom 0.2.17",
  "libc",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -813,6 +937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "veil-cli-rs"
 version = "0.1.0"
 dependencies = [
@@ -996,6 +1132,14 @@ dependencies = [
  "toml",
  "ureq",
  "urlencoding",
+]
+
+[[package]]
+name = "veilkey-installer"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "colored",
 ]
 
 [[package]]
@@ -1164,6 +1308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "services/veil-cli",
+    "services/installer",
 ]
 resolver = "2"

--- a/install/proxmox-lxc-debian/install-localvault.sh
+++ b/install/proxmox-lxc-debian/install-localvault.sh
@@ -105,7 +105,10 @@ else
         -keyout "$TLS_DIR/key.pem" -out "$TLS_DIR/cert.pem" \
         -days 3650 -nodes \
         -subj "/CN=$(hostname)" \
-        -addext "subjectAltName=$SAN" 2>/dev/null
+        -addext "subjectAltName=$SAN" \
+        -addext "basicConstraints=critical,CA:FALSE" \
+        -addext "keyUsage=digitalSignature,keyEncipherment" \
+        -addext "extendedKeyUsage=serverAuth" 2>/dev/null
     echo "  Certificate generated (SAN: $SAN)"
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+# VeilKey bootstrap installer
+# Downloads the veilkey-installer binary and runs platform detection.
+#
+# Usage: curl -sL https://veilkey.dev/install | bash
+#
+# ⚠️  이 스크립트의 실행으로 발생하는 모든 결과에 대한
+#     귀책사유는 실행자 본인에게 있습니다.
+
+REPO="veilkey/veilkey-selfhosted"
+BIN_NAME="veilkey-installer"
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64) ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="aarch64" ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+case "$OS" in
+    linux) TARGET="${BIN_NAME}-${OS}-${ARCH}" ;;
+    darwin) TARGET="${BIN_NAME}-${OS}-${ARCH}" ;;
+    *) echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+echo "=== VeilKey Installer ==="
+echo ""
+echo "  OS:   $OS"
+echo "  Arch: $ARCH"
+echo ""
+
+# Try to download pre-built binary from GitHub Releases
+RELEASE_URL="https://github.com/$REPO/releases/latest/download/$TARGET"
+INSTALL_DIR="${VEILKEY_INSTALL_DIR:-/usr/local/bin}"
+
+echo "Downloading $BIN_NAME..."
+if curl -fsSL "$RELEASE_URL" -o "/tmp/$BIN_NAME" 2>/dev/null; then
+    chmod +x "/tmp/$BIN_NAME"
+    echo "Downloaded pre-built binary."
+else
+    echo "No pre-built binary available."
+    echo ""
+    echo "Install from source instead:"
+    echo "  git clone https://github.com/$REPO.git"
+    echo "  cd veilkey-selfhosted"
+    echo "  cargo build --release -p veilkey-installer"
+    echo "  ./target/release/veilkey-installer detect"
+    exit 1
+fi
+
+# Run detection
+echo ""
+"/tmp/$BIN_NAME" detect
+
+echo ""
+echo "To install, move the binary and run:"
+echo "  sudo mv /tmp/$BIN_NAME $INSTALL_DIR/$BIN_NAME"
+echo "  $BIN_NAME <platform> [options]"
+echo ""

--- a/services/installer/Cargo.toml
+++ b/services/installer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "veilkey-installer"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+description = "Cross-platform installer for VeilKey Self-Hosted"
+
+[[bin]]
+name = "veilkey-installer"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+colored = "2"

--- a/services/installer/README.md
+++ b/services/installer/README.md
@@ -1,0 +1,36 @@
+# VeilKey Installer
+
+Cross-platform installer CLI for VeilKey Self-Hosted.
+
+## Usage
+
+```bash
+# Detect platform
+veilkey-installer detect
+
+# macOS (Docker + CLI)
+veilkey-installer macos
+
+# Proxmox LXC (Debian)
+veilkey-installer proxmox-lxc-debian --ip <IP>/<MASK> --gateway <GATEWAY>
+
+# veil-cli on any Linux
+veilkey-installer veil-cli --url <VEILKEY_URL>
+```
+
+## Build
+
+```bash
+cargo build --release -p veilkey-installer
+```
+
+## Architecture
+
+The installer delegates to platform-specific bash scripts in `install/`. It provides:
+
+- Platform detection
+- CLI argument parsing with defaults
+- Prerequisite checking
+- Unified entry point across platforms
+
+Bash scripts remain the source of truth for install logic.

--- a/services/installer/src/main.rs
+++ b/services/installer/src/main.rs
@@ -1,0 +1,41 @@
+mod platforms;
+
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+
+#[derive(Parser)]
+#[command(name = "veilkey-installer")]
+#[command(about = "Cross-platform installer for VeilKey Self-Hosted")]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Detect platform and show recommended install command
+    Detect,
+    /// Install on macOS (Docker + CLI)
+    Macos(platforms::macos::MacosArgs),
+    /// Install on Proxmox LXC with Debian
+    ProxmoxLxcDebian(platforms::proxmox::ProxmoxArgs),
+    /// Install veil-cli on any Linux
+    VeilCli(platforms::veil_cli::VeilCliArgs),
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Commands::Detect => platforms::detect::run(),
+        Commands::Macos(args) => platforms::macos::run(args),
+        Commands::ProxmoxLxcDebian(args) => platforms::proxmox::run(args),
+        Commands::VeilCli(args) => platforms::veil_cli::run(args),
+    };
+
+    if let Err(e) = result {
+        eprintln!("{} {}", "ERROR:".red().bold(), e);
+        std::process::exit(1);
+    }
+}

--- a/services/installer/src/platforms/detect.rs
+++ b/services/installer/src/platforms/detect.rs
@@ -1,0 +1,41 @@
+use colored::Colorize;
+use std::path::Path;
+
+pub fn run() -> Result<(), String> {
+    println!("{}", "=== VeilKey Platform Detection ===".blue().bold());
+    println!();
+
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    println!("  OS:   {}", os);
+    println!("  Arch: {}", arch);
+
+    match os {
+        "macos" => {
+            println!("  Platform: {}", "macOS".green());
+            println!();
+            println!("Recommended:");
+            println!("  veilkey-installer macos");
+        }
+        "linux" => {
+            if Path::new("/usr/bin/pct").exists() || Path::new("/usr/sbin/pct").exists() {
+                println!("  Platform: {}", "Proxmox VE".green());
+                println!();
+                println!("Recommended:");
+                println!("  veilkey-installer proxmox-lxc-debian --ip <IP>/<MASK> --gateway <GW>");
+            } else {
+                println!("  Platform: {}", "Linux".green());
+                println!();
+                println!("Recommended:");
+                println!("  veilkey-installer veil-cli --url <VEILKEY_URL>");
+            }
+        }
+        _ => {
+            println!("  Platform: {} (unsupported)", os.red());
+            return Err(format!("Unsupported platform: {}", os));
+        }
+    }
+
+    println!();
+    Ok(())
+}

--- a/services/installer/src/platforms/macos.rs
+++ b/services/installer/src/platforms/macos.rs
@@ -1,0 +1,78 @@
+use clap::Args;
+use colored::Colorize;
+use std::process::Command;
+
+#[derive(Args)]
+pub struct MacosArgs {
+    /// VaultCenter host port
+    #[arg(long, default_value = "11181")]
+    pub vaultcenter_port: u16,
+
+    /// LocalVault host port
+    #[arg(long, default_value = "11180")]
+    pub localvault_port: u16,
+
+    /// Skip Docker Compose (CLI only)
+    #[arg(long)]
+    pub cli_only: bool,
+}
+
+pub fn run(args: MacosArgs) -> Result<(), String> {
+    println!("{}", "=== VeilKey Installer (macOS) ===".blue().bold());
+    println!();
+
+    // Check prerequisites
+    check_cmd("docker", "Install Docker Desktop: https://docs.docker.com/desktop/install/mac-install/")?;
+    check_cmd("npm", "Install Node.js: brew install node")?;
+    check_cmd("cargo", "Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh")?;
+    println!("{}", "[1/4] Prerequisites OK".green());
+
+    if !args.cli_only {
+        // Start Docker Compose
+        println!("[2/4] Starting services...");
+        run_cmd("docker", &["compose", "up", "--build", "-d"])?;
+        println!("{}", "  Services started".green());
+    } else {
+        println!("[2/4] Skipped (--cli-only)");
+    }
+
+    // Build CLI
+    println!("[3/4] Building veil CLI...");
+    run_cmd("cargo", &["build", "--release", "--quiet"])?;
+    println!("{}", "  Built".green());
+
+    // Install via npm + codesign
+    println!("[4/4] Installing CLI...");
+    run_cmd("bash", &["install/macos/veil-cli/install.sh"])?;
+    println!("{}", "  Installed".green());
+
+    println!();
+    println!("{}", "=== Installation complete ===".green().bold());
+    println!();
+    println!("  VaultCenter: https://localhost:{}", args.vaultcenter_port);
+    println!("  1. Open URL → set master + admin password");
+    println!("  2. veil → enter protected shell");
+    println!();
+
+    Ok(())
+}
+
+fn check_cmd(name: &str, help: &str) -> Result<(), String> {
+    if Command::new("which").arg(name).output().map(|o| o.status.success()).unwrap_or(false) {
+        Ok(())
+    } else {
+        Err(format!("{} not found.\n  {}", name, help))
+    }
+}
+
+fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), String> {
+    let status = Command::new(cmd)
+        .args(args)
+        .status()
+        .map_err(|e| format!("Failed to run {}: {}", cmd, e))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{} exited with {}", cmd, status))
+    }
+}

--- a/services/installer/src/platforms/mod.rs
+++ b/services/installer/src/platforms/mod.rs
@@ -1,0 +1,4 @@
+pub mod detect;
+pub mod macos;
+pub mod proxmox;
+pub mod veil_cli;

--- a/services/installer/src/platforms/proxmox.rs
+++ b/services/installer/src/platforms/proxmox.rs
@@ -1,0 +1,107 @@
+use clap::Args;
+use colored::Colorize;
+use std::process::Command;
+
+#[derive(Args)]
+pub struct ProxmoxArgs {
+    /// Container IP address (e.g. 10.50.0.110/16)
+    #[arg(long)]
+    pub ip: String,
+
+    /// Gateway IP address
+    #[arg(long)]
+    pub gateway: String,
+
+    /// Container ID (auto-detected if not set)
+    #[arg(long)]
+    pub ctid: Option<u32>,
+
+    /// Container hostname
+    #[arg(long, default_value = "veilkey")]
+    pub hostname: String,
+
+    /// Network bridge
+    #[arg(long, default_value = "vmbr1")]
+    pub bridge: String,
+
+    /// Memory in MB
+    #[arg(long, default_value = "2048")]
+    pub memory: u32,
+
+    /// CPU cores
+    #[arg(long, default_value = "2")]
+    pub cores: u32,
+
+    /// Disk size in GB
+    #[arg(long, default_value = "16")]
+    pub disk: u32,
+
+    /// Storage backend
+    #[arg(long, default_value = "local-lvm")]
+    pub storage: String,
+
+    /// LXC template
+    #[arg(long, default_value = "debian-13-standard_13.1-2_amd64.tar.zst")]
+    pub template: String,
+}
+
+pub fn run(args: ProxmoxArgs) -> Result<(), String> {
+    println!("{}", "=== VeilKey Installer (Proxmox LXC Debian) ===".blue().bold());
+    println!();
+
+    check_cmd("pct", "This command must run on a Proxmox host")?;
+
+    let ctid = match args.ctid {
+        Some(id) => id,
+        None => {
+            let output = Command::new("pvesh")
+                .args(["get", "/cluster/nextid"])
+                .output()
+                .map_err(|e| format!("Failed to get next ID: {}", e))?;
+            String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .parse::<u32>()
+                .map_err(|e| format!("Failed to parse CTID: {}", e))?
+        }
+    };
+
+    println!("  CTID:     {}", ctid);
+    println!("  Hostname: {}", args.hostname);
+    println!("  IP:       {}", args.ip);
+    println!("  Gateway:  {}", args.gateway);
+    println!("  Bridge:   {}", args.bridge);
+    println!("  Memory:   {}MB", args.memory);
+    println!("  Cores:    {}", args.cores);
+    println!("  Disk:     {}GB", args.disk);
+    println!();
+
+    // Delegate to bash script (proven and tested)
+    let status = Command::new("bash")
+        .args(["install/proxmox-lxc-debian/install-veilkey.sh"])
+        .env("CTID", ctid.to_string())
+        .env("CT_HOSTNAME", &args.hostname)
+        .env("CT_IP", &args.ip)
+        .env("CT_GW", &args.gateway)
+        .env("CT_BRIDGE", &args.bridge)
+        .env("CT_MEMORY", args.memory.to_string())
+        .env("CT_CORES", args.cores.to_string())
+        .env("CT_DISK", args.disk.to_string())
+        .env("CT_STORAGE", &args.storage)
+        .env("CT_TEMPLATE", &args.template)
+        .status()
+        .map_err(|e| format!("Failed to run installer: {}", e))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Installer exited with {}", status))
+    }
+}
+
+fn check_cmd(name: &str, help: &str) -> Result<(), String> {
+    if Command::new("which").arg(name).output().map(|o| o.status.success()).unwrap_or(false) {
+        Ok(())
+    } else {
+        Err(format!("{} not found.\n  {}", name, help))
+    }
+}

--- a/services/installer/src/platforms/veil_cli.rs
+++ b/services/installer/src/platforms/veil_cli.rs
@@ -1,0 +1,41 @@
+use clap::Args;
+use colored::Colorize;
+use std::process::Command;
+
+#[derive(Args)]
+pub struct VeilCliArgs {
+    /// VeilKey server URL (required)
+    #[arg(long)]
+    pub url: String,
+}
+
+pub fn run(args: VeilCliArgs) -> Result<(), String> {
+    println!("{}", "=== VeilKey Installer (veil-cli) ===".blue().bold());
+    println!();
+    println!("  URL: {}", args.url);
+    println!();
+
+    check_cmd("cargo", "Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh")?;
+    println!("{}", "[1/1] Prerequisites OK".green());
+
+    // Delegate to bash script
+    let status = Command::new("bash")
+        .args(["install/common/install-veil-cli.sh"])
+        .env("VEILKEY_URL", &args.url)
+        .status()
+        .map_err(|e| format!("Failed to run installer: {}", e))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Installer exited with {}", status))
+    }
+}
+
+fn check_cmd(name: &str, help: &str) -> Result<(), String> {
+    if Command::new("which").arg(name).output().map(|o| o.status.success()).unwrap_or(false) {
+        Ok(())
+    } else {
+        Err(format!("{} not found.\n  {}", name, help))
+    }
+}


### PR DESCRIPTION
## Summary

### Rust installer (`services/installer/`)
- `veilkey-installer detect` — auto-detect platform (macOS, Proxmox, Linux)
- `veilkey-installer macos` — macOS full install
- `veilkey-installer proxmox-lxc-debian --ip X --gateway Y` — Proxmox LXC
- `veilkey-installer veil-cli --url X` — CLI on any Linux
- Delegates to existing bash scripts (no duplication)
- Added to Cargo workspace

### Bootstrap script (`scripts/install.sh`)
- `curl -sL https://veilkey.dev/install | bash` → downloads binary + detect

### CI fix
- Add health check wait before "Create test secret" (was failing with exit 7)

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)