### PR TITLE
fix: init --token TLS validation with VEILKEY_TLS_INSECURE

### DIFF
--- a/services/localvault/internal/commands/init.go
+++ b/services/localvault/internal/commands/init.go
@@ -16,6 +16,7 @@ import (
 	"github.com/veilkey/veilkey-go-package/agentapi"
 	"github.com/veilkey/veilkey-go-package/cmdutil"
 	"github.com/veilkey/veilkey-go-package/crypto"
+	"github.com/veilkey/veilkey-go-package/tlsutil"
 )
 
 func RunInit() {
@@ -186,7 +187,8 @@ func decodeRegistrationToken(token string) (tokenID, vcURL, label string, err er
 
 func validateTokenRemote(vcURL, tokenID string) error {
 	url := strings.TrimRight(vcURL, "/") + agentapi.PathRegistrationTokenValidate + tokenID + "/validate"
-	client := &http.Client{Timeout: cmdutil.ParseDurationEnv("VEILKEY_HTTP_TIMEOUT", 10*time.Second)}
+	client := tlsutil.InitHTTPClientFromEnv()
+	client.Timeout = cmdutil.ParseDurationEnv("VEILKEY_HTTP_TIMEOUT", 10*time.Second)
 	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("cannot reach VaultCenter: %w", err)


### PR DESCRIPTION
## Summary
`validateTokenRemote()`가 기본 `http.Client{}`를 사용해서 자체 서명 인증서 환경에서 init 실패. `tlsutil.InitHTTPClientFromEnv()`로 교체하여 `VEILKEY_TLS_INSECURE=1` 반영.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)