### PR TITLE
docs: update DB_KEY derivation from salt to KEK

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -163,7 +163,7 @@ VaultCenter                    LocalVault
 
 ### 데이터베이스 암호화
 
-모든 데이터베이스는 SQLCipher로 암호화됩니다. 암호화 키는 salt 파일에서 자동 파생 — 별도 설정 불필요.
+모든 데이터베이스는 SQLCipher로 암호화됩니다. 암호화 키는 마스터 비밀번호(KEK)에서 파생 — unlock 후에만 DB 접근 가능.
 
 `sqlite3` 직접 접근은 차단됩니다. admin 비밀번호는 소유자 비밀번호(owner password)로만 변경 가능합니다.
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Both provide: secret management, vault browsing, audit logs, TOTP login, and ser
 
 ### Database Encryption
 
-All databases are encrypted with SQLCipher. The encryption key is automatically derived from the salt file — no manual configuration needed.
+All databases are encrypted with SQLCipher. The encryption key is derived from the master password (KEK) — database can only be opened after unlock.
 
 Direct `sqlite3` access is blocked. Admin password can only be changed via API with the owner password.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -188,6 +188,6 @@ scan:
 | `VEILKEY_HUB_URL` | Fallback API endpoint |
 | `VEILKEY_STATE_DIR` | Session state directory (default: `$TMPDIR/veilkey-cli`) |
 | `VEILKEY_FUNCTION_DIR` | Function wrapper directory |
-| `VEILKEY_DB_KEY` | Auto-derived from salt. No manual setting needed |
+| `VEILKEY_DB_KEY` | Derived from master password (KEK) during unlock. No manual setting needed |
 | `VEILKEY_TLS_INSECURE` | Set `1` to skip TLS certificate verification |
 | `VEILKEY_CURL_OPTS` | Custom curl options for bulk-apply sync (default: `-sk`) |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -86,11 +86,12 @@ Screen/AI sees:      VK:LOCAL:ea2bfd16
 
 ## Database Encryption
 
-All databases (VaultCenter + LocalVault) are encrypted with SQLCipher. The encryption key is automatically derived from the salt file (`DB_KEY = SHA256(salt)`). No manual `VEILKEY_DB_KEY` setting needed.
+All databases (VaultCenter + LocalVault) are encrypted with SQLCipher. The encryption key is derived from the master password: `DB_KEY = SHA256(KEK)`. Database can only be opened after unlock — salt file alone cannot open the DB.
 
 ```
-salt file (32 bytes, generated at init)
-  → SHA256(salt) → DB_KEY (64-char hex)
+master password (entered during unlock)
+  → KEK = DeriveKEK(password, salt)
+  → DB_KEY = SHA256(KEK)
   → SQLCipher _pragma_key
   → plain sqlite3 cannot read DB
 ```

--- a/docs/setup/env-vars.md
+++ b/docs/setup/env-vars.md
@@ -20,7 +20,7 @@
 |----------|---------|-------------|
 | `VEILKEY_ADDR` | `:10181` / `:10180` | Listen address |
 | `VEILKEY_DB_PATH` | `/data/veilkey.db` | Database path |
-| `VEILKEY_DB_KEY` | **(auto-derived)** | SQLCipher encryption key. Automatically derived from salt file (`SHA256(salt)`). No manual setting needed |
+| `VEILKEY_DB_KEY` | **(KEK-derived)** | SQLCipher encryption key. Derived from master password (KEK) during unlock. DB only opens after password entry |
 | `VEILKEY_TLS_INSECURE` | `0` | Accept self-signed certs (also applies to `init --token` validation) |
 | `VEILKEY_TLS_CERT` | - | TLS certificate path |
 | `VEILKEY_TLS_KEY` | - | TLS private key path |

--- a/services/localvault/internal/commands/server_test.go
+++ b/services/localvault/internal/commands/server_test.go
@@ -42,17 +42,26 @@ func TestServerStartsLocked(t *testing.T) {
 	}
 }
 
