### PR TITLE
feat: auto-archive stale agents (7-day heartbeat timeout)

### DIFF
--- a/services/vaultcenter/internal/api/gc_temp_refs.go
+++ b/services/vaultcenter/internal/api/gc_temp_refs.go
@@ -27,6 +27,12 @@ func StartTempRefGC(database *db.DB, interval time.Duration, stop <-chan struct{
 			} else if regCount > 0 {
 				log.Printf("registration token GC: expired %d tokens", regCount)
 			}
+			archiveCount, archiveErr := database.AutoArchiveStaleAgents(7 * 24 * time.Hour)
+			if archiveErr != nil {
+				log.Printf("agent auto-archive error: %v", archiveErr)
+			} else if archiveCount > 0 {
+				log.Printf("agent auto-archive: archived %d stale agents (no heartbeat for 7 days)", archiveCount)
+			}
 		}
 	}
 }

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -218,6 +218,17 @@ func (d *DB) UnarchiveAgent(nodeID string) error {
 	return d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Update("archived_at", nil).Error
 }
 
+// AutoArchiveStaleAgents archives agents with no heartbeat for the given duration.
+// Returns the number of agents archived.
+func (d *DB) AutoArchiveStaleAgents(staleAfter time.Duration) (int64, error) {
+	cutoff := time.Now().UTC().Add(-staleAfter)
+	now := time.Now().UTC()
+	result := d.conn.Model(&Agent{}).
+		Where("archived_at IS NULL AND last_seen < ?", cutoff).
+		Update("archived_at", &now)
+	return result.RowsAffected, result.Error
+}
+
 func (d *DB) GetAgentByNodeID(nodeID string) (*Agent, error) {
 	return dbFirst[Agent](d, "agent "+nodeID+" not found", "node_id = ?", nodeID)
 }


### PR DESCRIPTION
Agents with no heartbeat for 7 days auto-archived in GC loop. Closes #256.