### PR TITLE
security: require admin auth for mask-map API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +971,7 @@ dependencies = [
  "libc",
  "nix",
  "regex",
+ "rpassword",
  "rustls",
  "serde",
  "serde_json",
@@ -1109,6 +1131,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -644,7 +644,7 @@ func (s *Server) SetupRoutes() http.Handler {
 	s.adminHandler.Register(mux, s.requireReadyForOps, s.requireTrustedIP)
 	// tracked-ref cleanup routes delegate to the hkm handler (registered after IsHKM check below)
 	if s.IsHKM() {
-		s.hkmHandler.Register(mux, s.requireTrustedIP, s.requireReadyForOps)
+		s.hkmHandler.Register(mux, s.requireTrustedIP, s.requireReadyForOps, s.requireAdminAuth)
 		s.bulkHandler.Register(mux, s.requireTrustedIP)
 		s.pluginHandler.Register(mux, s.requireTrustedIP)
 		// Admin tracked-ref cleanup routes require an active hkm handler.

--- a/services/vaultcenter/internal/api/hkm/handler.go
+++ b/services/vaultcenter/internal/api/hkm/handler.go
@@ -68,13 +68,16 @@ func NewHandler(deps Deps) *Handler {
 // Register mounts all HKM routes onto mux.
 //   - requireTrustedIP  – restricts to trusted IP ranges
 //   - requireReadyForOps – requires server unlocked + install complete
+//   - requireAdminAuth  – requires admin session (password login)
 func (h *Handler) Register(
 	mux *http.ServeMux,
 	requireTrustedIP func(http.HandlerFunc) http.HandlerFunc,
 	requireReadyForOps func(http.HandlerFunc) http.HandlerFunc,
+	requireAdminAuth func(http.HandlerFunc) http.HandlerFunc,
 ) {
 	ready := requireReadyForOps
 	trusted := requireTrustedIP
+	adminAuth := requireAdminAuth
 
 	// Parent API (called by root/parent to manage this node's children)
 	mux.HandleFunc("POST /api/register", trusted(ready(h.handleRegister)))
@@ -96,8 +99,8 @@ func (h *Handler) Register(
 	// Key rotation (root triggers full tree rotation)
 	mux.HandleFunc("POST /api/federation/rotate", trusted(ready(h.handleFederatedRotate)))
 
-	// Mask map for veil-cli PTY masking
-	mux.HandleFunc("GET /api/mask-map", trusted(ready(h.handleMaskMap)))
+	// Mask map for veil-cli PTY masking — requires admin session
+	mux.HandleFunc("GET /api/mask-map", adminAuth(trusted(ready(h.handleMaskMap))))
 
 	// Agent management (Hub-only decryption)
 	agentAuth := h.requireAgentAuth

--- a/services/veil-cli/Cargo.toml
+++ b/services/veil-cli/Cargo.toml
@@ -36,3 +36,4 @@ chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 nix = { version = "0.29", features = ["term", "signal", "process"] }
 base64 = "0.22.1"
+rpassword = "7"

--- a/services/veil-cli/src/api.rs
+++ b/services/veil-cli/src/api.rs
@@ -93,6 +93,23 @@ impl VeilKeyClient {
         &self.base_url
     }
 
+    /// Login to VaultCenter with admin password.
+    /// Session cookie is stored in the agent's cookie jar for subsequent requests.
+    pub fn admin_login(&self, password: &str) -> Result<(), String> {
+        let url = format!("{}/api/admin/login", self.base_url);
+        let body = serde_json::json!({"password": password});
+        match self.agent.post(&url).send_json(&body) {
+            Ok(resp) => {
+                if resp.status() == 200 {
+                    Ok(())
+                } else {
+                    Err(format!("login failed: HTTP {}", resp.status()))
+                }
+            }
+            Err(e) => Err(format!("login request failed: {}", e)),
+        }
+    }
+
     #[allow(clippy::result_large_err)]
     pub fn raw_get(&self, url: &str) -> Result<ureq::Response, ureq::Error> {
         self.agent.get(url).call()

--- a/services/veil-cli/src/pty/session.rs
+++ b/services/veil-cli/src/pty/session.rs
@@ -38,6 +38,17 @@ pub fn run(args: &[String], api_url: &str, _log_path: &str, patterns_file: Optio
 
     let client = VeilKeyClient::new(api_url);
 
+    // Authenticate with admin password before fetching secrets
+    let password = rpassword::prompt_password("VeilKey password: ").unwrap_or_default();
+    if password.is_empty() {
+        eprintln!("[veilkey] password is required");
+        std::process::exit(1);
+    }
+    if let Err(e) = client.admin_login(&password) {
+        eprintln!("[veilkey] authentication failed: {}", e);
+        std::process::exit(1);
+    }
+
     // Load detection patterns
     let cfg = load_config(patterns_file).ok();
     let patterns: Vec<CompiledPattern> = cfg.map(|c| c.patterns).unwrap_or_default();


### PR DESCRIPTION
## Summary
mask-map API에 admin 세션 인증 추가. `veil` 실행 시 비밀번호 입력 필수.

### 변경
- VaultCenter: mask-map 라우트에 `requireAdminAuth` 미들웨어
- veil CLI: 시작 시 비밀번호 프롬프트 → `POST /api/admin/login` → 세션 쿠키로 mask-map fetch

### 사용자 경험
```
$ veil
VeilKey password: ********
(VEIL) $
```

## Test plan
- [x] `cargo check` + `cargo clippy` — 통과
- [x] `go build` VaultCenter — 통과

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)