### PR TITLE
docs: AI agent security boundary + CLAUDE.md template

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ VeilKey prevents AI from accessing secrets, but with root access:
 - Run AI coding tools as a regular user
 - Work inside `veil` shell only → PTY masking guaranteed
 - Perform `sudo` operations outside veil
+- Add [`examples/CLAUDE.md`](./examples/CLAUDE.md) to your project → enforces AI agent security boundary
 
 ## Security Disclaimer
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -98,6 +98,38 @@ Write operations (store secret, delete, etc.) restricted to trusted IPs.
 - Rate limiting: 10 failed attempts → 15-minute lockout
 - Configurable TTL: `VEILKEY_ADMIN_SESSION_TTL` (default: 2h)
 
+## AI Agent Security Boundary
+
+When running AI coding tools (Claude Code, Cursor, etc.) inside a `veil` session on a machine with a LocalVault:
+
+### Allowed
+
+| Action | Example |
+|--------|---------|
+| LocalVault API calls | `curl -sk https://localhost:10180/health` |
+| Service management | `docker compose restart localvault` |
+| Log viewing | `tail -f .localvault/localvault.log` |
+| VK ref usage in code | `export DB_PASSWORD=VK:LOCAL:xxx` |
+| Secret status check | `veilkey-cli status` |
+
+### Forbidden
+
+| Action | Reason |
+|--------|--------|
+| Read `.env` files directly | Contains infra config + VaultCenter URL |
+| Run `veilkey-cli resolve` | Decrypts secret to plaintext |
+| Read `/proc/*/environ` | Exposes resolved env vars |
+| Access `~/.bash_history` | May contain unmasked commands |
+| Read session log plaintext | `$TMPDIR/veilkey-cli/session.log` |
+
+### Principle
+
+> AI agents should interact with secrets **only through VK refs**. Any operation that would reveal plaintext must go through the VaultCenter admin UI or a human operator — never through the AI agent.
+
+### CLAUDE.md Template
+
+A template for `.claude/CLAUDE.md` is provided at [`examples/CLAUDE.md`](../examples/CLAUDE.md). Add this to any project where Claude Code runs alongside VeilKey to enforce the security boundary.
+
 ## Blockchain Audit
 
 - **Chain:** CometBFT (single validator + full nodes)

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,0 +1,23 @@
+# VeilKey Security Boundary for AI Agents
+
+This project uses VeilKey for secret management. Follow these rules when working with secrets.
+
+## Rules
+
+1. **Never read `.env` files directly.** They contain infrastructure secrets and VaultCenter URLs.
+2. **Never run `veilkey-cli resolve`** or any command that decrypts secrets to plaintext.
+3. **Never read `/proc/*/environ`** or process memory. Resolved env vars contain plaintext.
+4. **Never read `~/.bash_history`.** It may contain unmasked secret values.
+5. **Use VK refs only.** Reference secrets as `VK:LOCAL:xxxxx` — never as plaintext values.
+
+## Allowed
+
+- Check LocalVault health: `curl -sk https://localhost:10180/health`
+- Check service status: `docker compose ps`
+- View logs: `tail -f .localvault/localvault.log`
+- Use VK refs in code: `export DB_PASSWORD=VK:LOCAL:xxxxx`
+- Check veil status: `veilkey-cli status`
+
+## If you need a secret value
+
+Ask the human operator. Do not attempt to resolve, decrypt, or read secrets yourself.


### PR DESCRIPTION
## Summary

Define the security boundary for AI coding tools running alongside VeilKey.

## Changes

- `docs/security-model.md` — new "AI Agent Security Boundary" section
  - Allowed: API calls, service management, VK ref usage
  - Forbidden: .env reads, resolve, /proc/environ, bash history
  - Principle: AI agents interact with secrets only through VK refs

- `examples/CLAUDE.md` — drop-in template for any project using VeilKey with Claude Code

- `README.md` — reference to CLAUDE.md template

## Context

Derived from actual Claude Code session on CT 104 (SoulFlow + LocalVault) where the AI agent security boundary was established and recorded in `.claude/projects/-root/memory/feedback_veilkey_access.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)