### PR TITLE
feat: agent soft delete (archive/unarchive)

### DIFF
--- a/services/vaultcenter/internal/api/hkm/handler.go
+++ b/services/vaultcenter/internal/api/hkm/handler.go
@@ -93,6 +93,8 @@ func (h *Handler) Register(
 	// Agent management (Hub-only decryption)
 	mux.HandleFunc("POST /api/agents/heartbeat", ready(h.handleAgentHeartbeat))
 	mux.HandleFunc("DELETE /api/agents/by-node/{node_id}", trusted(ready(h.handleAgentUnregisterByNode)))
+	mux.HandleFunc("POST /api/agents/by-node/{node_id}/archive", trusted(ready(h.handleAgentArchive)))
+	mux.HandleFunc("POST /api/agents/by-node/{node_id}/unarchive", trusted(ready(h.handleAgentUnarchive)))
 	mux.HandleFunc("GET /api/resolve-agent/{token}", ready(h.handleAgentResolve))
 	mux.HandleFunc("GET /api/agents", ready(h.handleAgentList))
 	mux.HandleFunc("GET /api/agents/{agent}/rebind-plan", trusted(ready(h.handleAgentRebindPlan)))

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_archive.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_archive.go
@@ -1,0 +1,42 @@
+package hkm
+
+import (
+	"log"
+	"net/http"
+)
+
+func (h *Handler) handleAgentArchive(w http.ResponseWriter, r *http.Request) {
+	nodeID := r.PathValue("node_id")
+	if nodeID == "" {
+		respondError(w, http.StatusBadRequest, "node_id is required")
+		return
+	}
+	if err := h.deps.DB().ArchiveAgent(nodeID); err != nil {
+		log.Printf("agent: archive failed node=%s: %v", nodeID, err)
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	log.Printf("agent: archived node=%s", nodeID)
+	respondJSON(w, http.StatusOK, map[string]any{
+		"node_id": nodeID,
+		"status":  "archived",
+	})
+}
+
+func (h *Handler) handleAgentUnarchive(w http.ResponseWriter, r *http.Request) {
+	nodeID := r.PathValue("node_id")
+	if nodeID == "" {
+		respondError(w, http.StatusBadRequest, "node_id is required")
+		return
+	}
+	if err := h.deps.DB().UnarchiveAgent(nodeID); err != nil {
+		log.Printf("agent: unarchive failed node=%s: %v", nodeID, err)
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	log.Printf("agent: unarchived node=%s", nodeID)
+	respondJSON(w, http.StatusOK, map[string]any{
+		"node_id": nodeID,
+		"status":  "active",
+	})
+}

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_list.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_list.go
@@ -10,7 +10,13 @@ import (
 func (h *Handler) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	h.advancePendingRotationsBestEffort()
 
-	agents, err := h.deps.DB().ListAgents()
+	var agents []db.Agent
+	var err error
+	if r.URL.Query().Get("include_archived") == "true" {
+		agents, err = h.deps.DB().ListAgentsIncludeArchived()
+	} else {
+		agents, err = h.deps.DB().ListAgents()
+	}
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to list agents")
 		return

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -199,8 +199,23 @@ func (d *DB) BackfillAgentCapabilities() error {
 
 func (d *DB) ListAgents() ([]Agent, error) {
 	var agents []Agent
+	err := d.conn.Where("archived_at IS NULL").Order("last_seen DESC").Find(&agents).Error
+	return agents, err
+}
+
+func (d *DB) ListAgentsIncludeArchived() ([]Agent, error) {
+	var agents []Agent
 	err := d.conn.Order("last_seen DESC").Find(&agents).Error
 	return agents, err
+}
+
+func (d *DB) ArchiveAgent(nodeID string) error {
+	now := time.Now().UTC()
+	return d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Update("archived_at", &now).Error
+}
+
+func (d *DB) UnarchiveAgent(nodeID string) error {
+	return d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Update("archived_at", nil).Error
 }
 
 func (d *DB) GetAgentByNodeID(nodeID string) (*Agent, error) {

--- a/services/vaultcenter/internal/db/models.go
+++ b/services/vaultcenter/internal/db/models.go
@@ -177,6 +177,7 @@ type Agent struct {
 	NextRetryAt      *time.Time `gorm:"column:next_retry_at" json:"next_retry_at"`
 	BlockedAt        *time.Time `gorm:"column:blocked_at" json:"blocked_at"`
 	BlockReason      string     `gorm:"column:block_reason" json:"block_reason"`
+	ArchivedAt       *time.Time `gorm:"column:archived_at;index" json:"archived_at"`
 	IP               string     `gorm:"column:ip" json:"ip"`
 	Port             int        `gorm:"column:port;default:0" json:"port"`
 	DEK              []byte     `gorm:"column:dek" json:"dek"`


### PR DESCRIPTION
## Summary

Add soft delete for agents. Archived agents are hidden from listing but data is preserved.

## API

- `POST /api/agents/by-node/{node_id}/archive` — set archived_at, hide from list
- `POST /api/agents/by-node/{node_id}/unarchive` — clear archived_at, restore
- `GET /api/agents?include_archived=true` — show all including archived

## Why

Chain TX `DeleteAgent` fails (#254). Soft delete bypasses chain and safely cleans up stale agents without data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)