### PR TITLE
security: block resolve in non-TTY to prevent AI bypass

### DIFF
--- a/services/veil-cli/src/commands.rs
+++ b/services/veil-cli/src/commands.rs
@@ -69,6 +69,13 @@ pub fn cmd_wrap(args: &[String], api_url: &str, log_path: &str, patterns_file: O
 }
 
 pub fn cmd_resolve(hash: &str, api_url: &str) {
+    // Block non-TTY execution to prevent AI tools from reading plaintext via pipe
+    if unsafe { libc::isatty(1) } == 0 {
+        eprintln!(
+            "[veilkey] resolve is only available in interactive terminal (stdout must be a TTY)"
+        );
+        process::exit(1);
+    }
     let client = VeilKeyClient::new(api_url);
     match client.resolve(hash) {
         Ok(v) => print!("{}", v),

--- a/tests/smoke/resolve-tty-guard.bats
+++ b/tests/smoke/resolve-tty-guard.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+# resolve TTY guard — ensure resolve blocks non-TTY (pipe) execution
+
+@test "resolve blocks pipe execution (non-TTY stdout)" {
+  # Pipe execution: stdout is not a TTY → must be rejected
+  result=$(veilkey-cli resolve VK:LOCAL:test123 2>&1 || true)
+  [[ "$result" == *"interactive terminal"* ]] || [[ "$result" == *"TTY"* ]]
+}
+
+@test "resolve error message does not leak server URL" {
+  result=$(veilkey-cli resolve VK:LOCAL:test123 2>&1 || true)
+  # Must not contain IP addresses or URLs
+  ! echo "$result" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+@test "source code has TTY check in cmd_resolve" {
+  REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)}"
+  grep -q 'isatty' "$REPO_ROOT/services/veil-cli/src/commands.rs"
+}


### PR DESCRIPTION
## Summary
`veilkey-cli resolve`가 파이프(비-TTY)로 실행되면 거부. AI 도구가 PTY 마스킹을 우회해서 평문을 읽는 것 방지.

## 테스트
- bats 3/3: 파이프 차단, URL 미노출, 소스코드 가드 확인

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)