### PR TITLE
fix: VaultCenter resolve canonical refs + veil-cli mask_map fetch

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_resolve_secret.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_resolve_secret.go
@@ -34,9 +34,16 @@ func (h *Handler) handleResolveSecret(w http.ResponseWriter, r *http.Request) {
 
 	isCascade := r.Header.Get("X-VeilKey-Cascade") == "true"
 
-	if tracked, err := h.deps.DB().GetRef(ref); err == nil && tracked != nil {
-		if h.resolveTrackedRef(w, ref, tracked) {
-			return
+	// Try exact match first, then canonical forms (VK:LOCAL:ref, VK:TEMP:ref)
+	candidates := []string{ref}
+	if !strings.Contains(ref, ":") {
+		candidates = append(candidates, "VK:LOCAL:"+ref, "VK:TEMP:"+ref)
+	}
+	for _, candidate := range candidates {
+		if tracked, err := h.deps.DB().GetRef(candidate); err == nil && tracked != nil {
+			if h.resolveTrackedRef(w, candidate, tracked) {
+				return
+			}
 		}
 	}
 
@@ -63,6 +70,38 @@ func (h *Handler) handleResolveSecret(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
+		}
+	}
+
+	// Fallback: scan all agents for this ref (when tracked ref has no agent_hash)
+	if !strings.Contains(ref, ":") {
+		agents, _ := h.deps.DB().ListAgents()
+		for i := range agents {
+			agent := &agents[i]
+			if len(agent.DEK) == 0 {
+				continue
+			}
+			agentDEK, dekErr := h.decryptAgentDEK(agent.DEK, agent.DEKNonce)
+			if dekErr != nil {
+				continue
+			}
+			ai := agentToInfo(agent)
+			cipher, cipherErr := h.fetchAgentCiphertext(ai.URL(), ref)
+			if cipherErr != nil {
+				continue
+			}
+			plaintext, decErr := crypto.Decrypt(agentDEK, cipher.Ciphertext, cipher.Nonce)
+			if decErr != nil {
+				continue
+			}
+			respondJSON(w, http.StatusOK, map[string]interface{}{
+				"ref":                ref,
+				"name":               cipher.Name,
+				"value":              string(plaintext),
+				"vault":              agent.Label,
+				"vault_runtime_hash": agent.AgentHash,
+			})
+			return
 		}
 	}
 

--- a/services/veil-cli/src/api.rs
+++ b/services/veil-cli/src/api.rs
@@ -239,28 +239,25 @@ impl VeilKeyClient {
         };
 
         // 2. Resolve each ref to get plaintext → canonical mapping
+        //    Uses self.resolve() which tries canonical + raw ref via resolve_candidates
         for entry in &ref_entries {
             let canonical = match entry["ref_canonical"].as_str() {
                 Some(c) => c,
                 None => continue,
             };
-            let resolve_url = format!(
-                "{}/api/resolve/{}",
-                self.base_url,
-                urlencoding::encode(canonical)
-            );
-            let resolve_resp = self.agent.get(&resolve_url).call();
-            if let Err(e) = &resolve_resp {
-                eprintln!("[veilkey] resolve {} failed: {}", canonical, e);
+            // Skip non-VK refs (VE: configs are not secrets)
+            if !canonical.starts_with("VK:") {
                 continue;
             }
-            if let Ok(resp) = resolve_resp {
-                let data: serde_json::Value = resp.into_json().unwrap_or_default();
-                if let Some(value) = data["value"].as_str() {
+            match self.resolve(canonical) {
+                Ok(value) => {
                     let trimmed = value.trim_end_matches(['\r', '\n']);
                     if !trimmed.is_empty() {
                         mask_map.push((trimmed.to_string(), canonical.to_string()));
                     }
+                }
+                Err(e) => {
+                    eprintln!("[veilkey] resolve {} failed: {}", canonical, e);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix the core resolve flow so veil wrap-pty can load secrets and auto-resolve VK refs in environment variables.

## Root cause

1. VaultCenter `/api/resolve/{ref}` searched by `ref_canonical` but received raw ref (e.g. `bdd9d472` vs `VK:LOCAL:bdd9d472`)
2. veil-cli `fetch_all_secrets_mask_map` sent URL-encoded canonical refs directly instead of using `resolve()` method which tries multiple candidates
3. VE: config refs were included in resolve attempts, all failing with 404

## Fix

- VaultCenter: try canonical forms + fallback scan across all agents
- veil-cli: use `self.resolve()` + skip VE: refs

## Result

```
[veilkey] loaded 15 secret(s) from vaults
RESOLVED:VK:LOCAL:010212b6  ← plaintext resolved, then re-masked by PTY
[veilkey] 15 secret(s) masked in session
```

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)