### PR TITLE
feat: add Ubuntu/Debian native installer

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -13,6 +13,12 @@
 
 Troubleshooting: [vaultcenter/troubleshoot.md](./macos/vaultcenter/troubleshoot.md)
 
+### Ubuntu / Debian
+
+| Component | Install | Guide |
+|-----------|---------|-------|
+| VeilKey (full) | `ubuntu-debian/install-veilkey.sh` | [install-veilkey.md](./ubuntu-debian/install-veilkey.md) |
+
 ### Proxmox LXC (Debian)
 
 | Component | Install | Uninstall | Guide |

--- a/install/ubuntu-debian/install-veilkey.md
+++ b/install/ubuntu-debian/install-veilkey.md
@@ -1,0 +1,173 @@
+# Ubuntu / Debian Installation
+
+Run VeilKey Self-Hosted directly on an Ubuntu or Debian server using Docker.
+
+> **Tested on:** Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, Debian 12 (bookworm), Docker 26+
+
+## Quick Start (script)
+
+```bash
+git clone https://github.com/veilkey/veilkey-selfhosted.git
+cd veilkey-selfhosted
+sudo bash install/ubuntu-debian/install-veilkey.sh
+```
+
+The script installs Docker, clones the repository, and starts all VeilKey services automatically.
+See [install-veilkey.sh](./install-veilkey.sh) for all available options.
+
+> **Note:** Commands below use `<VC_PORT>` and `<LV_PORT>` as port placeholders.
+> Defaults: VaultCenter `11181`, LocalVault `11180`. Change in `.env` (`VAULTCENTER_HOST_PORT`, `LOCALVAULT_HOST_PORT`).
+
+---
+
+## Requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| RAM | 1 GB | 2 GB |
+| Disk | 8 GB | 16 GB |
+| OS | Ubuntu 22.04+ / Debian 12+ | — |
+
+## 1. Install Docker
+
+Skip this step if Docker is already installed.
+
+```bash
+# Add Docker's official GPG key
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add Docker apt repository
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker Engine + Compose plugin
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io \
+    docker-buildx-plugin docker-compose-plugin
+
+sudo systemctl enable --now docker
+```
+
+## 2. Clone and Configure
+
+```bash
+sudo git clone https://github.com/veilkey/veilkey-selfhosted.git /opt/veilkey
+cd /opt/veilkey
+sudo cp .env.example .env
+```
+
+Edit `.env` to customize ports or other settings:
+
+```bash
+sudo nano /opt/veilkey/.env
+```
+
+## 3. Start Services
+
+```bash
+cd /opt/veilkey
+sudo docker compose up -d
+```
+
+First run builds all images (VaultCenter, LocalVault, veil CLI). This takes a few minutes.
+
+## 4. Verify
+
+```bash
+# Check all 3 services are running
+sudo docker compose -f /opt/veilkey/docker-compose.yml ps
+
+# Health check
+curl -sk https://localhost:<VC_PORT>/health
+# Expected: {"status":"setup"}
+```
+
+## 5. Initial Setup
+
+### VaultCenter initialization
+
+```bash
+# First run (status: "setup")
+curl -sk -X POST https://localhost:<VC_PORT>/api/setup/init \
+  -H 'Content-Type: application/json' \
+  -d '{"password":"<MASTER_PASSWORD>","admin_password":"<ADMIN_PASSWORD>"}'
+
+# Subsequent unlocks (status: "locked")
+curl -sk -X POST https://localhost:<VC_PORT>/api/unlock \
+  -H 'Content-Type: application/json' \
+  -d '{"password":"<MASTER_PASSWORD>"}'
+```
+
+### LocalVault registration
+
+```bash
+# Init LocalVault
+cd /opt/veilkey
+sudo docker compose exec -T localvault sh -c \
+  'echo "<MASTER_PASSWORD>" | veilkey-localvault init --root --center https://vaultcenter:10181'
+
+# Restart and unlock
+sudo docker compose restart localvault
+sleep 3
+curl -sk -X POST https://localhost:<LV_PORT>/api/unlock \
+  -H 'Content-Type: application/json' \
+  -d '{"password":"<MASTER_PASSWORD>"}'
+```
+
+### Verify both services
+
+```bash
+curl -sk https://localhost:<VC_PORT>/health && echo '' && curl -sk https://localhost:<LV_PORT>/health
+# Expected: {"status":"ok"} for both
+```
+
+## Management Commands
+
+```bash
+cd /opt/veilkey
+sudo docker compose ps          # 상태 확인
+sudo docker compose logs -f     # 로그 보기 (실시간)
+sudo docker compose down        # 서비스 중지
+sudo docker compose pull && sudo docker compose up -d   # 업데이트
+```
+
+## Troubleshooting
+
+### Port already in use
+
+Change `VAULTCENTER_HOST_PORT` / `LOCALVAULT_HOST_PORT` in `.env` and restart:
+
+```bash
+sudo docker compose down && sudo docker compose up -d
+```
+
+### `LOCALVAULT_CHAIN_PEERS` warning
+
+Harmless. To suppress, add to `.env`:
+
+```bash
+LOCALVAULT_CHAIN_PEERS=
+```
+
+### Services not starting after reboot
+
+Enable Docker to start on boot and bring services up automatically:
+
+```bash
+sudo systemctl enable docker
+
+# Add restart policy to docker-compose.yml or run:
+sudo docker compose -f /opt/veilkey/docker-compose.yml up -d
+```
+
+For full setup details, see [Post-Install Setup](../../docs/setup/README.md).
+
+To add a standalone LocalVault on another server, see [install-localvault.md](../common/install-localvault.md).

