### PR TITLE
feat: veil-cli single-request mask_map via /api/mask-map

### DIFF
--- a/services/veil-cli/src/api.rs
+++ b/services/veil-cli/src/api.rs
@@ -183,24 +183,22 @@ impl VeilKeyClient {
         Ok(out)
     }
 
-    /// Fetch all secrets from all vaults and resolve each to build a mask map.
+    /// Fetch all secrets via /api/mask-map (single request).
     /// Returns Vec<(plaintext, vk_ref)> sorted by plaintext length descending.
     /// Returns None if the API is unreachable after retries (fail-closed).
     pub fn fetch_all_secrets_mask_map(&self) -> Option<Vec<(String, String)>> {
-        let mut mask_map: Vec<(String, String)> = Vec::new();
-
-        // 1. Get all tracked refs (no auth required, no values)
-        //    Retry up to 3 times with backoff on failure (fail-closed: None on total failure)
         let max_retries: u32 = std::env::var("VEILKEY_MASK_FETCH_RETRIES")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(3);
-        let mut ref_entries: Option<Vec<serde_json::Value>> = None;
+
+        // Single request to /api/mask-map — server resolves all secrets
+        let mut data: Option<serde_json::Value> = None;
         for attempt in 0..max_retries {
             if attempt > 0 {
                 let delay = std::time::Duration::from_millis(500 * (1 << attempt));
                 eprintln!(
-                    "[veilkey] retrying refs fetch in {}ms (attempt {}/{})",
+                    "[veilkey] retrying mask-map fetch in {}ms (attempt {}/{})",
                     delay.as_millis(),
                     attempt + 1,
                     max_retries
@@ -209,107 +207,76 @@ impl VeilKeyClient {
             }
             match self
                 .agent
-                .get(&format!("{}/api/refs", self.base_url))
+                .get(&format!("{}/api/mask-map", self.base_url))
                 .call()
             {
                 Ok(resp) => {
-                    let data: serde_json::Value = resp.into_json().unwrap_or_default();
-                    ref_entries = Some(data["refs"].as_array().cloned().unwrap_or_default());
+                    data = resp.into_json().ok();
                     break;
                 }
                 Err(e) => {
                     eprintln!(
-                        "[veilkey] failed to fetch refs (attempt {}/{}): {}",
+                        "[veilkey] mask-map fetch failed (attempt {}/{}): {}",
                         attempt + 1,
                         max_retries,
                         e
                     );
+                    // Fallback: try legacy /api/refs + resolve path
+                    if attempt == max_retries - 1 {
+                        eprintln!("[veilkey] trying legacy refs+resolve fallback...");
+                        return self.fetch_all_secrets_mask_map_legacy();
+                    }
                 }
             }
         }
-        let ref_entries = match ref_entries {
-            Some(entries) => entries,
+
+        let data = match data {
+            Some(d) => d,
             None => {
                 eprintln!(
-                    "[veilkey] FATAL: could not fetch refs after {} attempts — fail-closed",
+                    "[veilkey] FATAL: could not fetch mask-map after {} attempts — fail-closed",
                     max_retries
                 );
                 return None;
             }
         };
 
-        // 2. Resolve each ref to get plaintext → canonical mapping
-        //    Uses self.resolve() which tries canonical + raw ref via resolve_candidates
-        for entry in &ref_entries {
-            let canonical = match entry["ref_canonical"].as_str() {
-                Some(c) => c,
-                None => continue,
-            };
-            // Skip non-VK refs (VE: configs are not secrets)
-            if !canonical.starts_with("VK:") {
-                continue;
-            }
-            match self.resolve(canonical) {
-                Ok(value) => {
-                    let trimmed = value.trim_end_matches(['\r', '\n']);
-                    if !trimmed.is_empty() {
-                        mask_map.push((trimmed.to_string(), canonical.to_string()));
-                    }
-                }
-                Err(e) => {
-                    eprintln!("[veilkey] resolve {} failed: {}", canonical, e);
-                }
+        let entries = data["entries"].as_array().cloned().unwrap_or_default();
+        let mut result: Vec<(String, String)> = Vec::new();
+        for entry in &entries {
+            let vk_ref = entry["ref"].as_str().unwrap_or_default();
+            let value = entry["value"].as_str().unwrap_or_default();
+            let trimmed = value.trim_end_matches(['\r', '\n']);
+            if !trimmed.is_empty() && !vk_ref.is_empty() {
+                result.push((trimmed.to_string(), vk_ref.to_string()));
             }
         }
 
-        // Deduplicate: same plaintext → prefer VK:LOCAL over VK:TEMP
-        let mut deduped: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
-        for (plaintext, vk_ref) in &mask_map {
-            let existing = deduped.get(plaintext);
-            let prefer_new = match existing {
-                None => true,
-                Some(old) => old.contains(":TEMP:") && vk_ref.contains(":LOCAL:"),
-            };
-            if prefer_new {
-                deduped.insert(plaintext.clone(), vk_ref.clone());
-            }
-        }
-        let mut result: Vec<(String, String)> = deduped.into_iter().collect();
-
-        // 4. Add encoded variants (base64, hex) so encoded secrets are also masked.
-        //    Each variant maps back to the same VK ref as the original plaintext.
-        //    Only add variants for secrets >= 8 chars to avoid false positives.
+        // Add encoded variants (base64, hex)
         let mut encoded_variants: Vec<(String, String)> = Vec::new();
         for (plaintext, vk_ref) in &result {
             if plaintext.len() < 8 {
                 continue;
             }
-            // base64 standard
             let b64_std = base64::engine::general_purpose::STANDARD.encode(plaintext.as_bytes());
             if !result.iter().any(|(p, _)| p == &b64_std) {
                 encoded_variants.push((b64_std, vk_ref.clone()));
             }
-            // base64 URL-safe
             let b64_url = base64::engine::general_purpose::URL_SAFE.encode(plaintext.as_bytes());
             if b64_url != base64::engine::general_purpose::STANDARD.encode(plaintext.as_bytes())
                 && !result.iter().any(|(p, _)| p == &b64_url)
             {
                 encoded_variants.push((b64_url, vk_ref.clone()));
             }
-            // hex lowercase
             let hex_lower: String = plaintext.bytes().map(|b| format!("{:02x}", b)).collect();
             if !result.iter().any(|(p, _)| p == &hex_lower) {
                 encoded_variants.push((hex_lower, vk_ref.clone()));
             }
         }
         result.extend(encoded_variants);
-
-        // Sort by plaintext length descending (longest match first)
         result.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
 
         // Remove entries where plaintext is a substring of any VK ref
-        // (prevents double-substitution, e.g. plaintext "ea2bfd16" matching inside "VK:LOCAL:ea2bfd16")
         let all_refs: Vec<String> = result.iter().map(|(_, r)| r.clone()).collect();
         result.retain(|(plaintext, _)| {
             !all_refs
@@ -317,6 +284,40 @@ impl VeilKeyClient {
                 .any(|r| r.contains(plaintext.as_str()) && r != plaintext)
         });
 
+        Some(result)
+    }
+
+    /// Legacy fallback: fetch refs + resolve each individually (N+1 requests).
+    fn fetch_all_secrets_mask_map_legacy(&self) -> Option<Vec<(String, String)>> {
+        let refs_resp = self
+            .agent
+            .get(&format!("{}/api/refs", self.base_url))
+            .call();
+        let ref_entries: Vec<serde_json::Value> = match refs_resp {
+            Ok(resp) => {
+                let data: serde_json::Value = resp.into_json().unwrap_or_default();
+                data["refs"].as_array().cloned().unwrap_or_default()
+            }
+            Err(_) => return None,
+        };
+
+        let mut result: Vec<(String, String)> = Vec::new();
+        for entry in &ref_entries {
+            let canonical = match entry["ref_canonical"].as_str() {
+                Some(c) => c,
+                None => continue,
+            };
+            if !canonical.starts_with("VK:") {
+                continue;
+            }
+            if let Ok(value) = self.resolve(canonical) {
+                let trimmed = value.trim_end_matches(['\r', '\n']);
+                if !trimmed.is_empty() {
+                    result.push((trimmed.to_string(), canonical.to_string()));
+                }
+            }
+        }
+        result.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
         Some(result)
     }
 


### PR DESCRIPTION
Phase B of #279. 1 request replaces N+1. Legacy fallback included.