-func TestDBKeyDerivedFromSalt(t *testing.T) {
+func TestDBKeyDerivedFromKEK(t *testing.T) {
+	// DB encryption key is derived from KEK (master password) in api.go Unlock().
+	// server.go must NOT contain any direct DB key derivation — it defers to Unlock().
 	src, err := os.ReadFile("server.go")
 	if err != nil {
 		t.Fatalf("failed to read server.go: %v", err)
 	}
 	code := string(src)
-	if !contains(code, "deriveDBKey(salt)") {
-		t.Error("server.go must derive DB key from salt via deriveDBKey()")
+	if contains(code, "deriveDBKey(salt)") {
+		t.Error("server.go must NOT derive DB key from salt directly — KEK-based derivation is in api.go Unlock()")
 	}
-	if !contains(code, "sha256.Sum256") {
-		t.Error("server.go must use SHA256 for DB key derivation")
+
+	// Verify api.go uses KEK-based derivation
+	apiSrc, err := os.ReadFile("../api/api.go")
+	if err != nil {
+		t.Fatalf("failed to read api.go: %v", err)
+	}
+	apiCode := string(apiSrc)
+	if !contains(apiCode, "deriveDBKeyFromKEK") {
+		t.Error("api.go must derive DB key from KEK via deriveDBKeyFromKEK()")
 	}
 }
 

--- a/services/vaultcenter/internal/commands/server_test.go
+++ b/services/vaultcenter/internal/commands/server_test.go
@@ -42,18 +42,26 @@ func TestServerStartsLocked(t *testing.T) {
 	}
 }
 
-func TestDBKeyDerivedFromSalt(t *testing.T) {
-	// DB encryption key must be derived from salt — no separate VEILKEY_DB_KEY required.
+func TestDBKeyDerivedFromKEK(t *testing.T) {
+	// DB encryption key is derived from KEK (master password) in api.go Unlock().
+	// server.go must NOT contain any direct DB key derivation — it defers to Unlock().
 	src, err := os.ReadFile("server.go")
 	if err != nil {
 		t.Fatalf("failed to read server.go: %v", err)
 	}
 	code := string(src)
-	if !contains(code, "deriveDBKey(salt)") {
-		t.Error("server.go must derive DB key from salt via deriveDBKey()")
+	if contains(code, "deriveDBKey(salt)") {
+		t.Error("server.go must NOT derive DB key from salt directly — KEK-based derivation is in api.go Unlock()")
 	}
-	if !contains(code, "sha256.Sum256") {
-		t.Error("server.go must use SHA256 for DB key derivation")
+
+	// Verify api.go uses KEK-based derivation
+	apiSrc, err := os.ReadFile("../api/api.go")
+	if err != nil {
+		t.Fatalf("failed to read api.go: %v", err)
+	}
+	apiCode := string(apiSrc)
+	if !contains(apiCode, "deriveDBKeyFromKEK") {
+		t.Error("api.go must derive DB key from KEK via deriveDBKeyFromKEK()")
 	}
 }
 

--- a/tests/smoke/no-password-on-disk.bats
+++ b/tests/smoke/no-password-on-disk.bats
@@ -33,10 +33,18 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)}"
   [ "$count" -eq 0 ]
 }
 
-@test "DB key derived from salt in VaultCenter server.go" {
-  grep -q 'deriveDBKey(salt)' "$REPO_ROOT/services/vaultcenter/internal/commands/server.go"
+@test "DB key derived from KEK in VaultCenter api.go" {
+  grep -q 'deriveDBKeyFromKEK' "$REPO_ROOT/services/vaultcenter/internal/api/api.go"
 }
 
-@test "DB key derived from salt in LocalVault server.go" {
-  grep -q 'deriveDBKey(salt)' "$REPO_ROOT/services/localvault/internal/commands/server.go"
+@test "DB key derived from KEK in LocalVault api.go" {
+  grep -q 'deriveDBKeyFromKEK' "$REPO_ROOT/services/localvault/internal/api/api.go"
+}
+
+@test "no legacy deriveDBKey(salt) in VaultCenter server.go" {
+  ! grep -q 'deriveDBKey(salt)' "$REPO_ROOT/services/vaultcenter/internal/commands/server.go"
+}
+
+@test "no legacy deriveDBKey(salt) in LocalVault server.go" {
+  ! grep -q 'deriveDBKey(salt)' "$REPO_ROOT/services/localvault/internal/commands/server.go"
 }


### PR DESCRIPTION
## Summary
- All docs and tests still referenced old `deriveDBKey(salt)` / `SHA256(salt)` approach
- Updated to reflect current KEK-based derivation (`DB_KEY = SHA256(KEK)`) from PR #377
- Updated files: env-vars.md, security-model.md, cli.md, README.md, README.ko.md
- Updated Go unit tests (VC + LV) to verify `deriveDBKeyFromKEK` in api.go
- Updated smoke tests to check KEK derivation and reject legacy salt derivation

## Test plan
- [x] `bats tests/smoke/no-password-on-disk.bats` — 8/8 pass
- [x] `go test -run TestDBKey` in both VC and LV — pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)