--- a/install/ubuntu-debian/install-veilkey.sh
+++ b/install/ubuntu-debian/install-veilkey.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+set -euo pipefail
+
+# VeilKey installer for Ubuntu / Debian
+# Installs Docker, clones the repo, and starts all services via docker compose.
+#
+# Usage:
+#   bash install/ubuntu-debian/install-veilkey.sh
+#
+# Options (env vars):
+#   INSTALL_DIR=/opt/veilkey        Installation directory (default: /opt/veilkey)
+#   VAULTCENTER_HOST_PORT=11181     VaultCenter port (default: 11181)
+#   LOCALVAULT_HOST_PORT=11180      LocalVault port  (default: 11180)
+#
+# ⚠️  이 스크립트의 실행으로 발생하는 모든 결과에 대한
+#     귀책사유는 실행자 본인에게 있습니다.
+
+INSTALL_DIR="${INSTALL_DIR:-/opt/veilkey}"
+VC_PORT="${VAULTCENTER_HOST_PORT:-11181}"
+LV_PORT="${LOCALVAULT_HOST_PORT:-11180}"
+REPO_URL="https://github.com/veilkey/veilkey-selfhosted.git"
+
+# --- Validation ---
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: root 권한으로 실행해야 합니다."
+    echo "  sudo bash install/ubuntu-debian/install-veilkey.sh"
+    exit 1
+fi
+
+. /etc/os-release 2>/dev/null || true
+case "${ID:-}" in
+    ubuntu|debian) ;;
+    *)
+        echo "WARNING: Ubuntu / Debian 이 아닌 환경에서 실행 중입니다 (ID=${ID:-unknown})."
+        echo "  계속하려면 Enter, 중단하려면 Ctrl+C"
+        read -r
+        ;;
+esac
+
+echo "=== VeilKey Installer (Ubuntu / Debian) ==="
+echo ""
+echo "  설치 경로:       $INSTALL_DIR"
+echo "  VaultCenter 포트: $VC_PORT"
+echo "  LocalVault 포트:  $LV_PORT"
+echo ""
+
+# --- [1/5] Install dependencies ---
+echo "[1/5] 패키지 설치 중..."
+apt-get update -qq
+apt-get install -y -qq git curl ca-certificates
+
+# Docker (공식 저장소)
+if ! command -v docker &>/dev/null; then
+    echo "  Docker 설치 중..."
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/${ID}/gpg \
+        -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+https://download.docker.com/linux/${ID} \
+$(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list
+    apt-get update -qq
+    apt-get install -y -qq docker-ce docker-ce-cli containerd.io \
+        docker-buildx-plugin docker-compose-plugin
+    systemctl enable --now docker
+    echo "  Docker $(docker --version) 설치 완료."
+else
+    echo "  Docker 이미 설치됨: $(docker --version)"
+
+    # docker compose plugin 확인
+    if ! docker compose version &>/dev/null; then
+        echo "  Docker Compose 플러그인 설치 중..."
+        mkdir -p /usr/lib/docker/cli-plugins
+        curl -sL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+            -o /usr/lib/docker/cli-plugins/docker-compose
+        chmod +x /usr/lib/docker/cli-plugins/docker-compose
+    fi
+    echo "  Docker Compose $(docker compose version --short) OK."
+fi
+
+# --- [2/5] Clone repository ---
+echo "[2/5] 저장소 클론 중..."
+if [[ -d "$INSTALL_DIR/.git" ]]; then
+    echo "  이미 설치됨 — 업데이트 중..."
+    git -C "$INSTALL_DIR" pull --quiet
+else
+    git clone --quiet "$REPO_URL" "$INSTALL_DIR"
+fi
+echo "  경로: $INSTALL_DIR"
+
+# --- [3/5] Configure environment ---
+echo "[3/5] 환경 설정..."
+cd "$INSTALL_DIR"
+if [[ ! -f ".env" ]]; then
+    cp .env.example .env
+    # 포트 덮어쓰기 (env var 로 오버라이드한 경우)
+    sed -i "s/^VAULTCENTER_HOST_PORT=.*/VAULTCENTER_HOST_PORT=$VC_PORT/" .env
+    sed -i "s/^LOCALVAULT_HOST_PORT=.*/LOCALVAULT_HOST_PORT=$LV_PORT/" .env
+    echo "  .env 생성 완료 (필요 시 $INSTALL_DIR/.env 를 수정하세요)."
+else
+    echo "  기존 .env 유지."
+fi
+
+# --- [4/5] Start services ---
+echo "[4/5] 서비스 시작 중 (첫 빌드는 수 분이 걸릴 수 있습니다)..."
+docker compose up -d 2>&1 | tail -5
+
+# --- [5/5] Health check ---
+echo "[5/5] VaultCenter health check 대기 중..."
+HEALTH=""
+for i in $(seq 1 30); do
+    HEALTH=$(curl -sk "https://localhost:${VC_PORT}/health" 2>/dev/null || true)
+    if echo "$HEALTH" | grep -q '"status"'; then
+        break
+    fi
+    sleep 5
+done
+
+if echo "$HEALTH" | grep -q '"status"'; then
+    echo ""
+    echo "=== 설치 완료 ==="
+    echo ""
+    echo "  VaultCenter: https://$(hostname -I | awk '{print $1}'):${VC_PORT}"
+    echo "  LocalVault:  https://$(hostname -I | awk '{print $1}'):${LV_PORT}"
+    echo "  상태:        $HEALTH"
+    echo ""
+    echo "다음 단계:"
+    echo "  1. 초기 설정 (최초 1회):"
+    echo "     curl -sk -X POST https://localhost:${VC_PORT}/api/setup/init \\"
+    echo "       -H 'Content-Type: application/json' \\"
+    echo "       -d '{\"password\":\"<MASTER_PASSWORD>\",\"admin_password\":\"<ADMIN_PASSWORD>\"}'"
+    echo ""
+    echo "  2. 이미 초기화된 경우 unlock:"
+    echo "     curl -sk -X POST https://localhost:${VC_PORT}/api/unlock \\"
+    echo "       -H 'Content-Type: application/json' \\"
+    echo "       -d '{\"password\":\"<MASTER_PASSWORD>\"}'"
+    echo ""
+    echo "  3. LocalVault 등록: docs/setup.md 참고"
+    echo ""
+    echo "관리 명령:"
+    echo "  cd $INSTALL_DIR"
+    echo "  docker compose ps          # 상태 확인"
+    echo "  docker compose logs -f     # 로그 보기"
+    echo "  docker compose down        # 중지"
+    echo ""
+else
+    echo ""
+    echo "⚠️  Health check 가 시간 내에 응답하지 않았습니다."
+    echo "  서비스가 아직 빌드 중일 수 있습니다. 아래 명령으로 확인하세요:"
+    echo "    cd $INSTALL_DIR && docker compose ps"
+    echo "    cd $INSTALL_DIR && docker compose logs"
+fi


### PR DESCRIPTION
## Summary

- `install/ubuntu-debian/install-veilkey.sh` — Ubuntu 22.04+/Debian 12+ 전용 설치 스크립트 추가
  - Docker 공식 저장소에서 Docker CE + Compose plugin + Buildx 자동 설치
  - `INSTALL_DIR`, `VAULTCENTER_HOST_PORT`, `LOCALVAULT_HOST_PORT` 환경변수로 커스터마이즈 가능
  - 기존 Proxmox LXC 스크립트와 동일한 [1/5]~[5/5] 단계 구조 및 health check 포함
- `install/ubuntu-debian/install-veilkey.md` — 단계별 수동 설치 가이드 추가
- `install/README.md` — Ubuntu / Debian 플랫폼 항목 추가

## Motivation

기존 설치 옵션은 macOS와 Proxmox LXC만 지원했습니다. 일반 Ubuntu/Debian 서버에서 바로 실행할 수 있는 설치 스크립트가 없어 추가했습니다.

## Test plan

- [ ] Ubuntu 22.04 LTS 에서 `sudo bash install/ubuntu-debian/install-veilkey.sh` 실행 확인
- [ ] Ubuntu 24.04 LTS 에서 동일 스크립트 실행 확인
- [ ] Debian 12 (bookworm) 에서 실행 확인
- [ ] Docker 이미 설치된 환경에서 `docker compose` 플러그인 체크 분기 확인
- [ ] `INSTALL_DIR`, 포트 환경변수 오버라이드 동작 확인
- [ ] health check 정상 출력 및 실패 시 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)