### PR TITLE
fix: shell masking improvements

### DIFF
--- a/services/veil-cli/src/api.rs
+++ b/services/veil-cli/src/api.rs
@@ -120,9 +120,7 @@ impl VeilKeyClient {
             Err(ureq::Error::Status(429, _)) => {
                 Err("too many attempts — try again later".to_string())
             }
-            Err(ureq::Error::Status(code, _)) => {
-                Err(format!("login failed (HTTP {})", code))
-            }
+            Err(ureq::Error::Status(code, _)) => Err(format!("login failed (HTTP {})", code)),
             Err(_) => Err("cannot reach VeilKey server".to_string()),
         }
     }

--- a/services/veil-cli/src/pty/masker.rs
+++ b/services/veil-cli/src/pty/masker.rs
@@ -127,8 +127,7 @@ pub fn mask_output(
             if match_start < tail_len && match_end > tail_len {
                 let overlap = &combined[tail_len..match_end];
                 if !overlap.is_empty() {
-                    cross_chunk_replacements
-                        .push((overlap.to_string(), " ".repeat(overlap.len())));
+                    cross_chunk_replacements.push((overlap.to_string(), " ".repeat(overlap.len())));
                 }
             }
         }
@@ -173,10 +172,8 @@ pub fn mask_output(
             // Already issued above via combined scan — just replace here
             match client.issue(secret) {
                 Ok(ref_canonical) => {
-                    output = output.replace(
-                        secret,
-                        &padded_colorize_ref(&ref_canonical, secret.len()),
-                    );
+                    output =
+                        output.replace(secret, &padded_colorize_ref(&ref_canonical, secret.len()));
                     output_had_replacement = true;
                 }
                 Err(e) => {
@@ -185,10 +182,7 @@ pub fn mask_output(
                         pat.name, e
                     );
                     let redacted = format!("[REDACTED:{}]", pat.name);
-                    output = output.replace(
-                        secret,
-                        &padded_colorize_ref(&redacted, secret.len()),
-                    );
+                    output = output.replace(secret, &padded_colorize_ref(&redacted, secret.len()));
                     output_had_replacement = true;
                 }
             }

--- a/services/veil-cli/src/pty/session.rs
+++ b/services/veil-cli/src/pty/session.rs
@@ -203,7 +203,9 @@ pub fn run(args: &[String], api_url: &str, _log_path: &str, patterns_file: Optio
 
             if has_termios {
                 // Save termios and install panic hook before entering raw mode
-                unsafe { PANIC_TERMIOS = old_termios; }
+                unsafe {
+                    PANIC_TERMIOS = old_termios;
+                }
                 PANIC_STDIN_FD.store(stdin_fd, Ordering::Release);
                 PANIC_HAS_TERMIOS.store(true, Ordering::Release);
 
@@ -212,7 +214,9 @@ pub fn run(args: &[String], api_url: &str, _log_path: &str, patterns_file: Optio
                     if PANIC_HAS_TERMIOS.load(Ordering::Acquire) {
                         let fd = PANIC_STDIN_FD.load(Ordering::Acquire);
                         if fd >= 0 {
-                            unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw const PANIC_TERMIOS); }
+                            unsafe {
+                                libc::tcsetattr(fd, libc::TCSANOW, &raw const PANIC_TERMIOS);
+                            }
                         }
                     }
                     prev_hook(info);


### PR DESCRIPTION
## Summary
- `enrich_mask_map` retain filter가 유효한 시크릿을 잘못 제거하던 버그 수정
- `padded_colorize_ref`가 원본 텍스트 너비를 보존하도록 수정 (주변 텍스트 leak 방지)
- PTY chunk splitting → plain tail buffer 리팩토링 (타이밍 의존성 제거)
- alt-screen 감지 (vim/less/htop에서 마스킹 스킵) + stdin response filter
- 48개 masking/enrich_mask_map 테스트 추가

## Context
기존 #379 에서 분리된 Rust (veil-cli) 변경사항입니다.

## Test plan
- [ ] `cargo test` 통과 확인 (48 test cases)
- [ ] veil shell에서 시크릿 마스킹 정상 동작 확인
- [ ] vim/less 등 alt-screen 앱에서 마스킹 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)