### PR TITLE
fix: Guard against VK:TEMP refs in persistent storage

### DIFF
--- a/services/localvault/internal/api/bulk/apply.go
+++ b/services/localvault/internal/api/bulk/apply.go
@@ -169,6 +169,9 @@ func validateBulkApplyStep(step bulkApplyStep) error {
 	if strings.TrimSpace(step.Content) == "" {
 		return fmt.Errorf("content is required")
 	}
+	if strings.Contains(step.Content, "VK:TEMP:") {
+		return fmt.Errorf("content contains VK:TEMP references — TEMP refs expire and must be activated to LOCAL before writing to files")
+	}
 	parent := filepath.Dir(step.TargetPath)
 	if _, err := os.Stat(parent); err != nil {
 		return fmt.Errorf("parent path not found: %s", parent)

--- a/services/veil-cli/src/bin/veilkey_cli.rs
+++ b/services/veil-cli/src/bin/veilkey_cli.rs
@@ -257,10 +257,28 @@ fn cmd_filter(file: &str, api_url: &str, log_path: &str, patterns_file: Option<&
     process_stream(&mut detector, reader);
 
     if detector.stats.detections > 0 {
-        eprintln!(
-            "\n[veilkey] {} secret(s) detected and replaced",
-            detector.stats.detections
-        );
+        let entries = logger.read_entries();
+        let temp_count = entries.iter()
+            .filter(|e| e.veilkey.contains(":TEMP:"))
+            .count();
+
+        if temp_count > 0 {
+            eprintln!(
+                "\n\x1b[1;33m[veilkey] WARNING: {} of {} secret(s) replaced with VK:TEMP references.\x1b[0m",
+                temp_count, detector.stats.detections
+            );
+            eprintln!(
+                "\x1b[33m  TEMP refs expire and should NOT be written to config files.\x1b[0m"
+            );
+            eprintln!(
+                "\x1b[33m  Use 'POST /api/activate' to convert TEMP → LOCAL before saving.\x1b[0m"
+            );
+        } else {
+            eprintln!(
+                "\n[veilkey] {} secret(s) detected and replaced",
+                detector.stats.detections
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`VK:TEMP` references can be accidentally written to config files (e.g., `.env`) through two paths:

1. **bulk-apply**: No validation prevents TEMP refs in step content → written to disk → service fails when TEMP expires
2. **veil-cli filter**: Output contains TEMP refs with no warning → user pipes to file → same failure

## Fix

### 1. LocalVault bulk-apply validation (`services/localvault/internal/api/bulk/apply.go`)

`validateBulkApplyStep()` now rejects any step whose content contains `VK:TEMP:` references:

```go
if strings.Contains(step.Content, "VK:TEMP:") {
    return fmt.Errorf("content contains VK:TEMP references — TEMP refs expire and must be activated to LOCAL before writing to files")
}
```

### 2. veil-cli filter warning (`services/veil-cli/src/bin/veilkey_cli.rs`)

`cmd_filter()` now checks logger entries after processing and warns on stderr if any TEMP refs were emitted:

```
[veilkey] WARNING: 3 of 3 secret(s) replaced with VK:TEMP references.
  TEMP refs expire and should NOT be written to config files.
  Use 'POST /api/activate' to convert TEMP → LOCAL before saving.
```

## Testing

- `cargo check` passes
- Bulk-apply with TEMP content → returns 409 precheck_failed
- Filter with TEMP output → stderr warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)