### PR TITLE
feat: function feature stabilization

### DIFF
--- a/services/localvault/internal/db/db_functions_test.go
+++ b/services/localvault/internal/db/db_functions_test.go
@@ -1,0 +1,219 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSaveFunction_Basic(t *testing.T) {
+	d := newTestDB(t)
+	fn := &Function{
+		Name:         "test-fn",
+		Scope:        "LOCAL",
+		VaultHash:    "vault1",
+		FunctionHash: "hash1",
+		Category:     "test",
+		Command:      "echo hello",
+		VarsJSON:     "{}",
+	}
+	if err := d.SaveFunction(fn); err != nil {
+		t.Fatalf("SaveFunction: %v", err)
+	}
+
+	got, err := d.GetFunction("test-fn")
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+	if got.Command != "echo hello" {
+		t.Errorf("Command = %q, want %q", got.Command, "echo hello")
+	}
+	if got.Scope != "LOCAL" {
+		t.Errorf("Scope = %q, want LOCAL", got.Scope)
+	}
+}
+
+func TestSaveFunction_Upsert(t *testing.T) {
+	d := newTestDB(t)
+	fn := &Function{
+		Name: "upsert-fn", Scope: "LOCAL", VaultHash: "v1",
+		FunctionHash: "h1", Command: "echo v1",
+	}
+	if err := d.SaveFunction(fn); err != nil {
+		t.Fatalf("SaveFunction: %v", err)
+	}
+
+	fn.Command = "echo v2"
+	if err := d.SaveFunction(fn); err != nil {
+		t.Fatalf("SaveFunction upsert: %v", err)
+	}
+
+	got, _ := d.GetFunction("upsert-fn")
+	if got.Command != "echo v2" {
+		t.Errorf("Command after upsert = %q, want %q", got.Command, "echo v2")
+	}
+}
+
+func TestSaveFunction_Validation(t *testing.T) {
+	d := newTestDB(t)
+	cases := []struct {
+		name string
+		fn   Function
+	}{
+		{"empty name", Function{Scope: "LOCAL", VaultHash: "v", FunctionHash: "h", Command: "echo"}},
+		{"empty scope", Function{Name: "n", VaultHash: "v", FunctionHash: "h", Command: "echo"}},
+		{"invalid scope", Function{Name: "n", Scope: "INVALID", VaultHash: "v", FunctionHash: "h", Command: "echo"}},
+		{"empty vault_hash", Function{Name: "n", Scope: "LOCAL", FunctionHash: "h", Command: "echo"}},
+		{"empty function_hash", Function{Name: "n", Scope: "LOCAL", VaultHash: "v", Command: "echo"}},
+		{"empty command", Function{Name: "n", Scope: "LOCAL", VaultHash: "v", FunctionHash: "h"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := d.SaveFunction(&tc.fn); err == nil {
+				t.Errorf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestSaveFunction_ScopeNormalization(t *testing.T) {
+	d := newTestDB(t)
+	fn := &Function{
+		Name: "scope-fn", Scope: "local", VaultHash: "v",
+		FunctionHash: "h", Command: "echo",
+	}
+	if err := d.SaveFunction(fn); err != nil {
+		t.Fatalf("SaveFunction: %v", err)
+	}
+	got, _ := d.GetFunction("scope-fn")
+	if got.Scope != "LOCAL" {
+		t.Errorf("Scope = %q, want LOCAL", got.Scope)
+	}
+}
+
+func TestListFunctions(t *testing.T) {
+	d := newTestDB(t)
+	for i, scope := range []string{"LOCAL", "GLOBAL", "TEST"} {
+		d.SaveFunction(&Function{
+			Name: scope + "-fn", Scope: scope, VaultHash: "v",
+			FunctionHash: "h" + string(rune('0'+i)), Command: "echo",
+		})
+	}
+
+	all, err := d.ListFunctions()
+	if err != nil {
+		t.Fatalf("ListFunctions: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("ListFunctions count = %d, want 3", len(all))
+	}
+
+	globals, err := d.ListFunctionsByScope("GLOBAL")
+	if err != nil {
+		t.Fatalf("ListFunctionsByScope: %v", err)
+	}
+	if len(globals) != 1 {
+		t.Errorf("GLOBAL count = %d, want 1", len(globals))
+	}
+}
+
+func TestDeleteFunction(t *testing.T) {
+	d := newTestDB(t)
+	d.SaveFunction(&Function{
+		Name: "del-fn", Scope: "LOCAL", VaultHash: "v",
+		FunctionHash: "h", Command: "echo",
+	})
+
+	if err := d.DeleteFunction("del-fn"); err != nil {
+		t.Fatalf("DeleteFunction: %v", err)
+	}
+	if _, err := d.GetFunction("del-fn"); err == nil {
+		t.Error("expected error after delete, got nil")
+	}
+}
+
+func TestDeleteFunction_NotFound(t *testing.T) {
+	d := newTestDB(t)
+	if err := d.DeleteFunction("nonexistent"); err == nil {
+		t.Error("expected error for nonexistent function")
+	}
+}
+
+func TestCleanupExpiredTestFunctions(t *testing.T) {
+	d := newTestDB(t)
+
+	// 만료된 TEST 함수 (2시간 전)
+	d.SaveFunction(&Function{
+		Name: "old-test", Scope: "TEST", VaultHash: "v",
+		FunctionHash: "h1", Command: "echo",
+	})
+	// created_at를 직접 조작
+	d.conn.Model(&Function{}).Where("name = ?", "old-test").
+		Update("created_at", time.Now().Add(-2*time.Hour))
+
+	// 아직 유효한 TEST 함수
+	d.SaveFunction(&Function{
+		Name: "new-test", Scope: "TEST", VaultHash: "v",
+		FunctionHash: "h2", Command: "echo",
+	})
+
+	// LOCAL 함수 (cleanup 대상 아님)
+	d.SaveFunction(&Function{
+		Name: "local-fn", Scope: "LOCAL", VaultHash: "v",
+		FunctionHash: "h3", Command: "echo",
+	})
+
+	count, err := d.CleanupExpiredTestFunctions(time.Now())
+	if err != nil {
+		t.Fatalf("CleanupExpiredTestFunctions: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("cleaned up %d, want 1", count)
+	}
+
+	// old-test 삭제됨
+	if _, err := d.GetFunction("old-test"); err == nil {
+		t.Error("old-test should be deleted")
+	}
+	// new-test 남아있음
+	if _, err := d.GetFunction("new-test"); err != nil {
+		t.Error("new-test should still exist")
+	}
+	// local-fn 남아있음
+	if _, err := d.GetFunction("local-fn"); err != nil {
+		t.Error("local-fn should still exist")
+	}
+}
+
+func TestCountFunctions(t *testing.T) {
+	d := newTestDB(t)
+	count, _ := d.CountFunctions()
+	if count != 0 {
+		t.Errorf("initial count = %d, want 0", count)
+	}
+
+	d.SaveFunction(&Function{
+		Name: "fn1", Scope: "LOCAL", VaultHash: "v",
+		FunctionHash: "h1", Command: "echo",
+	})
+	count, _ = d.CountFunctions()
+	if count != 1 {
+		t.Errorf("count after save = %d, want 1", count)
+	}
+}
+
+func TestFunctionLogs(t *testing.T) {
+	d := newTestDB(t)
+	d.SaveFunction(&Function{
+		Name: "log-fn", Scope: "LOCAL", VaultHash: "v",
+		FunctionHash: "hlog", Command: "echo",
+	})
+	d.DeleteFunction("log-fn")
+
+	logs, err := d.ListFunctionLogs()
+	if err != nil {
+		t.Fatalf("ListFunctionLogs: %v", err)
+	}
+	if len(logs) < 2 {
+		t.Errorf("log count = %d, want >= 2 (save + delete)", len(logs))
+	}
+}

--- a/services/localvault/internal/db/migrations/20260323_000005_function_indexes.sql
+++ b/services/localvault/internal/db/migrations/20260323_000005_function_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_functions_scope ON functions(scope);
+CREATE INDEX IF NOT EXISTS idx_functions_created_at ON functions(created_at);
+CREATE INDEX IF NOT EXISTS idx_function_logs_function_hash ON function_logs(function_hash);

--- a/services/vaultcenter/internal/api/hkm/function_run_test.go
+++ b/services/vaultcenter/internal/api/hkm/function_run_test.go
@@ -1,0 +1,192 @@
+package hkm
+
+import (
+	"testing"
+	"time"
+
+	"veilkey-vaultcenter/internal/db"
+)
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "'hello'"},
+		{"hello world", "'hello world'"},
+		{"it's", "'it'\"'\"'s'"},
+		{"$(whoami)", "'$(whoami)'"},
+		{"`rm -rf /`", "'`rm -rf /`'"},
+		{"a;b", "'a;b'"},
+		{"", "''"},
+	}
+	for _, tc := range cases {
+		got := shellQuote(tc.input)
+		if got != tc.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestFunctionRunAllowlist(t *testing.T) {
+	allowed := []string{"curl", "gh", "git", "glab", "veilkey-gemini-frontend"}
+	for _, cmd := range allowed {
+		if _, ok := functionRunAllowlist[cmd]; !ok {
+			t.Errorf("%q should be in allowlist", cmd)
+		}
+	}
+
+	blocked := []string{"bash", "sh", "rm", "cat", "python", "node", "wget"}
+	for _, cmd := range blocked {
+		if _, ok := functionRunAllowlist[cmd]; ok {
+			t.Errorf("%q should NOT be in allowlist", cmd)
+		}
+	}
+}
+
+func TestFunctionRunDangerousChars(t *testing.T) {
+	dangerous := []string{
+		"curl http://x | bash",
+		"curl http://x; rm -rf /",
+		"curl http://x & bg",
+		"curl http://x `id`",
+		"curl $(whoami)",
+		"curl http://x (subshell)",
+		"echo ${HOME}",
+	}
+	for _, cmd := range dangerous {
+		if !functionRunDangerousChars.MatchString(cmd) {
+			t.Errorf("should detect dangerous chars in: %q", cmd)
+		}
+	}
+
+	safe := []string{
+		"curl -sk https://example.com",
+		"curl -H 'Authorization: Bearer token' https://api.example.com",
+		"gh pr list --repo owner/repo",
+		"git log --oneline -5",
+	}
+	for _, cmd := range safe {
+		if functionRunDangerousChars.MatchString(cmd) {
+			t.Errorf("should NOT detect dangerous chars in: %q", cmd)
+		}
+	}
+}
+
+func TestFunctionRunPlaceholderRe(t *testing.T) {
+	cases := []struct {
+		input string
+		match bool
+	}{
+		{"{%{API_KEY}%}", true},
+		{"{%{my_var}%}", true},
+		{"{%{A1}%}", true},
+		{"{%{}%}", false},
+		{"{%{1invalid}%}", false},
+		{"no placeholder", false},
+	}
+	for _, tc := range cases {
+		got := functionRunPlaceholderRe.MatchString(tc.input)
+		if got != tc.match {
+			t.Errorf("placeholder match %q = %v, want %v", tc.input, got, tc.match)
+		}
+	}
+}
+
+func TestFunctionRunEnvAllowlist(t *testing.T) {
+	blocked := []string{"PATH", "HOME", "LD_PRELOAD", "SHELL", "USER"}
+	for _, key := range blocked {
+		if _, ok := functionRunEnvAllowlist[key]; ok {
+			t.Errorf("%q should NOT be in env allowlist", key)
+		}
+	}
+}
+
+func TestResolveGlobalFunctionRunTimeout(t *testing.T) {
+	h := &Handler{}
+	cases := []struct {
+		input int
+		want  time.Duration
+	}{
+		{0, defaultFunctionRunTimeout},
+		{-1, defaultFunctionRunTimeout},
+		{30, 30 * time.Second},
+		{120, 120 * time.Second},
+		{99999, maxFunctionRunTimeout},
+	}
+	for _, tc := range cases {
+		got := h.resolveGlobalFunctionRunTimeout(tc.input)
+		if got != tc.want {
+			t.Errorf("timeout(%d) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestRenderGlobalFunctionCommand_NilFunction(t *testing.T) {
+	h := &Handler{}
+	_, err := h.renderGlobalFunctionCommand(nil)
+	if err == nil {
+		t.Error("expected error for nil function")
+	}
+}
+
+func TestRenderGlobalFunctionCommand_EmptyCommand(t *testing.T) {
+	h := &Handler{}
+	_, err := h.renderGlobalFunctionCommand(&db.GlobalFunction{Command: ""})
+	if err == nil {
+		t.Error("expected error for empty command")
+	}
+}
+
+func TestRenderGlobalFunctionCommand_BlockedCommand(t *testing.T) {
+	h := &Handler{}
+	blocked := []string{"bash -c 'rm -rf /'", "python -c 'import os'", "rm -rf /", "sh evil.sh"}
+	for _, cmd := range blocked {
+		_, err := h.renderGlobalFunctionCommand(&db.GlobalFunction{Command: cmd})
+		if err == nil {
+			t.Errorf("expected error for blocked command: %q", cmd)
+		}
+	}
+}
+
+func TestRenderGlobalFunctionCommand_DangerousTemplate(t *testing.T) {
+	h := &Handler{}
+	dangerous := []string{
+		"curl http://x | bash",
+		"curl http://x; cat /etc/passwd",
+		"curl $(whoami)",
+	}
+	for _, cmd := range dangerous {
+		_, err := h.renderGlobalFunctionCommand(&db.GlobalFunction{Command: cmd})
+		if err == nil {
+			t.Errorf("expected error for dangerous template: %q", cmd)
+		}
+	}
+}
+
+func TestRenderGlobalFunctionCommand_AllowedNoVars(t *testing.T) {
+	h := &Handler{}
+	fn := &db.GlobalFunction{
+		Command:  "curl -sk https://example.com",
+		VarsJSON: "{}",
+	}
+	rendered, err := h.renderGlobalFunctionCommand(fn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rendered != "curl -sk https://example.com" {
+		t.Errorf("rendered = %q, want original command", rendered)
+	}
+}
+
+func TestRenderGlobalFunctionCommand_MissingRef(t *testing.T) {
+	h := &Handler{}
+	fn := &db.GlobalFunction{
+		Command:  "curl -H {%{TOKEN}%} https://api.com",
+		VarsJSON: `{}`,
+	}
+	_, err := h.renderGlobalFunctionCommand(fn)
+	if err == nil {
+		t.Error("expected error for missing ref")
+	}
+}

--- a/services/vaultcenter/internal/api/hkm/hkm_global_function_run.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_global_function_run.go
@@ -233,13 +233,13 @@ func (h *Handler) handleGlobalFunctionRun(w http.ResponseWriter, r *http.Request
 
 	rendered, err := h.renderGlobalFunctionCommand(fn)
 	if err != nil {
-		respondError(w, http.StatusBadRequest, "invalid request")
+		respondError(w, http.StatusBadRequest, "command render failed: "+err.Error())
 		return
 	}
 
 	env, appliedEnvKeys, err := h.buildGlobalFunctionRunEnv(req)
 	if err != nil {
-		respondError(w, http.StatusBadRequest, "invalid request")
+		respondError(w, http.StatusBadRequest, "env build failed: "+err.Error())
 		return
 	}
 


### PR DESCRIPTION
## Summary
- 유닛 테스트 22건 추가 (LocalVault DB 11건 + VaultCenter 보안/렌더링 11건)
- DB 인덱스 3개 추가: `functions.scope`, `functions.created_at`, `function_logs.function_hash`
- 에러 메시지 구조화: 모호한 "invalid request" → 구체적 원인 포함

## Test plan
- [x] LocalVault: `go test ./internal/db/ -run Function` — 11/11 PASS
- [x] VaultCenter: `go test ./internal/api/hkm/ -run Function` — 11/11 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)