### PR TITLE
fix: remove duplicate code in heartbeat + unlock

### DIFF
--- a/services/localvault/internal/api/api.go
+++ b/services/localvault/internal/api/api.go
@@ -431,11 +431,6 @@ func (s *Server) handleUnlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(req.Password) > 256 {
-		s.respondError(w, http.StatusBadRequest, "password too long")
-		return
-	}
-
 	kek := crypto.DeriveKEK(req.Password, s.salt)
 	if err := s.Unlock(kek); err != nil {
 		log.Printf("Unlock failed from %s: %v", r.RemoteAddr, err)

--- a/services/localvault/internal/api/heartbeat.go
+++ b/services/localvault/internal/api/heartbeat.go
@@ -99,9 +99,6 @@ func (s *Server) SendHeartbeatOnce(endpoint, label string, port int) error {
 	if saltBytes := s.Salt(); len(saltBytes) > 0 {
 		payload["salt"] = base64.StdEncoding.EncodeToString(saltBytes)
 	}
-	if saltBytes := s.Salt(); len(saltBytes) > 0 {
-		payload["salt"] = base64.StdEncoding.EncodeToString(saltBytes)
-	}
 	// Include registration token for first-time registration
 	if regToken, err := s.db.GetConfig("VEILKEY_REGISTRATION_TOKEN"); err == nil && regToken != nil && regToken.Value != "" {
 		payload["registration_token"] = regToken.Value


### PR DESCRIPTION
중복 코드 제거:
- heartbeat.go: salt 전송 블록이 2번 반복됨 → 1번으로
- api.go handleUnlock: password 길이 체크가 2번 → 1번으로

🤖 Generated with [Claude Code](https://claude.com/claude-code)