### PR TITLE
docs: add Store & Use Secrets section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,93 @@ veil exec echo VK:LOCAL:xxx   # Run command with real values
 veil scan file.env            # Find secrets in files (222 patterns)
 ```
 
+## Store & Use Secrets
+
+### 1. Store a secret
+
+```bash
+# Login to VaultCenter
+curl -sk -X POST https://<VC>:11181/api/admin/login \
+  -H 'Content-Type: application/json' \
+  -d '{"password":"<ADMIN_PASSWORD>"}' -c /tmp/vk-cookies.txt
+
+# Create temp ref
+curl -sk -X POST https://<VC>:11181/api/keycenter/temp-refs \
+  -H 'Content-Type: application/json' -b /tmp/vk-cookies.txt \
+  -d '{"name":"MY_API_KEY","value":"sk-actual-key-value"}'
+# → {"ref":"VK:TEMP:xxxxxxxx"}
+
+# Get vault hash
+curl -sk https://<VC>:11181/api/agents
+# → {"agents":[{"agent_hash":"a0a761c6", ...}]}
+
+# Promote to vault
+curl -sk -X POST https://<VC>:11181/api/keycenter/promote \
+  -H 'Content-Type: application/json' -b /tmp/vk-cookies.txt \
+  -d '{"ref":"VK:TEMP:xxxxxxxx","name":"MY_API_KEY","vault_hash":"a0a761c6"}'
+# → {"token":"VK:LOCAL:yyyyyyyy"}
+```
+
+### 2. Use in `.env` files
+
+Put VK references in `.env` — never plaintext:
+
+```env
+# .env
+ANTHROPIC_API_KEY=VK:LOCAL:ce2aac9a
+OPENAI_API_KEY=VK:LOCAL:7accddf2
+DB_PASSWORD=VK:LOCAL:bdd9d472
+```
+
+### 3. Resolve at runtime
+
+**Option A** — resolve in command args:
+
+```bash
+veil exec echo VK:LOCAL:ce2aac9a
+# → sk-ant-oat01-xxxxx (actual value)
+```
+
+**Option B** — resolve `.env` for your app:
+
+```bash
+#!/bin/bash
+# veil-run.sh — resolve VK refs in .env, then exec
+while IFS="=" read -r key value; do
+  [[ -z "$key" || "$key" =~ ^# ]] && continue
+  if [[ "$value" == VK:LOCAL:* || "$value" == VK:TEMP:* ]]; then
+    export "$key=$(veilkey-cli resolve "$value")"
+  else
+    export "$key=$value"
+  fi
+done < .env
+exec "$@"
+
+# Usage:
+#   ./veil-run.sh node app.js
+#   ./veil-run.sh python manage.py runserver
+#   ./veil-run.sh make dev
+```
+
+Your app receives real values. The `.env` file never contains plaintext.
+
+> **Note:** `veil exec` resolves VK refs in **command arguments**. For environment variables from `.env` files, use the wrapper pattern above.
+
+### 4. Use VK refs everywhere — even for infra
+
+```bash
+# Create an LXC without knowing the password
+veil exec pct create 105 local:vztmpl/debian-13.tar.zst \
+  --hostname myapp --password VK:LOCAL:bdd9d472 ...
+
+# SSH with a VK-managed key
+veil exec ssh -i VK:LOCAL:ssh-private-key user@host
+
+# Login to VaultCenter using a VK ref for the admin password
+veil exec curl -sk -X POST https://vc:11181/api/admin/login \
+  -d '{"password":"VK:LOCAL:6da25530"}'
+```
+
 ## Architecture
 
 VeilKey splits secrets across two servers. **Both must be compromised** to access any secret.


### PR DESCRIPTION
## Summary
- README에 **Store & Use Secrets** 섹션 추가
- 시크릿 저장(temp-ref → promote), `.env` VK 참조, 런타임 resolve, 인프라 활용 패턴 포함
- 실제 DeerFlow + VeilKey 연동 테스트 기반으로 작성

## Context
AI agent(Claude Code)가 VeilKey를 처음 사용했을 때 문서 부족으로 삽질한 부분을 보완:
1. 시크릿 저장/사용 전체 워크플로우가 README에 없었음
2. `.env` + VK 참조 연동 패턴이 없었음
3. `veil exec`이 args만 치환하고 env var는 안 한다는 점이 명시되지 않았음
4. 인프라 명령(pct create 등)에 VK 참조 사용 예시가 없었음

## Test plan
- [x] VK 참조로 LXC 생성 (`veil exec pct create --password VK:LOCAL:xxx`)
- [x] API 키 LocalVault 저장 (temp-ref → promote)
- [x] DeerFlow `.env`에 VK 참조 세팅
- [x] `veil-run.sh` 래퍼로 resolve 후 앱 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)