### PR TITLE
fix: resolve 8 remaining TUI bugs

### DIFF
--- a/services/vaultcenter/internal/tui/page_functions.go
+++ b/services/vaultcenter/internal/tui/page_functions.go
@@ -120,7 +120,7 @@ func (m functionsModel) update(msg tea.Msg, c *Client) (functionsModel, tea.Cmd)
 		case fnTabList:
 			return m.updateList(msg, c)
 		case fnTabBindings:
-			return m.updateBindings(msg)
+			return m.updateBindings(msg, c)
 		}
 	}
 	return m, nil
@@ -164,7 +164,7 @@ func (m functionsModel) updateDetail(msg tea.KeyMsg, c *Client) (functionsModel,
 	return m, nil
 }
 
-func (m functionsModel) updateBindings(msg tea.KeyMsg) (functionsModel, tea.Cmd) {
+func (m functionsModel) updateBindings(msg tea.KeyMsg, c *Client) (functionsModel, tea.Cmd) {
 	switch msg.String() {
 	case "j", "down":
 		if m.bindingCursor < len(m.bindings)-1 {
@@ -174,6 +174,9 @@ func (m functionsModel) updateBindings(msg tea.KeyMsg) (functionsModel, tea.Cmd)
 		if m.bindingCursor > 0 {
 			m.bindingCursor--
 		}
+	case "r":
+		m.loading = true
+		return m, loadBindingsCmd(c)
 	}
 	return m, nil
 }
@@ -275,6 +278,10 @@ func (m functionsModel) viewBindings(width int) string {
 
 	if m.loading {
 		b.WriteString(styleDim.Render("  Loading..."))
+		return b.String()
+	}
+	if m.offline {
+		b.WriteString(styleError.Render("  ⚠ Cannot reach VaultCenter"))
 		return b.String()
 	}
 	if len(m.bindings) == 0 {

--- a/services/vaultcenter/internal/tui/page_keycenter.go
+++ b/services/vaultcenter/internal/tui/page_keycenter.go
@@ -237,6 +237,14 @@ func (m keycenterModel) updateCreate(msg tea.KeyMsg, c *Client) (keycenterModel,
 	case "esc":
 		m.subview = kcList
 		m.creating = false
+	default:
+		var cmd tea.Cmd
+		if m.focusIdx == 0 {
+			m.nameInput, cmd = m.nameInput.Update(msg)
+		} else {
+			m.valueInput, cmd = m.valueInput.Update(msg)
+		}
+		return m, cmd
 	}
 	return m, nil
 }

--- a/services/vaultcenter/internal/tui/page_plugins.go
+++ b/services/vaultcenter/internal/tui/page_plugins.go
@@ -26,7 +26,6 @@ type pluginItem struct {
 
 type pluginsListMsg struct {
 	plugins []pluginItem
-	err     error
 }
 
 func newPluginsModel() pluginsModel {
@@ -37,7 +36,7 @@ func fetchPluginsCmd(c *Client) tea.Cmd {
 	return func() tea.Msg {
 		result, err := c.getJSON("/api/plugins")
 		if err != nil {
-			return pluginsListMsg{err: err}
+			return errMsg{err}
 		}
 		// Parse plugins from result
 		raw, _ := json.Marshal(result["plugins"])
@@ -49,16 +48,13 @@ func fetchPluginsCmd(c *Client) tea.Cmd {
 
 func (m pluginsModel) update(msg tea.Msg, c *Client) (pluginsModel, tea.Cmd) {
 	switch msg := msg.(type) {
-	case loginSuccessMsg:
-		return m, fetchPluginsCmd(c)
+	case errMsg:
+		m.err = msg.err.Error()
+		m.loaded = true
 	case pluginsListMsg:
-		if msg.err != nil {
-			m.err = msg.err.Error()
-		} else {
-			m.plugins = msg.plugins
-			m.loaded = true
-			m.err = ""
-		}
+		m.plugins = msg.plugins
+		m.loaded = true
+		m.err = ""
 	case tea.KeyMsg:
 		if msg.String() == "r" {
 			return m, fetchPluginsCmd(c)

--- a/services/vaultcenter/internal/tui/page_vaults.go
+++ b/services/vaultcenter/internal/tui/page_vaults.go
@@ -284,6 +284,9 @@ func (m vaultsModel) update(msg tea.Msg, c *Client) (vaultsModel, tea.Cmd) {
 	case errMsg:
 		m.loading = false
 		m.offline = true
+		m.secretsLoading = false
+		m.metaLoading = false
+		m.revealing = false
 		return m, nil
 
 	case tea.KeyMsg:
@@ -367,7 +370,7 @@ func (m vaultsModel) update(msg tea.Msg, c *Client) (vaultsModel, tea.Cmd) {
 		case vaultTabAgents:
 			return m.updateAgents(msg, c)
 		case vaultTabCatalog:
-			return m.updateCatalog(msg)
+			return m.updateCatalog(msg, c)
 		}
 	}
 	return m, nil
@@ -455,7 +458,7 @@ func (m vaultsModel) updateAgents(msg tea.KeyMsg, c *Client) (vaultsModel, tea.C
 	return m, nil
 }
 
-func (m vaultsModel) updateCatalog(msg tea.KeyMsg) (vaultsModel, tea.Cmd) {
+func (m vaultsModel) updateCatalog(msg tea.KeyMsg, c *Client) (vaultsModel, tea.Cmd) {
 	switch msg.String() {
 	case "j", "down":
 		if m.catalogCursor < len(m.filteredCatalog)-1 {
@@ -469,6 +472,9 @@ func (m vaultsModel) updateCatalog(msg tea.KeyMsg) (vaultsModel, tea.Cmd) {
 		m.catalogSearching = true
 		m.catalogSearch.SetValue(m.catalogQuery)
 		m.catalogSearch.Focus()
+	case "r":
+		m.loading = true
+		return m, loadCatalogCmd(c)
 	}
 	return m, nil
 }

--- a/services/vaultcenter/internal/tui/tui_test.go
+++ b/services/vaultcenter/internal/tui/tui_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"fmt"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // Domain: truncate must never produce broken UTF-8
@@ -87,6 +89,79 @@ func TestSwitchPageResetsModel(t *testing.T) {
 	m, _ = m.switchPage(pageKeycenter)
 	if m.err != nil {
 		t.Fatal("switchPage must clear m.err")
+	}
+}
+
+// BUG-1: updateCreate must forward regular key input to the focused textinput
+func TestUpdateCreate_ForwardsRegularKeyInput(t *testing.T) {
+	m := newKeycenterModel()
+	m.subview = kcCreate
+	m.creating = true
+	m.focusIdx = 0
+	m.nameInput.Focus()
+
+	// Send a regular character key — should be forwarded to the focused textinput
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+	m2, _ := m.updateCreate(keyMsg, nil)
+
+	if m2.nameInput.Value() != "a" {
+		t.Errorf("expected nameInput to contain 'a', got %q", m2.nameInput.Value())
+	}
+
+	// Now test with focus on valueInput
+	m.focusIdx = 1
+	m.nameInput.Blur()
+	m.valueInput.Focus()
+
+	keyMsg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+	m3, _ := m.updateCreate(keyMsg, nil)
+
+	if m3.valueInput.Value() != "x" {
+		t.Errorf("expected valueInput to contain 'x', got %q", m3.valueInput.Value())
+	}
+}
+
+// BUG-3: plugins must set loaded=true on error so "Loading..." disappears
+func TestPlugins_LoadedTrueOnError(t *testing.T) {
+	m := newPluginsModel()
+	if m.loaded {
+		t.Fatal("expected loaded=false initially")
+	}
+
+	m2, _ := m.update(errMsg{fmt.Errorf("connection refused")}, nil)
+
+	if !m2.loaded {
+		t.Error("expected loaded=true after errMsg")
+	}
+	if m2.err == "" {
+		t.Error("expected err to be set after errMsg")
+	}
+}
+
+// BUG-2: vaults errMsg must reset all loading states
+func TestVaults_ErrMsgResetsAllLoadingStates(t *testing.T) {
+	m := newVaultsModel()
+	m.secretsLoading = true
+	m.metaLoading = true
+	m.revealing = true
+	m.loading = true
+
+	m2, _ := m.update(errMsg{fmt.Errorf("timeout")}, nil)
+
+	if m2.secretsLoading {
+		t.Error("expected secretsLoading=false after errMsg")
+	}
+	if m2.metaLoading {
+		t.Error("expected metaLoading=false after errMsg")
+	}
+	if m2.revealing {
+		t.Error("expected revealing=false after errMsg")
+	}
+	if m2.loading {
+		t.Error("expected loading=false after errMsg")
+	}
+	if !m2.offline {
+		t.Error("expected offline=true after errMsg")
 	}
 }
 


### PR DESCRIPTION
## Summary
- **BUG-1**: Keycenter create textinput was broken — regular key input now forwarded to focused textinput via default case in `updateCreate()`
- **BUG-2**: Vaults `errMsg` handler now resets `secretsLoading`, `metaLoading`, and `revealing` states
- **BUG-3**: Plugins sets `loaded=true` on error so "Loading..." stops showing
- **BUG-4**: Functions Bindings tab now supports `r` key for refresh
- **BUG-5**: Vaults Catalog tab now supports `r` key for refresh
- **BUG-6**: Functions `viewBindings()` now checks `m.offline` like `viewList()` does
- **BUG-7**: `fetchPluginsCmd` returns `errMsg` on error so parent Model shows it in status bar
- **BUG-8**: Removed dead `loginSuccessMsg` case from plugins `update()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tui/...` passes
- [x] New tests: `TestUpdateCreate_ForwardsRegularKeyInput`, `TestPlugins_LoadedTrueOnError`, `TestVaults_ErrMsgResetsAllLoadingStates`
- [ ] Manual: verify keycenter create form accepts typed characters
- [ ] Manual: verify plugins page shows error instead of infinite loading
- [ ] Manual: verify catalog/bindings tabs respond to `r` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)