### PR TITLE
feat: TUI search, secret CRUD, promote, config delete

### DIFF
--- a/services/vaultcenter/internal/tui/client.go
+++ b/services/vaultcenter/internal/tui/client.go
@@ -171,6 +171,52 @@ func (c *Client) GetVaultAudit(vaultHash string) ([]map[string]any, error) {
 	return decodeList[map[string]any](data, "events")
 }
 
+// ── Secret Create ──
+
+func (c *Client) CreateVaultSecret(runtimeHash, name, value string) (map[string]any, error) {
+	return c.postJSON("/api/vaults/"+runtimeHash+"/keys", marshal(map[string]string{
+		"name":  name,
+		"value": value,
+	}))
+}
+
+// ── Secret Update/Delete ──
+
+func (c *Client) UpdateVaultSecret(runtimeHash, name, value string) (map[string]any, error) {
+	return c.putJSON("/api/vaults/"+runtimeHash+"/keys/"+name, marshal(map[string]string{
+		"name":  name,
+		"value": value,
+	}))
+}
+
+func (c *Client) DeleteVaultSecret(runtimeHash, name string) error {
+	return c.deleteJSON("/api/vaults/" + runtimeHash + "/keys/" + name)
+}
+
+// ── Config CRUD ──
+
+func (c *Client) SaveConfig(key, value string) (map[string]any, error) {
+	return c.postJSON("/api/configs", marshal(map[string]string{"key": key, "value": value}))
+}
+
+func (c *Client) DeleteConfig(key string) error {
+	return c.deleteJSON("/api/configs/" + key)
+}
+
+// ── Approvals ──
+
+func (c *Client) ListRebindApprovals() ([]map[string]any, error) {
+	data, err := c.getJSON("/api/admin/approvals/rebind")
+	if err != nil {
+		return nil, err
+	}
+	return decodeList[map[string]any](data, "agents")
+}
+
+func (c *Client) ApproveRebind(agent string) (map[string]any, error) {
+	return c.postJSON("/api/admin/approvals/rebind/"+agent+"/approve", []byte("{}"))
+}
+
 // ── Secret Reveal ──
 
 // RevealAuthorize opens a reveal window for a secret ref.
