### PR TITLE
refactor: move DeriveDBKey to shared crypto package + fix init encryption

### DIFF
--- a/services/localvault/go.mod
+++ b/services/localvault/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/mattn/go-sqlite3 v1.14.33
 	github.com/veilkey/veilkey-chain v0.9.0
-	github.com/veilkey/veilkey-go-package v0.4.3
+	github.com/veilkey/veilkey-go-package v0.4.4
 	golang.org/x/crypto v0.49.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1

--- a/services/localvault/go.sum
+++ b/services/localvault/go.sum
@@ -200,6 +200,8 @@ github.com/veilkey/veilkey-go-package v0.4.2 h1:Ghf4G7du33kf/KTUC6cVf+icko9jOeac
 github.com/veilkey/veilkey-go-package v0.4.2/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/veilkey/veilkey-go-package v0.4.3 h1:mur0y6dhj3z7pSWya1iPTsnyzX9eXYDZ9MqxBUo8YD4=
 github.com/veilkey/veilkey-go-package v0.4.3/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
+github.com/veilkey/veilkey-go-package v0.4.4 h1:qqWP8hPwOkCSuaYL9WStlcGuuNBps6pPSJwFRUG1/Hs=
+github.com/veilkey/veilkey-go-package v0.4.4/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.4.0-alpha.0.0.20240404170359-43604f3112c5 h1:qxen9oVGzDdIRP6ejyAJc760RwW4SnVDiTYTzwnXuxo=

--- a/services/localvault/internal/commands/init.go
+++ b/services/localvault/internal/commands/init.go
@@ -108,6 +108,9 @@ func RunInit() {
 	}
 	kek := crypto.DeriveKEK(password, salt)
 
