### PR TITLE
fix: log and return actual error in agent unregister

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
@@ -14,7 +14,8 @@ func (h *Handler) handleAgentUnregisterByNode(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteAgent, chain.DeleteAgentPayload{NodeID: nodeID}); err != nil {
-		respondError(w, http.StatusNotFound, "not found")
+		log.Printf("agent: delete failed node=%s: %v", nodeID, err)
+		respondError(w, http.StatusNotFound, err.Error())
 		return
 	}
 	log.Printf("agent: unregistered node=%s", nodeID)


### PR DESCRIPTION
Generic 'not found' error was hiding the real SubmitTx failure reason.