### PR TITLE
feat: agent soft-delete — DEK 보존으로 재연결 가능

### DIFF
--- a/services/vaultcenter/README.md
+++ b/services/vaultcenter/README.md
@@ -23,6 +23,36 @@ docker compose up --build -d vaultcenter
 - CometBFT ABCI chain layer for audit trail
 - Bulk-apply: template rendering + workflow proxy to LocalVault
 
+## Agent lifecycle
+
+Agent 상태 전이는 모두 체인 TX로 기록된다. DEK(암호화 키)는 보안상 체인에 포함하지 않으며 DB에만 저장.
+
+```
+[heartbeat] → UpsertAgent TX → agent 생성/갱신 (DEK 발급)
+[archive]   → DB 직접         → archived_at 설정 (UI에서 숨김)
+[unarchive] → DB 직접         → archived_at 해제
+[delete]    → DeleteAgent TX  → deleted_at 설정 (soft-delete, DEK 보존)
+```
+
+### Soft-delete 설계 원칙
+
+`DELETE /api/agents/by-node/{node_id}`는 **soft-delete**:
+- `deleted_at` 타임스탬프만 설정, 실제 레코드/DEK는 보존
+- 체인에 DeleteAgent TX가 기록되어 감사 이력 유지
+- 삭제된 agent의 LocalVault가 재연결(heartbeat) 시 → `deleted_at` 해제 → 기존 DEK로 복호화 가능
+
+**이유:** VaultCenter는 체인 블록(v1~vn)으로 전체 상태를 재구성할 수 있어야 한다. DEK가 DB에서 삭제되면 해당 agent의 시크릿을 영구적으로 복호화할 수 없다. hard-delete는 지원하지 않는다.
+
+### Archive vs Delete
+
+| | Archive | Delete |
+|---|---------|--------|
+| 체인 TX | 없음 | DeleteAgent TX |
+| DEK 보존 | O | O |
+| 감사 이력 | 없음 | 체인에 기록 |
+| 자동 복원 | unarchive API | heartbeat 시 자동 |
+| 용도 | UI 정리 | agent 등록 해제 |
+
 ## API
 
 See [docs/setup/](../../docs/setup/README.md) for usage guides.

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_heartbeat.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_heartbeat.go
@@ -102,6 +102,15 @@ func (h *Handler) handleAgentHeartbeat(w http.ResponseWriter, r *http.Request) {
 
 	agent, err := h.deps.DB().GetAgentByNodeID(nodeID)
 	if err == nil {
+		// Restore soft-deleted agent on reconnection — DEK is preserved
+		if agent.DeletedAt != nil {
+			if err := h.deps.DB().RestoreDeletedAgent(nodeID); err != nil {
+				respondError(w, http.StatusInternalServerError, "failed to restore deleted agent")
+				return
+			}
+			log.Printf("agent: restored deleted agent node=%s (%s)", nodeID, req.Label)
+			agent.DeletedAt = nil
+		}
 		if agent.BlockedAt != nil && agent.BlockReason == "key_version_mismatch" && agent.KeyVersion == req.KeyVersion {
 			if _, err := h.deps.SubmitTx(r.Context(), chain.TxUpdateAgentState, clearRebindPayload(nodeID)); err != nil {
 				respondError(w, http.StatusInternalServerError, "failed to clear blocked rebind state")

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/veilkey/veilkey-go-package/agentapi"
-	"gorm.io/gorm"
 )
 
 // AgentRetrySchedule defines backoff intervals for rebind/rotation retries.
@@ -199,13 +198,13 @@ func (d *DB) BackfillAgentCapabilities() error {
 
 func (d *DB) ListAgents() ([]Agent, error) {
 	var agents []Agent
-	err := d.conn.Where("archived_at IS NULL").Order("last_seen DESC").Find(&agents).Error
+	err := d.conn.Where("archived_at IS NULL AND deleted_at IS NULL").Order("last_seen DESC").Find(&agents).Error
 	return agents, err
 }
 
 func (d *DB) ListAgentsIncludeArchived() ([]Agent, error) {
 	var agents []Agent
-	err := d.conn.Order("last_seen DESC").Find(&agents).Error
+	err := d.conn.Where("deleted_at IS NULL").Order("last_seen DESC").Find(&agents).Error
 	return agents, err
 }
 
@@ -239,35 +238,19 @@ func (d *DB) GetAgentByHash(agentHash string) (*Agent, error) {
 	return dbFirst[Agent](d, "agent hash "+agentHash+" not found", "agent_hash = ?", agentHash)
 }
 func (d *DB) DeleteAgentByNodeID(nodeID string) error {
-	agent, err := d.GetAgentByNodeID(nodeID)
-	if err != nil {
-		return err
+	now := time.Now().UTC()
+	result := d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Update("deleted_at", &now)
+	if result.Error != nil {
+		return result.Error
 	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("agent %s not found", nodeID)
+	}
+	return nil
+}
 
-	return d.conn.Transaction(func(tx *gorm.DB) error {
-		if agent.AgentHash != "" {
-			if err := tx.Where("vault_runtime_hash = ? OR vault_node_uuid = ?", agent.AgentHash, nodeID).Delete(&SecretCatalog{}).Error; err != nil {
-				return err
-			}
-			if err := tx.Where("agent_hash = ?", agent.AgentHash).Delete(&TokenRef{}).Error; err != nil {
-				return err
-			}
-			if err := tx.Where("vault_runtime_hash = ? OR vault_node_uuid = ?", agent.AgentHash, nodeID).Delete(&VaultInventory{}).Error; err != nil {
-				return err
-			}
-		} else {
-			if err := tx.Where("vault_node_uuid = ?", nodeID).Delete(&SecretCatalog{}).Error; err != nil {
-				return err
-			}
-			if err := tx.Where("vault_node_uuid = ?", nodeID).Delete(&VaultInventory{}).Error; err != nil {
-				return err
-			}
-		}
-		if err := tx.Where("node_id = ?", nodeID).Delete(&Agent{}).Error; err != nil {
-			return err
-		}
-		return nil
-	})
+func (d *DB) RestoreDeletedAgent(nodeID string) error {
+	return d.conn.Model(&Agent{}).Where("node_id = ?", nodeID).Update("deleted_at", nil).Error
 }
 
 func (d *DB) GetAgentRecord(hashOrLabel string) (*Agent, error) {

--- a/services/vaultcenter/internal/db/models.go
+++ b/services/vaultcenter/internal/db/models.go
@@ -178,6 +178,7 @@ type Agent struct {
 	BlockedAt        *time.Time `gorm:"column:blocked_at" json:"blocked_at"`
 	BlockReason      string     `gorm:"column:block_reason" json:"block_reason"`
 	ArchivedAt       *time.Time `gorm:"column:archived_at;index" json:"archived_at"`
+	DeletedAt        *time.Time `gorm:"column:deleted_at;index" json:"deleted_at"`
 	IP               string     `gorm:"column:ip" json:"ip"`
 	Port             int        `gorm:"column:port;default:0" json:"port"`
 	DEK              []byte     `gorm:"column:dek" json:"dek"`


### PR DESCRIPTION
## Summary
- DeleteAgent를 hard-delete에서 soft-delete로 전환
- `deleted_at` 타임스탬프만 설정, 실제 레코드/DEK는 보존
- 삭제된 agent의 LocalVault가 heartbeat 시 자동 복원

## Why
DEK는 보안상 체인에 기록하지 않으므로 (UpsertAgentPayload 주석 참조), hard-delete로 DB에서 DEK가 삭제되면 해당 agent의 시크릿을 영구적으로 복호화할 수 없다. 체인 블록(v1~vn)으로 전체 상태를 재구성할 수 있어야 하는 설계 원칙에 위배.

## Changes
- `Agent` 모델: `deleted_at` 필드 추가
- `DeleteAgentByNodeID`: `deleted_at` 설정으로 변경 (기존 hard-delete 제거)
- `RestoreDeletedAgent`: 새 메서드 추가
- `ListAgents`/`ListAgentsIncludeArchived`: deleted 제외
- heartbeat: deleted agent 재연결 시 자동 복원
- VaultCenter README: agent lifecycle 문서화

## Test plan
- [ ] Docker 리빌드 후 delete → agent list에서 사라지는지 확인
- [ ] delete 후 LocalVault heartbeat → agent 자동 복원 확인
- [ ] 복원된 agent의 기존 DEK로 시크릿 복호화 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)