+	// Set DB encryption key before opening DB — derived from salt
+	_ = os.Setenv("VEILKEY_DB_KEY", crypto.DeriveDBKey(salt))
+
 	database, err := db.New(dbPath)
 	if err != nil {
 		log.Fatalf("Failed to initialize database: %v", err)

--- a/services/localvault/internal/commands/server.go
+++ b/services/localvault/internal/commands/server.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -24,11 +22,6 @@ import (
 	"github.com/veilkey/veilkey-go-package/crypto"
 )
 
-// deriveDBKey derives a SQLCipher encryption key from the salt file.
-func deriveDBKey(salt []byte) string {
-	h := sha256.Sum256(salt)
-	return hex.EncodeToString(h[:])
-}
 
 var initMu sync.Mutex
 
@@ -258,7 +251,7 @@ func mustLoadServer() (*api.Server, string, int) {
 	// Derive DB encryption key from salt
 	// Always derive DB key from salt — ignore VEILKEY_DB_KEY env var
 	{
-		_ = os.Setenv("VEILKEY_DB_KEY", deriveDBKey(salt))
+		_ = os.Setenv("VEILKEY_DB_KEY", crypto.DeriveDBKey(salt))
 	}
 
 	database, err := db.New(dbPath)

--- a/services/localvault/internal/commands/server_test.go
+++ b/services/localvault/internal/commands/server_test.go
@@ -48,11 +48,11 @@ func TestDBKeyDerivedFromSalt(t *testing.T) {
 		t.Fatalf("failed to read server.go: %v", err)
 	}
 	code := string(src)
-	if !contains(code, "deriveDBKey(salt)") {
-		t.Error("server.go must derive DB key from salt via deriveDBKey()")
+	if !contains(code, "crypto.DeriveDBKey(salt)") {
+		t.Error("server.go must derive DB key from salt via crypto.DeriveDBKey()")
 	}
-	if !contains(code, "sha256.Sum256") {
-		t.Error("server.go must use SHA256 for DB key derivation")
+	if !contains(code, "crypto.DeriveDBKey") {
+		t.Error("server.go must use crypto.DeriveDBKey")
 	}
 }
 

--- a/services/vaultcenter/go.mod
+++ b/services/vaultcenter/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/veilkey/veilkey-chain v0.9.0
-	github.com/veilkey/veilkey-go-package v0.4.3
+	github.com/veilkey/veilkey-go-package v0.4.4
 	github.com/wneessen/go-mail v0.7.2
 	golang.org/x/crypto v0.49.0
 	gorm.io/gorm v1.31.1

--- a/services/vaultcenter/go.sum
+++ b/services/vaultcenter/go.sum
@@ -286,6 +286,8 @@ github.com/veilkey/veilkey-chain v0.9.0 h1:CL02G6BC9hY8LTEjAJuJA9/iG1L5wOf/wdCnD
 github.com/veilkey/veilkey-chain v0.9.0/go.mod h1:1UiPygoIR7lSdagVIQL/KDnWb9HEzzDo3eIH0iP4ZGk=
 github.com/veilkey/veilkey-go-package v0.4.3 h1:mur0y6dhj3z7pSWya1iPTsnyzX9eXYDZ9MqxBUo8YD4=
 github.com/veilkey/veilkey-go-package v0.4.3/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
+github.com/veilkey/veilkey-go-package v0.4.4 h1:qqWP8hPwOkCSuaYL9WStlcGuuNBps6pPSJwFRUG1/Hs=
+github.com/veilkey/veilkey-go-package v0.4.4/go.mod h1:FczrNJtUx0kFRvAKsuIB4nkN14D1HCymutJZtUHP5PQ=
 github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
 github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/services/vaultcenter/internal/commands/init.go
+++ b/services/vaultcenter/internal/commands/init.go
@@ -64,6 +64,9 @@ func RunInit() {
 	}
 	kek := crypto.DeriveKEK(password, salt)
 
+	// Set DB encryption key before opening DB
+	_ = os.Setenv("VEILKEY_DB_KEY", crypto.DeriveDBKey(salt))
+
 	database, err := db.New(dbPath)
 	if err != nil {
 		log.Fatalf("Failed to initialize database: %v", err)

--- a/services/vaultcenter/internal/commands/server.go
+++ b/services/vaultcenter/internal/commands/server.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"log"
 	"net/http"
 	"os"
@@ -15,13 +13,9 @@ import (
 
 	chain "github.com/veilkey/veilkey-chain"
 	"github.com/veilkey/veilkey-go-package/cmdutil"
+	"github.com/veilkey/veilkey-go-package/crypto"
 )
 
-// deriveDBKey derives a SQLCipher encryption key from the salt file.
-func deriveDBKey(salt []byte) string {
-	h := sha256.Sum256(salt)
-	return hex.EncodeToString(h[:])
-}
 
 func RunServer() {
 	dbPath := os.Getenv("VEILKEY_DB_PATH")
@@ -47,7 +41,7 @@ func RunServer() {
 	// Derive DB encryption key from salt — no separate VEILKEY_DB_KEY needed
 	// Always derive DB key from salt — ignore VEILKEY_DB_KEY env var
 	{
-		dbKey := deriveDBKey(salt)
+		dbKey := crypto.DeriveDBKey(salt)
 		_ = os.Setenv("VEILKEY_DB_KEY", dbKey)
 	}
 

--- a/services/vaultcenter/internal/commands/server_test.go
+++ b/services/vaultcenter/internal/commands/server_test.go
@@ -49,11 +49,11 @@ func TestDBKeyDerivedFromSalt(t *testing.T) {
 		t.Fatalf("failed to read server.go: %v", err)
 	}
 	code := string(src)
-	if !contains(code, "deriveDBKey(salt)") {
-		t.Error("server.go must derive DB key from salt via deriveDBKey()")
+	if !contains(code, "crypto.DeriveDBKey(salt)") {
+		t.Error("server.go must derive DB key from salt via crypto.DeriveDBKey()")
 	}
-	if !contains(code, "sha256.Sum256") {
-		t.Error("server.go must use SHA256 for DB key derivation")
+	if !contains(code, "crypto.DeriveDBKey") {
+		t.Error("server.go must use crypto.DeriveDBKey")
 	}
 }
 

--- a/tests/smoke/no-password-on-disk.bats
+++ b/tests/smoke/no-password-on-disk.bats
@@ -34,9 +34,9 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)}"
 }
 
 @test "DB key derived from salt in VaultCenter server.go" {
-  grep -q 'deriveDBKey(salt)' "$REPO_ROOT/services/vaultcenter/internal/commands/server.go"
+  grep -q 'crypto.DeriveDBKey(salt)' "$REPO_ROOT/services/vaultcenter/internal/commands/server.go"
 }
 
 @test "DB key derived from salt in LocalVault server.go" {
-  grep -q 'deriveDBKey(salt)' "$REPO_ROOT/services/localvault/internal/commands/server.go"
+  grep -q 'crypto.DeriveDBKey(salt)' "$REPO_ROOT/services/localvault/internal/commands/server.go"
 }


### PR DESCRIPTION
## Summary
- `deriveDBKey()` 중복 제거 → `crypto.DeriveDBKey()` (veilkey-go-package v0.4.4)
- init 버그 수정: DB 생성 전에 `VEILKEY_DB_KEY` 설정 → DB가 처음부터 암호화됨

## Test plan
- [x] `go test` — TestDBKeyDerivedFromSalt PASS (양쪽)
- [x] `go build` — 양쪽 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)