### PR TITLE
feat: /api/mask-map endpoint — single-request + long polling

### DIFF
--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -70,6 +70,9 @@ type Server struct {
 	chainHome       string
 	chainNodeID     string
 	bulkApplyDir    string
+	maskMapVersion  uint64
+	maskMapMu       sync.RWMutex
+	maskMapNotify   chan struct{}
 	updateMu        sync.RWMutex
 	updateState     systemUpdateState
 	approvalHandler *approval.Handler
@@ -414,7 +417,8 @@ func NewServer(database *db.DB, kek []byte, trustedIPs []string) *Server {
 		unlockLimiter: ratelimit.New(),
 		httpClient:    newPooledHTTPClient(tlsutil.InitHTTPClientFromEnv()),
 		chainStore:    &db.ChainStoreAdapter{DB: database},
-		bulkApplyDir:  strings.TrimSpace(os.Getenv("VEILKEY_BULK_APPLY_DIR")),
+		bulkApplyDir:   strings.TrimSpace(os.Getenv("VEILKEY_BULK_APPLY_DIR")),
+		maskMapNotify:  make(chan struct{}),
 	}
 	if database.HasNodeInfo() {
 		if info, err := database.GetNodeInfo(); err == nil {
@@ -448,6 +452,28 @@ func (s *Server) BulkApplyDir() string {
 func (s *Server) SetSalt(salt []byte) {
 	s.salt = salt
 	s.approvalHandler = approval.NewHandler(s.db, salt, s.httpClient)
+}
+
+// BumpMaskMapVersion increments the mask_map version and notifies waiting long-poll clients.
+func (s *Server) BumpMaskMapVersion() {
+	s.maskMapMu.Lock()
+	s.maskMapVersion++
+	ch := s.maskMapNotify
+	s.maskMapNotify = make(chan struct{})
+	s.maskMapMu.Unlock()
+	close(ch) // wake all waiting long-poll goroutines
+}
+
+func (s *Server) MaskMapVersion() uint64 {
+	s.maskMapMu.RLock()
+	defer s.maskMapMu.RUnlock()
+	return s.maskMapVersion
+}
+
+func (s *Server) MaskMapWait() <-chan struct{} {
+	s.maskMapMu.RLock()
+	defer s.maskMapMu.RUnlock()
+	return s.maskMapNotify
 }
 
 func (s *Server) Unlock(kek []byte) error {

--- a/services/vaultcenter/internal/api/hkm/handler.go
+++ b/services/vaultcenter/internal/api/hkm/handler.go
@@ -47,6 +47,12 @@ type Deps interface {
 
 	// ChainInfo returns genesis JSON and persistent_peers for child nodes joining the chain.
 	ChainInfo() (genesisJSON []byte, persistentPeers string)
+
+	// MaskMapVersion returns the current mask_map version counter.
+	MaskMapVersion() uint64
+
+	// MaskMapWait returns a channel that closes when mask_map version changes.
+	MaskMapWait() <-chan struct{}
 }
 
 // Handler owns all HKM HTTP handlers.
@@ -89,6 +95,9 @@ func (h *Handler) Register(
 
 	// Key rotation (root triggers full tree rotation)
 	mux.HandleFunc("POST /api/federation/rotate", trusted(ready(h.handleFederatedRotate)))
+
+	// Mask map for veil-cli PTY masking
+	mux.HandleFunc("GET /api/mask-map", trusted(ready(h.handleMaskMap)))
 
 	// Agent management (Hub-only decryption)
 	mux.HandleFunc("POST /api/agents/heartbeat", ready(h.handleAgentHeartbeat))

--- a/services/vaultcenter/internal/api/hkm/hkm_mask_map.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_mask_map.go
@@ -1,0 +1,116 @@
+package hkm
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"veilkey-vaultcenter/internal/db"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+)
+
+// handleMaskMap serves the full mask_map for veil-cli PTY masking.
+// Supports long polling: if ?version=N matches current version, waits up to ?wait=Ns.
+func (h *Handler) handleMaskMap(w http.ResponseWriter, r *http.Request) {
+	clientVersion, _ := strconv.ParseUint(r.URL.Query().Get("version"), 10, 64)
+	waitSec, _ := strconv.Atoi(r.URL.Query().Get("wait"))
+	if waitSec < 0 {
+		waitSec = 0
+	}
+	if waitSec > 60 {
+		waitSec = 60
+	}
+
+	serverVersion := h.deps.MaskMapVersion()
+
+	// Long poll: if client is up to date, wait for changes
+	if clientVersion >= serverVersion && waitSec > 0 {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Duration(waitSec)*time.Second)
+		defer cancel()
+		select {
+		case <-h.deps.MaskMapWait():
+			serverVersion = h.deps.MaskMapVersion()
+		case <-ctx.Done():
+			respondJSON(w, http.StatusOK, map[string]any{
+				"version": serverVersion,
+				"changed": false,
+				"entries": []any{},
+			})
+			return
+		}
+	}
+
+	// Build mask_map from all active agents
+	agents, err := h.deps.DB().ListAgents()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to list agents")
+		return
+	}
+
+	type maskEntry struct {
+		Ref   string `json:"ref"`
+		Value string `json:"value"`
+		Vault string `json:"vault"`
+	}
+
+	var entries []maskEntry
+	for i := range agents {
+		agent := &agents[i]
+		if len(agent.DEK) == 0 {
+			continue
+		}
+		agentDEK, dekErr := h.decryptAgentDEK(agent.DEK, agent.DEKNonce)
+		if dekErr != nil {
+			continue
+		}
+
+		// Get secret catalog for this agent
+		// ListSecretCatalogFiltered uses vault_hash, but we also need vault_runtime_hash match
+		allCatalog, _ := h.deps.DB().ListSecretCatalog()
+		var catalog []db.SecretCatalog
+		for _, sec := range allCatalog {
+			if sec.VaultRuntimeHash == agent.AgentHash && sec.Status == "active" {
+				catalog = append(catalog, sec)
+			}
+		}
+
+		ai := agentToInfo(agent)
+		for _, sec := range catalog {
+			// Extract raw ref from canonical (VK:LOCAL:xxx → xxx)
+			ref := sec.RefCanonical
+			parts := strings.SplitN(ref, ":", 3)
+			rawRef := ref
+			if len(parts) == 3 {
+				rawRef = parts[2]
+			}
+
+			cipher, fetchErr := h.fetchAgentCiphertext(ai.URL(), rawRef)
+			if fetchErr != nil {
+				continue
+			}
+			plaintext, decErr := crypto.Decrypt(agentDEK, cipher.Ciphertext, cipher.Nonce)
+			if decErr != nil {
+				continue
+			}
+			pt := strings.TrimRight(string(plaintext), "\r\n")
+			if pt == "" {
+				continue
+			}
+			entries = append(entries, maskEntry{
+				Ref:   sec.RefCanonical,
+				Value: pt,
+				Vault: agent.VaultName,
+			})
+		}
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"version": serverVersion,
+		"changed": true,
+		"count":   len(entries),
+		"entries": entries,
+	})
+}


### PR DESCRIPTION
Phase A of #279. 1 request replaces N+1. Long polling for real-time updates. Tested: 13 secrets in single response.