### PR TITLE
feat: Docker entrypoint wrapper + deployment examples

### DIFF
--- a/docs/setup/veil-cli/usage.md
+++ b/docs/setup/veil-cli/usage.md
@@ -49,3 +49,35 @@ veilkey-cli status
 veilkey-cli scan file.env
 # Detects secrets using 222 built-in patterns
 ```
+
+## Run services with VK refs
+
+### Direct / systemd / cron
+
+Wrap with `veil` — VK refs in env vars are auto-resolved:
+
+```bash
+# Direct
+veil node app.js
+
+# systemd
+ExecStart=/usr/local/bin/veil /usr/bin/node app.js
+
+# cron
+* * * * * /usr/local/bin/veil /path/to/script.sh
+```
+
+`.env` contains only VK refs, never plaintext.
+
+### Docker
+
+Use the entrypoint wrapper — resolves VK refs at container start:
+
+```dockerfile
+COPY docker-entrypoint-veilkey.sh /usr/local/bin/
+COPY --from=veilkey-veil:dev /usr/local/bin/veilkey-cli /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint-veilkey.sh"]
+CMD ["node", "app.js"]
+```
+
+See [`examples/docker-entrypoint-veilkey.sh`](../../../examples/docker-entrypoint-veilkey.sh) and [`examples/Dockerfile.veilkey-app`](../../../examples/Dockerfile.veilkey-app).

--- a/examples/Dockerfile.veilkey-app
+++ b/examples/Dockerfile.veilkey-app
@@ -1,0 +1,28 @@
+# Example: Node.js app with VeilKey secret resolution
+#
+# .env:
+#   DB_PASSWORD=VK:LOCAL:xxx
+#   API_KEY=VK:LOCAL:yyy
+#
+# docker-compose.yml:
+#   services:
+#     myapp:
+#       build: .
+#       env_file: .env
+#       environment:
+#         VEILKEY_LOCALVAULT_URL: "https://vaultcenter:10181"
+#         VEILKEY_TLS_INSECURE: "1"
+
+FROM node:22-slim AS app
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY . .
+
+# Add VeilKey entrypoint
+COPY --from=veilkey-veil:dev /usr/local/bin/veilkey-cli /usr/local/bin/veilkey-cli
+COPY docker-entrypoint-veilkey.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint-veilkey.sh
+
+ENTRYPOINT ["docker-entrypoint-veilkey.sh"]
+CMD ["node", "app.js"]

--- a/examples/docker-entrypoint-veilkey.sh
+++ b/examples/docker-entrypoint-veilkey.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+# VeilKey Docker entrypoint wrapper
+# Resolves VK:LOCAL:xxx and VK:TEMP:xxx in environment variables before starting the app.
+#
+# Usage in Dockerfile:
+#   COPY docker-entrypoint-veilkey.sh /usr/local/bin/
+#   COPY --from=veilkey /usr/local/bin/veilkey-cli /usr/local/bin/
+#   ENTRYPOINT ["docker-entrypoint-veilkey.sh"]
+#   CMD ["node", "app.js"]
+#
+# Or in docker-compose.yml:
+#   services:
+#     myapp:
+#       entrypoint: ["docker-entrypoint-veilkey.sh"]
+#       command: ["node", "app.js"]
+#       environment:
+#         DB_PASSWORD: "VK:LOCAL:xxx"
+#         VEILKEY_LOCALVAULT_URL: "https://localvault:10180"
+#         VEILKEY_TLS_INSECURE: "1"
+#
+# Requires:
+#   - veilkey-cli binary in PATH
+#   - VEILKEY_LOCALVAULT_URL pointing to VaultCenter or LocalVault
+
+# Check if veilkey-cli exists
+if ! command -v veilkey-cli >/dev/null 2>&1; then
+    echo "[veilkey-entrypoint] WARNING: veilkey-cli not found — skipping VK ref resolution"
+    exec "$@"
+fi
+
+# Check if VeilKey URL is set
+if [ -z "$VEILKEY_LOCALVAULT_URL" ]; then
+    echo "[veilkey-entrypoint] WARNING: VEILKEY_LOCALVAULT_URL not set — skipping VK ref resolution"
+    exec "$@"
+fi
+
+# Resolve VK refs in all environment variables
+resolved=0
+failed=0
+for var in $(env | grep '=VK:' | cut -d= -f1); do
+    value=$(printenv "$var")
+    case "$value" in
+        VK:LOCAL:*|VK:TEMP:*)
+            plaintext=$(veilkey-cli resolve "$value" 2>/dev/null) || true
+            if [ -n "$plaintext" ]; then
+                export "$var=$plaintext"
+                resolved=$((resolved + 1))
+            else
+                echo "[veilkey-entrypoint] WARNING: failed to resolve $var ($value)"
+                failed=$((failed + 1))
+            fi
+            ;;
+    esac
+done
+
+if [ "$resolved" -gt 0 ] || [ "$failed" -gt 0 ]; then
+    echo "[veilkey-entrypoint] resolved $resolved variable(s), $failed failed"
+fi
+
+exec "$@"

--- a/examples/veilkey-app.service
+++ b/examples/veilkey-app.service
@@ -1,0 +1,23 @@
+# Example systemd service with VeilKey
+#
+# .env:
+#   DB_PASSWORD=VK:LOCAL:xxx
+#
+# Install:
+#   cp veilkey-app.service /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now veilkey-app
+
+[Unit]
+Description=My App (VeilKey protected)
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/veilkey/app.env
+ExecStart=/usr/local/bin/veil /usr/bin/node /opt/myapp/app.js
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Provide entrypoint wrapper and examples so all deployment types can use VK refs instead of plaintext in .env files.

## Files

- `examples/docker-entrypoint-veilkey.sh` — resolves VK refs at container start
- `examples/Dockerfile.veilkey-app` — example with veilkey-cli multi-stage
- `examples/veilkey-app.service` — systemd with veil wrapper
- `docs/setup/veil-cli/usage.md` — document all modes

## Coverage

| Deployment | Solution | .env plaintext |
|-----------|----------|----------------|
| Direct | `veil app` | No |
| systemd | `ExecStart=veil app` | No |
| cron | `veil script.sh` | No |
| Docker | entrypoint wrapper | No |

🤖 Generated with [Claude Code](https://claude.com/claude-code)