@@ -317,6 +363,28 @@ func (c *Client) getJSON(path string) (map[string]any, error) {
 
 func (c *Client) postJSON(path string, body []byte) (map[string]any, error) {
 	resp, err := c.http.Post(c.baseURL+path, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+	var result map[string]any
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
+}
+
+func (c *Client) putJSON(path string, body []byte) (map[string]any, error) {
+	req, err := http.NewRequest("PUT", c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/services/vaultcenter/internal/tui/messages.go
+++ b/services/vaultcenter/internal/tui/messages.go
@@ -11,6 +11,7 @@ type refsLoadedMsg struct{ refs []TempRef }
 type refRevealedMsg struct{ value string }
 type refCreatedMsg struct{ ref string }
 type refDeletedMsg struct{}
+type refPromotedMsg struct{}
 
 // Auth messages
 type loginSuccessMsg struct{}

--- a/services/vaultcenter/internal/tui/model.go
+++ b/services/vaultcenter/internal/tui/model.go
@@ -215,7 +215,10 @@ func detectTabClick(x int, names []string) int {
 
 func (m Model) isEditing() bool {
 	if m.activePage == pageKeycenter {
-		return m.keycenter.creating
+		return m.keycenter.creating || m.keycenter.subview == kcPromote
+	}
+	if m.activePage == pageVaults {
+		return m.vaults.creatingSecret || m.vaults.searching || m.vaults.catalogSearching
 	}
 	if m.activePage == pageSettings {
 		return m.settings.creatingToken

--- a/services/vaultcenter/internal/tui/page_keycenter.go
+++ b/services/vaultcenter/internal/tui/page_keycenter.go
@@ -16,6 +16,7 @@ const (
 	kcDetail
 	kcCreate
 	kcConfirm
+	kcPromote
 )
 
 type keycenterModel struct {
@@ -35,6 +36,11 @@ type keycenterModel struct {
 	nameInput  textinput.Model
 	valueInput textinput.Model
 	focusIdx   int
+
+	// Promote
+	vaults      []map[string]any
+	vaultCursor int
+	promoting   bool
 }
 
 func newKeycenterModel() keycenterModel {
@@ -83,8 +89,20 @@ func (m keycenterModel) update(msg tea.Msg, c *Client) (keycenterModel, tea.Cmd)
 		m.subview = kcList
 		return m, loadRefsCmd(c)
 
+	case vaultsLoadedMsg:
+		m.vaults = msg.vaults
+		m.vaultCursor = 0
+		return m, nil
+
+	case refPromotedMsg:
+		m.subview = kcList
+		m.promoting = false
+		return m, loadRefsCmd(c)
+
 	case tea.KeyMsg:
 		switch m.subview {
+		case kcPromote:
+			return m.updatePromote(msg, c)
 		case kcList:
 			return m.updateList(msg, c)
 		case kcDetail:
@@ -156,10 +174,46 @@ func (m keycenterModel) updateDetail(msg tea.KeyMsg, c *Client) (keycenterModel,
 		}
 	case "h":
 		m.revealed = ""
+	case "p":
+		m.subview = kcPromote
+		m.vaultCursor = 0
+		return m, loadVaultsCmd(c)
 	case "esc":
 		m.subview = kcList
 	}
 	return m, nil
+}
+
+func (m keycenterModel) updatePromote(msg tea.KeyMsg, c *Client) (keycenterModel, tea.Cmd) {
+	switch msg.String() {
+	case "j", "down":
+		if m.vaultCursor < len(m.vaults)-1 {
+			m.vaultCursor++
+		}
+	case "k", "up":
+		if m.vaultCursor > 0 {
+			m.vaultCursor--
+		}
+	case "enter":
+		if len(m.vaults) > 0 {
+			v := m.vaults[m.vaultCursor]
+			m.promoting = true
+			return m, promoteRefCmd(c, m.detailRef.RefCanonical, m.detailRef.SecretName, str(v, "vault_hash"))
+		}
+	case "esc":
+		m.subview = kcDetail
+	}
+	return m, nil
+}
+
+func promoteRefCmd(c *Client, ref, name, vaultHash string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := c.PromoteRef(ref, name, vaultHash)
+		if err != nil {
+			return errMsg{err}
+		}
+		return refPromotedMsg{}
+	}
 }
 
 func (m keycenterModel) updateCreate(msg tea.KeyMsg, c *Client) (keycenterModel, tea.Cmd) {
@@ -212,6 +266,8 @@ func (m keycenterModel) view(width int) string {
 		return m.viewCreate()
 	case kcConfirm:
 		return m.viewConfirm()
+	case kcPromote:
+		return m.viewPromote(width)
 	default:
 		return m.viewList(width)
 	}
@@ -291,7 +347,38 @@ func (m keycenterModel) viewDetail() string {
 		b.WriteString("  " + styleDim.Render("r reveal"))
 	}
 	b.WriteString("\n\n")
-	b.WriteString(styleDim.Render("  esc back"))
+	b.WriteString(styleDim.Render("  r reveal  h hide  p promote  esc back"))
+	return b.String()
+}
+
+func (m keycenterModel) viewPromote(width int) string {
+	var b strings.Builder
+	b.WriteString(styleHeader.Render(fmt.Sprintf("  Promote: %s → Vault", m.detailRef.RefCanonical)))
+	b.WriteString("\n\n")
+
+	if m.promoting {
+		b.WriteString("  " + styleDim.Render("Promoting..."))
+		return b.String()
+	}
+	if len(m.vaults) == 0 {
+		b.WriteString(styleDim.Render("  Loading vaults..."))
+		return b.String()
+	}
+
+	b.WriteString(styleDim.Render("  Select target vault:") + "\n\n")
+	for i, v := range m.vaults {
+		name := str(v, "vault_name")
+		if name == "" {
+			name = str(v, "vault_hash")
+		}
+		line := fmt.Sprintf("  %-24s %s", truncate(name, 22), str(v, "status"))
+		if i == m.vaultCursor {
+			line = lipgloss.NewStyle().Background(colorHighlight).Foreground(colorFg).Width(max(width-4, 60)).Render(line)
+		}
+		b.WriteString(line + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(styleDim.Render("  j/k move  enter promote  esc cancel"))
 	return b.String()
 }
 

--- a/services/vaultcenter/internal/tui/page_settings.go
+++ b/services/vaultcenter/internal/tui/page_settings.go
@@ -108,6 +108,17 @@ func revokeTokenCmd(c *Client, tokenID string) tea.Cmd {
 	}
 }
 
+type configDeletedMsg struct{}
+
+func deleteConfigCmd(c *Client, key string) tea.Cmd {
+	return func() tea.Msg {
+		if err := c.DeleteConfig(key); err != nil {
+			return errMsg{err}
+		}
+		return configDeletedMsg{}
+	}
+}
+
 func scheduleRotationCmd(c *Client) tea.Cmd {
 	return func() tea.Msg {
 		_, err := c.ScheduleAllRotations()
@@ -148,6 +159,10 @@ func (m settingsModel) update(msg tea.Msg, c *Client) (settingsModel, tea.Cmd) {
 	case tokenRevokedMsg:
 		m.message = "Token revoked"
 		return m, loadTokensCmd(c)
+
+	case configDeletedMsg:
+		m.message = "Config deleted"
+		return m, loadConfigsCmd(c)
 
 	case rotationScheduledMsg:
 		m.message = "Rotation scheduled for all agents"
@@ -203,6 +218,11 @@ func (m settingsModel) update(msg tea.Msg, c *Client) (settingsModel, tea.Cmd) {
 			return m.updateTokens(msg, c)
 		case settingsConfigs:
 			switch msg.String() {
+			case "d":
+				if len(m.configs) > 0 {
+					key := str(m.configs[m.configCursor], "key")
+					return m, deleteConfigCmd(c, key)
+				}
 			case "j", "down":
 				if m.configCursor < len(m.configs)-1 {
 					m.configCursor++
@@ -418,6 +438,6 @@ func (m settingsModel) viewConfigs(width int) string {
 		b.WriteString(line + "\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(styleDim.Render("  j/k move"))
+	b.WriteString(styleDim.Render("  j/k move  d delete"))
 	return b.String()
 }

--- a/services/vaultcenter/internal/tui/page_vaults.go
+++ b/services/vaultcenter/internal/tui/page_vaults.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -29,8 +30,20 @@ type vaultsModel struct {
 	showDetail     bool
 	detailVault    map[string]any
 	secrets        []map[string]any
+	filteredSecrets []map[string]any
 	secretsCursor  int
 	secretsLoading bool
+
+	// Search
+	searching   bool
+	searchInput textinput.Model
+	searchQuery string
+
+	// Secret create
+	creatingSecret bool
+	createName     textinput.Model
+	createValue    textinput.Model
+	createFocus    int
 
 	// Secret detail
 	showSecretDetail bool
@@ -46,8 +59,12 @@ type vaultsModel struct {
 	agentCursor int
 
 	// Catalog
-	catalog      []map[string]any
-	catalogCursor int
+	catalog          []map[string]any
+	filteredCatalog  []map[string]any
+	catalogCursor    int
+	catalogSearching bool
+	catalogSearch    textinput.Model
+	catalogQuery     string
 }
 
 type Vault = map[string]any
@@ -63,8 +80,56 @@ type secretMetaMsg struct {
 }
 type secretRevealedMsg struct{ value string }
 
+type secretCreatedMsg struct{}
+type secretDeletedMsg struct{}
+
 func newVaultsModel() vaultsModel {
-	return vaultsModel{loading: true}
+	si := textinput.New()
+	si.Placeholder = "search ref or name..."
+	si.Width = 40
+
+	ci := textinput.New()
+	ci.Placeholder = "search..."
+	ci.Width = 40
+
+	cn := textinput.New()
+	cn.Placeholder = "SECRET_NAME (A-Z_)"
+	cn.CharLimit = 128
+	cn.Width = 40
+
+	cv := textinput.New()
+	cv.Placeholder = "plaintext value"
+	cv.CharLimit = 4096
+	cv.Width = 40
+	cv.EchoMode = textinput.EchoPassword
+	cv.EchoCharacter = '•'
+
+	return vaultsModel{
+		loading:       true,
+		searchInput:   si,
+		catalogSearch: ci,
+		createName:    cn,
+		createValue:   cv,
+	}
+}
+
+func createSecretCmd(c *Client, runtimeHash, name, value string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := c.CreateVaultSecret(runtimeHash, name, value)
+		if err != nil {
+			return errMsg{err}
+		}
+		return secretCreatedMsg{}
+	}
+}
+
+func deleteSecretCmd(c *Client, runtimeHash, name string) tea.Cmd {
+	return func() tea.Msg {
+		if err := c.DeleteVaultSecret(runtimeHash, name); err != nil {
+			return errMsg{err}
+		}
+		return secretDeletedMsg{}
+	}
 }
 
 func loadVaultsCmd(c *Client) tea.Cmd {
@@ -141,8 +206,20 @@ func (m vaultsModel) update(msg tea.Msg, c *Client) (vaultsModel, tea.Cmd) {
 	case secretsLoadedMsg:
 		m.secrets = msg.secrets
 		m.secretsLoading = false
-		m.secretsCursor = clampCursor(m.secretsCursor, len(m.secrets))
+		m.applySecretFilter()
+		m.secretsCursor = clampCursor(m.secretsCursor, len(m.filteredSecrets))
 		return m, nil
+
+	case secretCreatedMsg:
+		m.creatingSecret = false
+		m.secretsLoading = true
+		return m, loadSecretsCmd(c, str(m.detailVault, "vault_runtime_hash"))
+
+	case secretDeletedMsg:
+		m.showSecretDetail = false
+		m.revealValue = ""
+		m.secretsLoading = true
+		return m, loadSecretsCmd(c, str(m.detailVault, "vault_runtime_hash"))
 
 	case agentsLoadedMsg:
 		m.agents = msg.agents
@@ -153,7 +230,8 @@ func (m vaultsModel) update(msg tea.Msg, c *Client) (vaultsModel, tea.Cmd) {
 	case catalogLoadedMsg:
 		m.catalog = msg.catalog
 		m.loading = false
-		m.catalogCursor = clampCursor(m.catalogCursor, len(m.catalog))
+		m.applyCatalogFilter()
+		m.catalogCursor = clampCursor(m.catalogCursor, len(m.filteredCatalog))
 		return m, nil
 
 	case secretMetaMsg:
@@ -173,6 +251,19 @@ func (m vaultsModel) update(msg tea.Msg, c *Client) (vaultsModel, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// Search mode in secrets
+		if m.searching {
+			return m.updateSearch(msg)
+		}
+		// Search mode in catalog
+		if m.catalogSearching {
+			return m.updateCatalogSearch(msg)
+		}
+		// Create secret mode
+		if m.creatingSecret {
+			return m.updateCreateSecret(msg, c)
+		}
+
 		// Tab switching
 		if !m.showDetail && !m.showSecretDetail {
 			switch msg.String() {
@@ -206,6 +297,18 @@ func (m vaultsModel) update(msg tea.Msg, c *Client) (vaultsModel, tea.Cmd) {
 				}
 			case "h":
 				m.revealValue = ""
+			case "d":
+				name := str(m.secretDetail, "name")
+				rh := str(m.detailVault, "vault_runtime_hash")
+				return m, deleteSecretCmd(c, rh, name)
+			case "e":
+				m.creatingSecret = true
+				m.createName.SetValue(str(m.secretDetail, "name"))
+				m.createValue.SetValue("")
+				m.createFocus = 1
+				m.createName.Blur()
+				m.createValue.Focus()
+				m.showSecretDetail = false
 			case "esc":
 				m.showSecretDetail = false
 				m.revealValue = ""
@@ -257,16 +360,29 @@ func (m vaultsModel) updateList(msg tea.KeyMsg, c *Client) (vaultsModel, tea.Cmd
 func (m vaultsModel) updateSecrets(msg tea.KeyMsg, c *Client) (vaultsModel, tea.Cmd) {
 	switch msg.String() {
 	case "j", "down":
-		if m.secretsCursor < len(m.secrets)-1 {
+		if m.secretsCursor < len(m.filteredSecrets)-1 {
 			m.secretsCursor++
 		}
 	case "k", "up":
 		if m.secretsCursor > 0 {
 			m.secretsCursor--
 		}
+	case "/":
+		m.searching = true
+		m.searchInput.SetValue(m.searchQuery)
+		m.searchInput.Focus()
+		return m, nil
+	case "n":
+		m.creatingSecret = true
+		m.createName.SetValue("")
+		m.createValue.SetValue("")
+		m.createFocus = 0
+		m.createName.Focus()
+		m.createValue.Blur()
+		return m, nil
 	case "enter":
-		if len(m.secrets) > 0 {
-			s := m.secrets[m.secretsCursor]
+		if len(m.filteredSecrets) > 0 {
+			s := m.filteredSecrets[m.secretsCursor]
 			m.showSecretDetail = true
 			m.secretDetail = s
 			m.metaLoading = true
@@ -301,13 +417,17 @@ func (m vaultsModel) updateAgents(msg tea.KeyMsg, c *Client) (vaultsModel, tea.C
 func (m vaultsModel) updateCatalog(msg tea.KeyMsg) (vaultsModel, tea.Cmd) {
 	switch msg.String() {
 	case "j", "down":
-		if m.catalogCursor < len(m.catalog)-1 {
+		if m.catalogCursor < len(m.filteredCatalog)-1 {
 			m.catalogCursor++
 		}
 	case "k", "up":
 		if m.catalogCursor > 0 {
 			m.catalogCursor--
 		}
+	case "/":
+		m.catalogSearching = true
+		m.catalogSearch.SetValue(m.catalogQuery)
+		m.catalogSearch.Focus()
 	}
 	return m, nil
 }
@@ -316,8 +436,17 @@ func (m vaultsModel) view(width int) string {
 	if m.showSecretDetail {
 		return m.viewSecretDetail()
 	}
+	if m.creatingSecret {
+		return m.viewSecretCreate()
+	}
+	if m.searching {
+		return m.viewSearching()
+	}
 	if m.showDetail {
 		return m.viewSecrets(width)
+	}
+	if m.catalogSearching {
+		return m.viewCatalogSearching()
 	}
 
 	// Sub-tabs
@@ -403,16 +532,24 @@ func (m vaultsModel) viewSecrets(width int) string {
 		b.WriteString(styleDim.Render("  Loading..."))
 		return b.String()
 	}
-	if len(m.secrets) == 0 {
-		b.WriteString(styleDim.Render("  No secrets."))
-		b.WriteString("\n\n" + styleDim.Render("  esc back"))
+	if m.searchQuery != "" {
+		b.WriteString("  " + styleDim.Render("search: ") + styleReveal.Render(m.searchQuery) + "\n\n")
+	}
+
+	if len(m.filteredSecrets) == 0 {
+		if m.searchQuery != "" {
+			b.WriteString(styleDim.Render("  No matches."))
+		} else {
+			b.WriteString(styleDim.Render("  No secrets."))
+		}
+		b.WriteString("\n\n" + styleDim.Render("  / search  n create  esc back"))
 		return b.String()
 	}
 
 	h := fmt.Sprintf("  %-28s %-28s %-10s %-10s", "Name", "Ref", "Scope", "Status")
 	b.WriteString(styleDim.Render(h))
 	b.WriteString("\n")
-	for i, s := range m.secrets {
+	for i, s := range m.filteredSecrets {
 		ref := str(s, "token")
 		if ref == "" {
 			ref = str(s, "ref")
@@ -429,7 +566,20 @@ func (m vaultsModel) viewSecrets(width int) string {
 		b.WriteString(line + "\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(styleDim.Render("  j/k move  enter detail  r refresh  esc back"))
+	b.WriteString(styleDim.Render("  j/k move  enter detail  / search  n create  r refresh  esc back"))
+	return b.String()
+}
+
+func (m vaultsModel) viewSecretCreate() string {
+	var b strings.Builder
+	name := str(m.detailVault, "vault_name")
+	b.WriteString(styleHeader.Render(fmt.Sprintf("  %s — New Secret", name)))
+	b.WriteString("\n\n")
+	b.WriteString("  " + styleLabel.Render("Name") + "\n")
+	b.WriteString("  " + m.createName.View() + "\n\n")
+	b.WriteString("  " + styleLabel.Render("Value") + "\n")
+	b.WriteString("  " + m.createValue.View() + "\n\n")
+	b.WriteString(styleDim.Render("  tab switch  enter create  esc cancel"))
 	return b.String()
 }
 
@@ -501,9 +651,9 @@ func (m vaultsModel) viewSecretDetail() string {
 
 	b.WriteString("\n\n")
 	if isVK {
-		b.WriteString(styleDim.Render("  r reveal  h hide  esc back"))
+		b.WriteString(styleDim.Render("  r reveal  h hide  e edit  d delete  esc back"))
 	} else {
-		b.WriteString(styleDim.Render("  esc back"))
+		b.WriteString(styleDim.Render("  e edit  d delete  esc back"))
 	}
 	return b.String()
 }
@@ -553,15 +703,24 @@ func (m vaultsModel) viewCatalog(width int) string {
 		b.WriteString(styleDim.Render("  Loading..."))
 		return b.String()
 	}
-	if len(m.catalog) == 0 {
-		b.WriteString(styleDim.Render("  No secrets in catalog."))
+	if m.catalogQuery != "" {
+		b.WriteString("  " + styleDim.Render("search: ") + styleReveal.Render(m.catalogQuery) + "\n\n")
+	}
+
+	if len(m.filteredCatalog) == 0 {
+		if m.catalogQuery != "" {
+			b.WriteString(styleDim.Render("  No matches."))
+		} else {
+			b.WriteString(styleDim.Render("  No secrets in catalog."))
+		}
+		b.WriteString("\n\n" + styleDim.Render("  / search"))
 		return b.String()
 	}
 
 	h := fmt.Sprintf("  %-24s %-20s %-14s %-10s", "Name", "Ref", "Class", "Bindings")
 	b.WriteString(styleDim.Render(h))
 	b.WriteString("\n")
-	for i, s := range m.catalog {
+	for i, s := range m.filteredCatalog {
 		line := fmt.Sprintf("  %-24s %-20s %-14s %-10s",
 			truncate(str(s, "secret_name"), 22),
 			truncate(str(s, "ref_canonical"), 18),
@@ -574,8 +733,141 @@ func (m vaultsModel) viewCatalog(width int) string {
 		b.WriteString(line + "\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(styleDim.Render("  j/k move  tab switch"))
+	b.WriteString(styleDim.Render("  j/k move  / search  tab switch"))
 	return b.String()
+}
+
+// ── Search ──
+
+func (m vaultsModel) updateSearch(msg tea.KeyMsg) (vaultsModel, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		m.searchQuery = m.searchInput.Value()
+		m.searching = false
+		m.applySecretFilter()
+		m.secretsCursor = 0
+	case "esc":
+		m.searching = false
+		if m.searchQuery == "" {
+			// No search active, go back to vault list
+		}
+	default:
+		var cmd tea.Cmd
+		m.searchInput, cmd = m.searchInput.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m vaultsModel) updateCatalogSearch(msg tea.KeyMsg) (vaultsModel, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		m.catalogQuery = m.catalogSearch.Value()
+		m.catalogSearching = false
+		m.applyCatalogFilter()
+		m.catalogCursor = 0
+	case "esc":
+		m.catalogSearching = false
+	default:
+		var cmd tea.Cmd
+		m.catalogSearch, cmd = m.catalogSearch.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *vaultsModel) applySecretFilter() {
+	if m.searchQuery == "" {
+		m.filteredSecrets = m.secrets
+		return
+	}
+	q := strings.ToLower(m.searchQuery)
+	var filtered []map[string]any
+	for _, s := range m.secrets {
+		name := strings.ToLower(str(s, "name"))
+		ref := strings.ToLower(str(s, "token"))
+		if ref == "" {
+			ref = strings.ToLower(str(s, "ref"))
+		}
+		scope := strings.ToLower(str(s, "scope"))
+		if strings.Contains(name, q) || strings.Contains(ref, q) || strings.Contains(scope, q) {
+			filtered = append(filtered, s)
+		}
+	}
+	m.filteredSecrets = filtered
+}
+
+func (m *vaultsModel) applyCatalogFilter() {
+	if m.catalogQuery == "" {
+		m.filteredCatalog = m.catalog
+		return
+	}
+	q := strings.ToLower(m.catalogQuery)
+	var filtered []map[string]any
+	for _, s := range m.catalog {
+		name := strings.ToLower(str(s, "secret_name"))
+		ref := strings.ToLower(str(s, "ref_canonical"))
+		class := strings.ToLower(str(s, "class"))
+		if strings.Contains(name, q) || strings.Contains(ref, q) || strings.Contains(class, q) {
+			filtered = append(filtered, s)
+		}
+	}
+	m.filteredCatalog = filtered
+}
+
+func (m vaultsModel) viewSearching() string {
+	var b strings.Builder
+	b.WriteString(styleHeader.Render("  Search secrets"))
+	b.WriteString("\n\n")
+	b.WriteString("  " + m.searchInput.View() + "\n\n")
+	b.WriteString(styleDim.Render("  enter search  esc cancel"))
+	return b.String()
+}
+
+func (m vaultsModel) viewCatalogSearching() string {
+	var b strings.Builder
+	b.WriteString(styleHeader.Render("  Search catalog"))
+	b.WriteString("\n\n")
+	b.WriteString("  " + m.catalogSearch.View() + "\n\n")
+	b.WriteString(styleDim.Render("  enter search  esc cancel"))
+	return b.String()
+}
+
+// ── Create secret ──
+
+func (m vaultsModel) updateCreateSecret(msg tea.KeyMsg, c *Client) (vaultsModel, tea.Cmd) {
+	switch msg.String() {
+	case "tab", "shift+tab":
+		if m.createFocus == 0 {
+			m.createFocus = 1
+			m.createName.Blur()
+			m.createValue.Focus()
+		} else {
+			m.createFocus = 0
+			m.createValue.Blur()
+			m.createName.Focus()
+		}
+		return m, nil
+	case "enter":
+		name := strings.TrimSpace(m.createName.Value())
+		value := strings.TrimSpace(m.createValue.Value())
+		if name == "" || value == "" {
+			return m, nil
+		}
+		runtimeHash := str(m.detailVault, "vault_runtime_hash")
+		return m, createSecretCmd(c, runtimeHash, name, value)
+	case "esc":
+		m.creatingSecret = false
+	default:
+		var cmd tea.Cmd
+		if m.createFocus == 0 {
+			m.createName, cmd = m.createName.Update(msg)
+		} else {
+			m.createValue, cmd = m.createValue.Update(msg)
+		}
+		return m, cmd
+	}
+	return m, nil
 }
 
 func clampCursor(cursor, length int) int {


### PR DESCRIPTION
## Summary

### 검색 (`/` 키)
- Vault secrets 목록: 이름, ref (VK:/VE:), scope로 검색
- Catalog: 이름, ref, class로 검색

### Secret CRUD
- `n` 생성 — vault 내 새 secret (이름 + 값)
- `e` 수정 — secret detail에서 값 변경
- `d` 삭제 — secret 삭제

### Keycenter promote
- `p` — temp ref → vault 승격 (vault 선택 UI)

### Config 관리
- `d` — Settings > Configs에서 config 삭제

## Test plan

- [x] `go vet` + `go build` 정상
- [x] isEditing() 체크에 promote/search/create 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)