### PR TITLE
perf: cache agent auth to avoid repeated DB+KEK lookups

### DIFF
--- a/services/localvault/internal/api/api.go
+++ b/services/localvault/internal/api/api.go
@@ -42,6 +42,10 @@ type Server struct {
 	unlockLimiter *ratelimit.UnlockRateLimiter
 	httpClient    *http.Client
 
+	// agentAuthCache caches the decrypted agent secret to avoid repeated DB+KEK lookups.
+	agentAuthCache   string
+	agentAuthCacheAt time.Time
+
 	secretsHandler   *secrets.Handler
 	configsHandler   *configs.Handler
 	bulkHandler      *bulk.Handler
@@ -163,10 +167,13 @@ func (s *Server) CleanupExpiredTestFunctions(now time.Time) (int, error) {
 }
 
 // agentAuthHeader returns the Authorization header value for requests to VaultCenter.
-// Returns empty string if agent secret is not available.
+// Caches the decrypted secret for 1 minute to avoid repeated DB+KEK lookups.
 func (s *Server) agentAuthHeader() string {
 	if s.IsLocked() {
 		return ""
+	}
+	if s.agentAuthCache != "" && time.Since(s.agentAuthCacheAt) < time.Minute {
+		return s.agentAuthCache
 	}
 	info, err := s.db.GetNodeInfo()
 	if err != nil || len(info.AgentSecret) == 0 {
@@ -177,7 +184,15 @@ func (s *Server) agentAuthHeader() string {
 	if err != nil {
 		return ""
 	}
-	return "Bearer " + string(decrypted)
+	s.agentAuthCache = "Bearer " + string(decrypted)
+	s.agentAuthCacheAt = time.Now()
+	return s.agentAuthCache
+}
+
+// invalidateAgentAuthCache clears the cached agent secret (call after receiving a new secret).
+func (s *Server) invalidateAgentAuthCache() {
+	s.agentAuthCache = ""
+	s.agentAuthCacheAt = time.Time{}
 }
 
 // ── Middleware ────────────────────────────────────────────────────────────────

--- a/services/localvault/internal/api/heartbeat.go
+++ b/services/localvault/internal/api/heartbeat.go
@@ -149,6 +149,7 @@ func (s *Server) SendHeartbeatOnce(endpoint, label string, port int) error {
 				log.Printf("heartbeat: failed to store agent_secret: %v", err)
 			} else {
 				log.Println("heartbeat: agent_secret stored successfully")
+				s.invalidateAgentAuthCache()
 			}
 		}
 		if hbResp.Status == "registered" {

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_common.go
@@ -24,22 +24,24 @@ func (e *agentStateError) Error() string {
 }
 
 type agentInfo struct {
-	NodeID         string
-	Label          string
-	AgentHash      string
-	VaultHash      string
-	VaultName      string
-	IP             string
-	Port           int
-	KeyVersion     int
-	DEK            []byte
-	DEKNonce       []byte
-	RebindRequired bool
-	RebindReason   string
-	RetryStage     int
-	NextRetryAt    string
-	Blocked        bool
-	BlockReason    string
+	NodeID           string
+	Label            string
+	AgentHash        string
+	VaultHash        string
+	VaultName        string
+	IP               string
+	Port             int
+	KeyVersion       int
+	DEK              []byte
+	DEKNonce         []byte
+	AgentSecretEnc   []byte
+	AgentSecretNonce []byte
+	RebindRequired   bool
+	RebindReason     string
+	RetryStage       int
+	NextRetryAt      string
+	Blocked          bool
+	BlockReason      string
 }
 
 func (a *agentInfo) URL() string {
@@ -78,9 +80,11 @@ func agentToInfo(agent *db.Agent) *agentInfo {
 		IP:             agent.IP,
 		Port:           agent.Port,
 		KeyVersion:     agent.KeyVersion,
-		DEK:            agent.DEK,
-		DEKNonce:       agent.DEKNonce,
-		RebindRequired: agent.RebindRequired,
+		DEK:              agent.DEK,
+		DEKNonce:         agent.DEKNonce,
+		AgentSecretEnc:   agent.AgentSecretEnc,
+		AgentSecretNonce: agent.AgentSecretNonce,
+		RebindRequired:   agent.RebindRequired,
 		RebindReason:   agent.RebindReason,
 		RetryStage:     agent.RetryStage,
 		NextRetryAt:    nextRetryAt,
@@ -122,13 +126,9 @@ func (h *Handler) decryptAgentSecret(encSecret, encNonce []byte) string {
 	return string(plaintext)
 }
 
-// setAgentAuthHeader adds an Authorization Bearer header to the request if the agent has a secret.
+// setAgentAuthHeader adds an Authorization Bearer header to the request using the agent's cached secret.
 func (h *Handler) setAgentAuthHeader(req *http.Request, agent *agentInfo) {
-	dbAgent, err := h.deps.DB().GetAgentByHash(agent.AgentHash)
-	if err != nil {
-		return
-	}
-	secret := h.decryptAgentSecret(dbAgent.AgentSecretEnc, dbAgent.AgentSecretNonce)
+	secret := h.decryptAgentSecret(agent.AgentSecretEnc, agent.AgentSecretNonce)
 	if secret != "" {
 		req.Header.Set("Authorization", "Bearer "+secret)
 	}


### PR DESCRIPTION
## Summary
- LocalVault: `agentAuthHeader()` 1분 캐싱 (#336)
- VaultCenter: `setAgentAuthHeader()` agentInfo에서 직접 복호화, DB 재조회 제거 (#337)

## Test plan
- [x] `go build` — 양쪽 통과

Closes #336, closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)