### PR TITLE
security: mask veil exec stderr output

### DIFF
--- a/services/veil-cli/src/commands.rs
+++ b/services/veil-cli/src/commands.rs
@@ -123,11 +123,14 @@ pub fn cmd_exec(args: &[String], api_url: &str, log_path: &str, patterns_file: O
         detector.register_known(plaintext, vk_ref);
     }
 
+    let cfg2 = load_config(patterns_file).ok();
+    let mask_pairs_clone = mask_pairs.clone();
+
     let mut child = match process::Command::new(&resolved[0])
         .args(&resolved[1..])
         .stdin(process::Stdio::inherit())
         .stdout(process::Stdio::piped())
-        .stderr(process::Stdio::inherit())
+        .stderr(process::Stdio::piped())
         .spawn()
     {
         Ok(c) => c,
@@ -137,8 +140,44 @@ pub fn cmd_exec(args: &[String], api_url: &str, log_path: &str, patterns_file: O
         }
     };
 
+    // Mask stderr in a separate thread
+    let stderr_handle = child.stderr.take().map(|stderr| {
+        let api = api_url.to_string();
+        let lp = log_path.to_string();
+        std::thread::spawn(move || {
+            if let Some(c2) = cfg2 {
+                let cl2 = VeilKeyClient::new(&api);
+                let lg2 = SessionLogger::new(&lp);
+                let mut det2 = SecretDetector::new(&c2, &cl2, &lg2, false);
+                for (p, v) in &mask_pairs_clone {
+                    det2.register_known(p, v);
+                }
+                let reader = io::BufReader::new(stderr);
+                for line in reader.lines() {
+                    match line {
+                        Ok(l) => eprintln!("{}", det2.process_line(&l)),
+                        Err(_) => break,
+                    }
+                }
+            } else {
+                // Fallback: pass through unmasked
+                let reader = io::BufReader::new(stderr);
+                for line in reader.lines() {
+                    match line {
+                        Ok(l) => eprintln!("{}", l),
+                        Err(_) => break,
+                    }
+                }
+            }
+        })
+    });
+
     if let Some(stdout) = child.stdout.take() {
         process_stream(&mut detector, stdout);
+    }
+
+    if let Some(h) = stderr_handle {
+        let _ = h.join();
     }
 
     let exit_code = match child.wait() {


### PR DESCRIPTION
## Summary
- `veil exec`의 stderr도 별도 스레드에서 SecretDetector를 통해 마스킹
- stdout + stderr 모두 평문 시크릿이 터미널에 노출되지 않음

## Why
이전 커밋에서 stdout 마스킹을 추가했지만, stderr는 그대로 inherit 상태였음.
프로그램이 시크릿을 stderr에 출력하면 AI가 읽을 수 있었음.

## Test plan
- [x] `cargo check` 통과
- [x] `cargo test` 전체 통과
- [ ] `veil exec` 실행 시 stderr에 시크릿이 VK ref로 마스킹되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)