### PR TITLE
test: cover 5 untested packages — 73 new tests

### DIFF
--- a/services/localvault/internal/api/configs/configs_test.go
+++ b/services/localvault/internal/api/configs/configs_test.go
@@ -1,0 +1,230 @@
+package configs
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── Source analysis: handler.go — route registration ──────────────────────────
+
+func TestSource_GETRoutesWrappedWithTrusted(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	getRoutes := []string{
+		"GET /api/configs",
+		"GET /api/configs/{key}",
+	}
+	for _, route := range getRoutes {
+		found := false
+		for _, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "trusted(") {
+					t.Errorf("GET route %s must be wrapped with trusted()", route)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("GET route not registered: %s", route)
+		}
+	}
+}
+
+func TestSource_WriteRoutesWrappedWithTrusted(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	writeRoutes := []string{
+		"POST /api/configs",
+		"PUT /api/configs/bulk",
+		"DELETE /api/configs/{key}",
+	}
+	for _, route := range writeRoutes {
+		found := false
+		for _, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "trusted(") {
+					t.Errorf("write route %s must be wrapped with trusted()", route)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("write route not registered: %s", route)
+		}
+	}
+}
+
+// ── Source analysis: configs.go — config key validation ───────────────────────
+
+func TestSource_ConfigKeyValidation(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	// All CRUD handlers must validate keys
+	handlers := []string{
+		"func (h *Handler) handleGetConfig(",
+		"func (h *Handler) handleSaveConfig(",
+		"func (h *Handler) handleDeleteConfig(",
+	}
+	for _, handler := range handlers {
+		fnBody := extractFn(content, handler)
+		if !strings.Contains(fnBody, "isValidResourceName") {
+			t.Errorf("handler %s must validate key with isValidResourceName", handler)
+		}
+	}
+}
+
+func TestSource_ConfigKeyValidationMessage(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `[A-Z_][A-Z0-9_]*`) {
+		t.Error("config key validation error must describe the expected pattern [A-Z_][A-Z0-9_]*")
+	}
+}
+
+// ── Source analysis: configs.go — bulk operations ─────────────────────────────
+
+func TestSource_BulkOperationsMaxLimit(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveConfigsBulk(")
+	if !strings.Contains(fnBody, "MaxBulkItems") {
+		t.Error("bulk save must enforce MaxBulkItems limit")
+	}
+}
+
+func TestSource_BulkOperationsValidatesAllKeys(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveConfigsBulk(")
+	if !strings.Contains(fnBody, "isValidResourceName(k)") {
+		t.Error("bulk save must validate every key with isValidResourceName")
+	}
+}
+
+func TestSource_BulkOperationsRequiresNonEmpty(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveConfigsBulk(")
+	if !strings.Contains(fnBody, `len(req.Configs) == 0`) {
+		t.Error("bulk save must reject empty configs map")
+	}
+}
+
+// ── Source analysis: configs.go — response format ─────────────────────────────
+
+func TestSource_ListConfigsResponseFormat(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleListConfigs(")
+	for _, field := range []string{`"configs"`, `"count"`} {
+		if !strings.Contains(fnBody, field) {
+			t.Errorf("list configs response must include field: %s", field)
+		}
+	}
+}
+
+func TestSource_GetConfigResponseFormat(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleGetConfig(")
+	for _, field := range []string{`"key"`, `"value"`, `"ref"`, `"scope"`, `"status"`} {
+		if !strings.Contains(fnBody, field) {
+			t.Errorf("get config response must include field: %s", field)
+		}
+	}
+}
+
+// ── Source analysis: constants.go — ref constants ─────────────────────────────
+
+func TestSource_RefConstants(t *testing.T) {
+	src, err := os.ReadFile("constants.go")
+	if err != nil {
+		t.Fatalf("failed to read constants.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "refFamilyVE") {
+		t.Error("configs package must define refFamilyVE constant")
+	}
+	if !strings.Contains(content, "refScopeLocal") {
+		t.Error("configs package must define refScopeLocal constant")
+	}
+	if !strings.Contains(content, "refStatusActive") {
+		t.Error("configs package must define refStatusActive constant")
+	}
+	if !strings.Contains(content, "refStatusBlock") {
+		t.Error("configs package must define refStatusBlock constant")
+	}
+}
+
+// ── Source analysis: configs.go — blocked config returns 423 ──────────────────
+
+func TestSource_BlockedConfigReturnsLocked(t *testing.T) {
+	src, err := os.ReadFile("configs.go")
+	if err != nil {
+		t.Fatalf("failed to read configs.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleGetConfig(")
+	if !strings.Contains(fnBody, "refStatusBlock") {
+		t.Error("handleGetConfig must check for blocked status")
+	}
+	if !strings.Contains(fnBody, "StatusLocked") {
+		t.Error("handleGetConfig must return StatusLocked (423) for blocked configs")
+	}
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+func extractFn(code, sig string) string {
+	i := strings.Index(code, sig)
+	if i < 0 {
+		return ""
+	}
+	rest := code[i:]
+	next := strings.Index(rest[1:], "\nfunc ")
+	if next < 0 {
+		return rest
+	}
+	return rest[:next+1]
+}

--- a/services/localvault/internal/api/secrets/secrets_test.go
+++ b/services/localvault/internal/api/secrets/secrets_test.go
@@ -1,0 +1,322 @@
+package secrets
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── Source analysis: secrets.go — /api/resolve/{ref} returns 403 ──────────────
+
+func TestSource_ResolveSecretReturns403(t *testing.T) {
+	src, err := os.ReadFile("secrets.go")
+	if err != nil {
+		t.Fatalf("failed to read secrets.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleResolveSecret(")
+	if !strings.Contains(fnBody, "StatusForbidden") {
+		t.Error("handleResolveSecret must return StatusForbidden (403)")
+	}
+	if !strings.Contains(fnBody, "plaintext resolution is disabled") || !strings.Contains(fnBody, "localvault direct") {
+		t.Error("handleResolveSecret must state that localvault direct plaintext resolution is disabled")
+	}
+}
+
+func TestSource_SaveSecretReturns403(t *testing.T) {
+	src, err := os.ReadFile("secrets.go")
+	if err != nil {
+		t.Fatalf("failed to read secrets.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveSecret(")
+	if !strings.Contains(fnBody, "StatusForbidden") {
+		t.Error("handleSaveSecret must return StatusForbidden (403)")
+	}
+}
+
+func TestSource_GetSecretReturns403(t *testing.T) {
+	src, err := os.ReadFile("secrets.go")
+	if err != nil {
+		t.Fatalf("failed to read secrets.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleGetSecret(")
+	if !strings.Contains(fnBody, "StatusForbidden") {
+		t.Error("handleGetSecret must return StatusForbidden (403)")
+	}
+}
+
+// ── Source analysis: handler.go — cipher routes require agentAuth ─────────────
+
+func TestSource_CipherGetRequiresAgentAuth(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "GET /api/cipher/{ref}") && !strings.Contains(line, "fields") {
+			if !strings.Contains(line, "agentAuth(") {
+				t.Error("GET /api/cipher/{ref} must be wrapped with agentAuth")
+			}
+			return
+		}
+	}
+	t.Error("GET /api/cipher/{ref} route not found")
+}
+
+func TestSource_CipherPostRequiresAgentAuth(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "POST /api/cipher") && !strings.Contains(line, "{ref}") {
+			if !strings.Contains(line, "agentAuth(") {
+				t.Error("POST /api/cipher must be wrapped with agentAuth")
+			}
+			return
+		}
+	}
+	t.Error("POST /api/cipher route not found")
+}
+
+func TestSource_CipherFieldRequiresAgentAuth(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "GET /api/cipher/{ref}/fields/{field}") {
+			if !strings.Contains(line, "agentAuth(") {
+				t.Error("GET /api/cipher/{ref}/fields/{field} must be wrapped with agentAuth")
+			}
+			return
+		}
+	}
+	t.Error("GET /api/cipher/{ref}/fields/{field} route not found")
+}
+
+// ── Source analysis: cipher_save.go — secret ref generation ──────────────────
+
+func TestSource_SecretRefUsesGenerateHexRef(t *testing.T) {
+	src, err := os.ReadFile("cipher_save.go")
+	if err != nil {
+		t.Fatalf("failed to read cipher_save.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `crypto.GenerateHexRef(8)`) {
+		t.Error("secret ref generation must use crypto.GenerateHexRef(8)")
+	}
+}
+
+func TestSource_CipherSaveValidatesName(t *testing.T) {
+	src, err := os.ReadFile("cipher_save.go")
+	if err != nil {
+		t.Fatalf("failed to read cipher_save.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveCipher(")
+	if !strings.Contains(fnBody, "isValidResourceName(req.Name)") {
+		t.Error("handleSaveCipher must validate name with isValidResourceName")
+	}
+}
+
+func TestSource_CipherSaveRequiresCiphertextAndNonce(t *testing.T) {
+	src, err := os.ReadFile("cipher_save.go")
+	if err != nil {
+		t.Fatalf("failed to read cipher_save.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveCipher(")
+	if !strings.Contains(fnBody, "len(req.Ciphertext) == 0") {
+		t.Error("handleSaveCipher must require non-empty ciphertext")
+	}
+	if !strings.Contains(fnBody, "len(req.Nonce) == 0") {
+		t.Error("handleSaveCipher must require non-empty nonce")
+	}
+}
+
+// ── Source analysis: fields.go — field management ─────────────────────────────
+
+func TestSource_SecretFieldsRequireActiveLifecycle(t *testing.T) {
+	src, err := os.ReadFile("fields.go")
+	if err != nil {
+		t.Fatalf("failed to read fields.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleSaveSecretFields(")
+	if !strings.Contains(fnBody, "refStatusActive") {
+		t.Error("handleSaveSecretFields must check for active status")
+	}
+	if !strings.Contains(fnBody, "VK:LOCAL or VK:EXTERNAL active lifecycle") {
+		t.Error("handleSaveSecretFields must enforce VK:LOCAL or VK:EXTERNAL scope")
+	}
+}
+
+func TestSource_DeleteFieldRequiresActiveLifecycle(t *testing.T) {
+	src, err := os.ReadFile("fields.go")
+	if err != nil {
+		t.Fatalf("failed to read fields.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) handleDeleteSecretField(")
+	if !strings.Contains(fnBody, "refStatusActive") {
+		t.Error("handleDeleteSecretField must check for active status")
+	}
+}
+
+func TestSource_FieldTypeNormalization(t *testing.T) {
+	src, err := os.ReadFile("fields.go")
+	if err != nil {
+		t.Fatalf("failed to read fields.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "func normalizeSecretFieldType(") {
+		t.Error("normalizeSecretFieldType function must exist")
+	}
+}
+
+func TestUnit_NormalizeSecretFieldType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"login", "login"},
+		{"otp", "otp"},
+		{"password", "password"},
+		{"key", "key"},
+		{"url", "url"},
+		{"unknown", "text"},
+		{"", "text"},
+	}
+	for _, tt := range tests {
+		got := normalizeSecretFieldType(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeSecretFieldType(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// ── Source analysis: handler.go — catalog/meta endpoint exists ────────────────
+
+func TestSource_SecretMetaEndpointExists(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "GET /api/secrets/meta/{name}") {
+		t.Error("secret meta endpoint GET /api/secrets/meta/{name} must be registered")
+	}
+}
+
+func TestSource_RekeyEndpointRequiresAgentAuth(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "POST /api/rekey") {
+			if !strings.Contains(line, "agentAuth(") {
+				t.Error("POST /api/rekey must be wrapped with agentAuth")
+			}
+			return
+		}
+	}
+	t.Error("POST /api/rekey route not found")
+}
+
+// ── Source analysis: secrets.go — resolve route is registered ─────────────────
+
+func TestSource_ResolveRouteRegistered(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "GET /api/resolve/{ref}") {
+		t.Error("GET /api/resolve/{ref} route must be registered")
+	}
+}
+
+// ── Source analysis: helpers.go — vaultcenter message constant ────────────────
+
+func TestSource_VaultcenterOnlyDecryptMessage(t *testing.T) {
+	src, err := os.ReadFile("helpers.go")
+	if err != nil {
+		t.Fatalf("failed to read helpers.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "vaultcenterOnlyDecryptMessage") {
+		t.Error("vaultcenterOnlyDecryptMessage constant must be defined")
+	}
+	if !strings.Contains(content, "localvault direct plaintext handling is disabled") {
+		t.Error("vaultcenterOnlyDecryptMessage must state plaintext handling is disabled")
+	}
+}
+
+// ── Source analysis: handler.go — fields routes require agentAuth ─────────────
+
+func TestSource_FieldsRoutesRequireAgentAuth(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	fieldRoutes := []string{
+		"POST /api/secrets/fields",
+		"DELETE /api/secrets/{name}/fields/{field}",
+	}
+	for _, route := range fieldRoutes {
+		found := false
+		for _, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "agentAuth(") {
+					t.Errorf("field route %s must be wrapped with agentAuth", route)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("field route not registered: %s", route)
+		}
+	}
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+func extractFn(code, sig string) string {
+	i := strings.Index(code, sig)
+	if i < 0 {
+		return ""
+	}
+	rest := code[i:]
+	next := strings.Index(rest[1:], "\nfunc ")
+	if next < 0 {
+		return rest
+	}
+	return rest[:next+1]
+}

--- a/services/vaultcenter/internal/api/admin/admin_auth_test.go
+++ b/services/vaultcenter/internal/api/admin/admin_auth_test.go
@@ -1,0 +1,305 @@
+package admin
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── Source analysis: admin_auth.go — session management and TOTP ──────────────
+
+func TestSource_AdminSessionCookieName(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `adminSessionCookieName`) {
+		t.Error("admin session cookie name constant must be defined")
+	}
+	if !strings.Contains(content, `"vk_session"`) {
+		t.Error("admin session cookie name must be vk_session")
+	}
+}
+
+func TestSource_SessionTTLUsesEnvDuration(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func adminSessionTTL()`) {
+		t.Error("adminSessionTTL function must exist")
+	}
+	if !strings.Contains(content, `envDuration("VEILKEY_ADMIN_SESSION_TTL"`) {
+		t.Error("session TTL must use envDuration with VEILKEY_ADMIN_SESSION_TTL")
+	}
+}
+
+func TestSource_SessionIdleTimeoutUsesEnvDuration(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func adminSessionIdleTimeout()`) {
+		t.Error("adminSessionIdleTimeout function must exist")
+	}
+	if !strings.Contains(content, `envDuration("VEILKEY_ADMIN_SESSION_IDLE_TIMEOUT"`) {
+		t.Error("idle timeout must use envDuration with VEILKEY_ADMIN_SESSION_IDLE_TIMEOUT")
+	}
+}
+
+func TestSource_TOTPUsesConstantTimeCompare(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `"crypto/subtle"`) {
+		t.Error("admin_auth.go must import crypto/subtle for TOTP comparison")
+	}
+	if !strings.Contains(content, `subtle.ConstantTimeCompare`) {
+		t.Error("TOTP verification must use subtle.ConstantTimeCompare")
+	}
+}
+
+func TestSource_TOTPWindowTolerance(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	// verifyTOTP must check offsets -1, 0, +1
+	if !strings.Contains(content, `func verifyTOTP(`) {
+		t.Error("verifyTOTP function must exist")
+	}
+	if !strings.Contains(content, `for offset := -1; offset <= 1; offset++`) {
+		t.Error("TOTP verification must check window offsets -1, 0, +1")
+	}
+}
+
+func TestSource_RevealWindowDurationConstant(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `adminRevealWindow`) {
+		t.Error("adminRevealWindow constant must be defined")
+	}
+	if !strings.Contains(content, `5 * time.Minute`) {
+		t.Error("reveal window must be 5 minutes")
+	}
+}
+
+func TestSource_CookieFlags_HttpOnly_Secure_SameSiteStrict(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func setAdminSessionCookie(`) {
+		t.Fatal("setAdminSessionCookie function must exist")
+	}
+
+	fnBody := extractFnBody(content, "func setAdminSessionCookie(")
+	if !strings.Contains(fnBody, "HttpOnly: true") {
+		t.Error("session cookie must have HttpOnly: true")
+	}
+	if !strings.Contains(fnBody, "Secure:   true") && !strings.Contains(fnBody, "Secure: true") {
+		t.Error("session cookie must have Secure: true")
+	}
+	if !strings.Contains(fnBody, "SameSite: http.SameSiteStrictMode") {
+		t.Error("session cookie must have SameSite: http.SameSiteStrictMode")
+	}
+}
+
+func TestSource_TokenHashUsesSHA256(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func hashAdminSessionToken(`) {
+		t.Error("hashAdminSessionToken function must exist")
+	}
+	fnBody := extractFnBody(content, "func hashAdminSessionToken(")
+	if !strings.Contains(fnBody, "sha256.Sum256") {
+		t.Error("token hash must use SHA256")
+	}
+}
+
+// ── Source analysis: passkey.go — COSE key validation ─────────────────────────
+
+func TestSource_Passkey_COSEKeyValidation(t *testing.T) {
+	src, err := os.ReadFile("passkey.go")
+	if err != nil {
+		t.Fatalf("failed to read passkey.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func parseCOSEES256Key(`) {
+		t.Error("parseCOSEES256Key function must exist for COSE key validation")
+	}
+	// Must validate key type EC2
+	if !strings.Contains(content, `kty != 2`) {
+		t.Error("COSE key validation must check kty == 2 (EC2)")
+	}
+	// Must validate algorithm ES256
+	if !strings.Contains(content, `alg != -7`) {
+		t.Error("COSE key validation must check alg == -7 (ES256)")
+	}
+	// Must validate curve P-256
+	if !strings.Contains(content, `crv != 1`) {
+		t.Error("COSE key validation must check crv == 1 (P-256)")
+	}
+	// Must validate point is on curve
+	if !strings.Contains(content, `IsOnCurve`) {
+		t.Error("COSE key validation must check IsOnCurve")
+	}
+}
+
+func TestSource_Passkey_ChallengeUsesCryptoRand(t *testing.T) {
+	src, err := os.ReadFile("passkey.go")
+	if err != nil {
+		t.Fatalf("failed to read passkey.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `"crypto/rand"`) {
+		t.Error("passkey.go must import crypto/rand for challenge generation")
+	}
+	if !strings.Contains(content, `rand.Read(challenge)`) {
+		t.Error("passkey challenge must use crypto/rand.Read")
+	}
+}
+
+// ── Source analysis: handler.go — route registration ──────────────────────────
+
+func TestSource_Handler_RequireAdminSessionMiddleware(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func (h *Handler) RequireAdminSession(`) {
+		t.Error("RequireAdminSession middleware must exist")
+	}
+	if !strings.Contains(content, `"admin session required"`) {
+		t.Error("RequireAdminSession must return 'admin session required' error")
+	}
+}
+
+func TestSource_Handler_ProtectedRoutesUseAdminSession(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	protectedRoutes := []string{
+		"GET /api/admin/approval-challenges",
+		"GET /api/admin/audit/recent",
+		"POST /api/admin/reveal-authorize",
+		"POST /api/admin/reveal",
+	}
+	for _, route := range protectedRoutes {
+		found := false
+		for _, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "RequireAdminSession") {
+					t.Errorf("route %s must be wrapped with RequireAdminSession", route)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("protected route not registered: %s", route)
+		}
+	}
+}
+
+// ── Source analysis: preview handlers ─────────────────────────────────────────
+
+func TestSource_StaticPreviewHandlersExist(t *testing.T) {
+	files := map[string][]string{
+		"admin_vue_preview.go": {
+			"func (h *Handler) HandleAdminVuePreview(",
+		},
+		"admin_html_only_preview.go": {
+			"func (h *Handler) HandleAdminHTMLOneShotPreview(",
+		},
+		"admin_mockup_previews.go": {
+			"func (h *Handler) HandleAdminMockupDark(",
+			"func (h *Handler) HandleAdminMockupAmber(",
+			"func (h *Handler) HandleAdminMockupMono(",
+		},
+	}
+
+	for file, sigs := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", file, err)
+		}
+		content := string(src)
+		for _, sig := range sigs {
+			if !strings.Contains(content, sig) {
+				t.Errorf("preview handler must exist in %s: %s", file, sig)
+			}
+		}
+	}
+}
+
+// ── Source analysis: admin_auth.go — TOTP algorithm uses SHA256 ───────────────
+
+func TestSource_TOTPAlgorithmUsesSHA256(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFnBody(content, "func totpCode(")
+	if !strings.Contains(fnBody, "hmac.New(sha256.New") {
+		t.Error("TOTP code generation must use HMAC-SHA256")
+	}
+}
+
+func TestSource_TOTPURIIncludesAlgorithmSHA256(t *testing.T) {
+	src, err := os.ReadFile("admin_auth.go")
+	if err != nil {
+		t.Fatalf("failed to read admin_auth.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFnBody(content, "func buildTOTPURI(")
+	if !strings.Contains(fnBody, `"SHA256"`) {
+		t.Error("TOTP URI must specify algorithm=SHA256")
+	}
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+func extractFnBody(code, sig string) string {
+	i := strings.Index(code, sig)
+	if i < 0 {
+		return ""
+	}
+	rest := code[i:]
+	next := strings.Index(rest[1:], "\nfunc ")
+	if next < 0 {
+		return rest
+	}
+	return rest[:next+1]
+}

--- a/services/vaultcenter/internal/api/approval/approval_test.go
+++ b/services/vaultcenter/internal/api/approval/approval_test.go
@@ -1,0 +1,275 @@
+package approval
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── Source analysis: tokens.go — HTML escaping (XSS prevention) ───────────────
+
+func TestSource_TokenHTML_EscapesOutput(t *testing.T) {
+	src, err := os.ReadFile("tokens.go")
+	if err != nil {
+		t.Fatalf("failed to read tokens.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func escapeApprovalHTML(`) {
+		t.Error("escapeApprovalHTML function must exist for XSS prevention")
+	}
+	// Must escape all five standard HTML entities
+	for _, entity := range []string{"&amp;", "&lt;", "&gt;", "&quot;", "&#39;"} {
+		if !strings.Contains(content, entity) {
+			t.Errorf("escapeApprovalHTML must produce HTML entity: %s", entity)
+		}
+	}
+}
+
+func TestSource_TokenHTML_AllFieldsEscaped(t *testing.T) {
+	src, err := os.ReadFile("tokens.go")
+	if err != nil {
+		t.Fatalf("failed to read tokens.go: %v", err)
+	}
+	content := string(src)
+
+	// The handleApprovalTokenPage function must escape all dynamic values
+	fnBody := extractFn(content, "func (h *Handler) handleApprovalTokenPage(")
+	escapeCount := strings.Count(fnBody, "escapeApprovalHTML(")
+	if escapeCount < 4 {
+		t.Errorf("handleApprovalTokenPage must escape at least 4 fields, found %d calls to escapeApprovalHTML", escapeCount)
+	}
+}
+
+func TestUnit_EscapeApprovalHTML(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`<script>alert("xss")</script>`, `&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;`},
+		{`Hello & goodbye`, `Hello &amp; goodbye`},
+		{`it's fine`, `it&#39;s fine`},
+		{`plain text`, `plain text`},
+	}
+	for _, tt := range tests {
+		got := escapeApprovalHTML(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeApprovalHTML(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// ── Source analysis: email_otp.go — OTP uses crypto/rand ──────────────────────
+
+func TestSource_OTPCodeUsesCryptoRand(t *testing.T) {
+	src, err := os.ReadFile("email_otp.go")
+	if err != nil {
+		t.Fatalf("failed to read email_otp.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `"crypto/rand"`) {
+		t.Error("email_otp.go must import crypto/rand")
+	}
+	if !strings.Contains(content, `func secureRandInt(`) {
+		t.Error("secureRandInt function must exist for unbiased random generation")
+	}
+	if !strings.Contains(content, `rand.Int(rand.Reader`) {
+		t.Error("OTP code generation must use crypto/rand.Int for unbiased randomness")
+	}
+}
+
+func TestSource_OTPHasBodySizeLimit(t *testing.T) {
+	src, err := os.ReadFile("email_otp.go")
+	if err != nil {
+		t.Fatalf("failed to read email_otp.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `MaxBytesReader`) {
+		t.Error("email OTP submit handler must use MaxBytesReader to limit body size")
+	}
+}
+
+func TestSource_OTPUsesConstantTimeCompare(t *testing.T) {
+	src, err := os.ReadFile("email_otp.go")
+	if err != nil {
+		t.Fatalf("failed to read email_otp.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `"crypto/subtle"`) {
+		t.Error("email_otp.go must import crypto/subtle")
+	}
+	if !strings.Contains(content, `subtle.ConstantTimeCompare`) {
+		t.Error("OTP verification must use subtle.ConstantTimeCompare")
+	}
+}
+
+func TestSource_OTPCodeHashedWithSHA256(t *testing.T) {
+	src, err := os.ReadFile("email_otp.go")
+	if err != nil {
+		t.Fatalf("failed to read email_otp.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func hashEmailOTPCode(`) {
+		t.Error("hashEmailOTPCode function must exist")
+	}
+	fnBody := extractFn(content, "func hashEmailOTPCode(")
+	if !strings.Contains(fnBody, "sha256.Sum256") {
+		t.Error("OTP code hash must use SHA256")
+	}
+}
+
+// ── Source analysis: secret_input.go — body size limit ────────────────────────
+
+func TestSource_SecretInputHasBodySizeLimit(t *testing.T) {
+	src, err := os.ReadFile("secret_input.go")
+	if err != nil {
+		t.Fatalf("failed to read secret_input.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `MaxBytesReader`) {
+		t.Error("secret input submit handler must use MaxBytesReader to limit body size")
+	}
+}
+
+func TestSource_SecretInputRequiresValueAndConfirm(t *testing.T) {
+	src, err := os.ReadFile("secret_input.go")
+	if err != nil {
+		t.Fatalf("failed to read secret_input.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `req.Value != req.Confirm`) {
+		t.Error("secret input must verify value and confirm match")
+	}
+}
+
+func TestSource_SecretInputStoresViaAgentEndpoint(t *testing.T) {
+	src, err := os.ReadFile("secret_input.go")
+	if err != nil {
+		t.Fatalf("failed to read secret_input.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func (h *Handler) storeSecretViaAgentEndpoint(`) {
+		t.Error("storeSecretViaAgentEndpoint function must exist")
+	}
+	// Must validate endpoint contains /api/agents/
+	if !strings.Contains(content, `/api/agents/`) {
+		t.Error("storeSecretViaAgentEndpoint must validate endpoint contains /api/agents/")
+	}
+}
+
+// ── Source analysis: handler.go — route registration ──────────────────────────
+
+func TestSource_Handler_RequireTrustedIPOnWriteRoutes(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	trustedRoutes := []string{
+		"POST /api/approvals/email-otp/request",
+		"POST /api/approvals/secret-input/request",
+	}
+	for _, route := range trustedRoutes {
+		found := false
+		for _, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "requireTrustedIP") {
+					t.Errorf("write route %s must be wrapped with requireTrustedIP", route)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("trusted route not registered: %s", route)
+		}
+	}
+}
+
+func TestSource_Handler_ApprovalTokenRoutesExist(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	routes := []string{
+		"GET /approve/t/{token}",
+		"POST /approve/t/{token}",
+		"GET /ui/approvals/email-otp",
+		"POST /ui/approvals/email-otp",
+		"GET /ui/approvals/secret-input",
+		"POST /ui/approvals/secret-input",
+	}
+	for _, route := range routes {
+		if !strings.Contains(content, route) {
+			t.Errorf("approval route not registered: %s", route)
+		}
+	}
+}
+
+// ── Source analysis: tokens.go — challenge status lifecycle ───────────────────
+
+func TestSource_ChallengeStatusLifecycle(t *testing.T) {
+	src, err := os.ReadFile("tokens.go")
+	if err != nil {
+		t.Fatalf("failed to read tokens.go: %v", err)
+	}
+	content := string(src)
+
+	// Status transitions: pending -> submitted (via CompleteApprovalTokenChallenge)
+	if !strings.Contains(content, `"submitted"`) {
+		t.Error("tokens.go must reference 'submitted' status")
+	}
+	if !strings.Contains(content, `challenge.Status == "submitted"`) {
+		t.Error("tokens.go must check for already-submitted challenges")
+	}
+	if !strings.Contains(content, `CompleteApprovalTokenChallenge`) {
+		t.Error("tokens.go must call CompleteApprovalTokenChallenge to transition status")
+	}
+}
+
+// ── Source analysis: email_otp.go — email template fields ─────────────────────
+
+func TestSource_EmailOTPTemplateHasRequiredFields(t *testing.T) {
+	src, err := os.ReadFile("email_otp.go")
+	if err != nil {
+		t.Fatalf("failed to read email_otp.go: %v", err)
+	}
+	content := string(src)
+
+	requiredFields := []string{
+		"Target email:",
+		"Send code by email",
+		"6-digit code",
+		"Verify code",
+	}
+	for _, field := range requiredFields {
+		if !strings.Contains(content, field) {
+			t.Errorf("email OTP template must include: %s", field)
+		}
+	}
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+func extractFn(code, sig string) string {
+	i := strings.Index(code, sig)
+	if i < 0 {
+		return ""
+	}
+	rest := code[i:]
+	next := strings.Index(rest[1:], "\nfunc ")
+	if next < 0 {
+		return rest
+	}
+	return rest[:next+1]
+}

--- a/services/vaultcenter/internal/api/bulk/bulk_test.go
+++ b/services/vaultcenter/internal/api/bulk/bulk_test.go
@@ -1,0 +1,295 @@
+package bulk
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── Source analysis: files.go — template format allowlist ─────────────────────
+
+func TestSource_TemplateFormatAllowlist(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "allowedBulkApplyFormatsFile") {
+		t.Error("bulk apply templates must define allowedBulkApplyFormatsFile")
+	}
+	for _, format := range []string{`"env"`, `"json"`, `"json_merge"`, `"line_patch"`, `"raw"`} {
+		if !strings.Contains(content, format) {
+			t.Errorf("allowed formats must include: %s", format)
+		}
+	}
+}
+
+func TestSource_TemplateFormatValidated(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `allowedBulkApplyFormatsFile[format]`) {
+		t.Error("template normalization must validate format against allowlist")
+	}
+}
+
+func TestUnit_AllowedFormatsMap(t *testing.T) {
+	expected := []string{"env", "json", "json_merge", "line_patch", "raw"}
+	for _, format := range expected {
+		if _, ok := allowedBulkApplyFormatsFile[format]; !ok {
+			t.Errorf("allowedBulkApplyFormatsFile must include %q", format)
+		}
+	}
+	if len(allowedBulkApplyFormatsFile) != len(expected) {
+		t.Errorf("allowedBulkApplyFormatsFile has %d entries, want %d", len(allowedBulkApplyFormatsFile), len(expected))
+	}
+}
+
+// ── Source analysis: workflows.go — workflow step validation ──────────────────
+
+func TestSource_WorkflowStepValidation(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func (h *Handler) loadBulkApplyWorkflowFile(")
+	if !strings.Contains(fnBody, `len(workflow.Steps) == 0`) {
+		t.Error("workflow validation must check for at least one step")
+	}
+	if !strings.Contains(fnBody, `step.Template`) {
+		t.Error("workflow validation must check each step has a template reference")
+	}
+}
+
+func TestSource_WorkflowStepSummaryHasPrechecks(t *testing.T) {
+	src, err := os.ReadFile("workflows.go")
+	if err != nil {
+		t.Fatalf("failed to read workflows.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func bulkApplyWorkflowStepSummaryFromTemplate(")
+	if !strings.Contains(fnBody, "ensure_target_parent_exists") {
+		t.Error("workflow step must have ensure_target_parent_exists precheck")
+	}
+	if !strings.Contains(fnBody, "ensure_target_parent_writable") {
+		t.Error("workflow step must have ensure_target_parent_writable precheck")
+	}
+}
+
+func TestSource_WorkflowStepPostchecksPerFormat(t *testing.T) {
+	src, err := os.ReadFile("workflows.go")
+	if err != nil {
+		t.Fatalf("failed to read workflows.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func bulkApplyWorkflowStepSummaryFromTemplate(")
+	checks := map[string]string{
+		`"json"`:       "json_parse",
+		`"json_merge"`: "json_merge_verify",
+		`"line_patch"`: "line_patch_verify",
+	}
+	for format, postcheck := range checks {
+		if !strings.Contains(fnBody, format) {
+			t.Errorf("workflow postchecks must handle format: %s", format)
+		}
+		if !strings.Contains(fnBody, postcheck) {
+			t.Errorf("format %s must produce postcheck: %s", format, postcheck)
+		}
+	}
+}
+
+// ── Source analysis: files.go — atomic write pattern ──────────────────────────
+
+func TestSource_AtomicWritePattern(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `func atomicWriteFile(`) {
+		t.Error("atomicWriteFile function must exist")
+	}
+	fnBody := extractFn(content, "func atomicWriteFile(")
+	// Must use temp file + rename pattern
+	if !strings.Contains(fnBody, `.tmp-`) {
+		t.Error("atomicWriteFile must create a temp file with .tmp- suffix")
+	}
+	if !strings.Contains(fnBody, `os.WriteFile(tmp`) {
+		t.Error("atomicWriteFile must write to temp file first")
+	}
+	if !strings.Contains(fnBody, `os.Rename(tmp`) {
+		t.Error("atomicWriteFile must rename temp file to final path")
+	}
+}
+
+func TestSource_AtomicWritePreservesPermission(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func atomicWriteFile(")
+	if !strings.Contains(fnBody, "mode os.FileMode") {
+		t.Error("atomicWriteFile must accept file mode parameter")
+	}
+	if !strings.Contains(fnBody, "os.WriteFile(tmp, content, mode)") {
+		t.Error("atomicWriteFile must apply mode to the temp file")
+	}
+}
+
+func TestSource_AtomicWriteCreatesDirIfNeeded(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	fnBody := extractFn(content, "func atomicWriteFile(")
+	if !strings.Contains(fnBody, "os.MkdirAll(filepath.Dir(path)") {
+		t.Error("atomicWriteFile must create parent directories if needed")
+	}
+}
+
+// ── Source analysis: handler.go — route registration ──────────────────────────
+
+func TestSource_BulkHandler_WriteRoutesRequireTrustedIP(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	writeRoutes := []string{
+		"POST /api/vaults/{vault}/bulk-apply/templates",
+		"PUT /api/vaults/{vault}/bulk-apply/templates/{name}",
+		"DELETE /api/vaults/{vault}/bulk-apply/templates/{name}",
+		"POST /api/vaults/{vault}/bulk-apply/workflows/{name}/precheck",
+		"POST /api/vaults/{vault}/bulk-apply/workflows/{name}/run",
+	}
+	for _, route := range writeRoutes {
+		found := false
+		for _, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "requireTrustedIP") {
+					t.Errorf("write route %s must be wrapped with requireTrustedIP", route)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("write route not registered: %s", route)
+		}
+	}
+}
+
+func TestSource_BulkHandler_ReadRoutesExist(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	readRoutes := []string{
+		"GET /api/vaults/{vault}/bulk-apply/templates",
+		"GET /api/vaults/{vault}/bulk-apply/templates/{name}",
+		"GET /api/vaults/{vault}/bulk-apply/workflows",
+		"GET /api/vaults/{vault}/bulk-apply/workflows/{name}",
+	}
+	for _, route := range readRoutes {
+		if !strings.Contains(content, route) {
+			t.Errorf("read route not registered: %s", route)
+		}
+	}
+}
+
+// ── Source analysis: files.go — template kind constant ────────────────────────
+
+func TestSource_TemplateKindConstant(t *testing.T) {
+	src, err := os.ReadFile("files.go")
+	if err != nil {
+		t.Fatalf("failed to read files.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `bulkApplyTemplateKind = "BulkApplyTemplate"`) {
+		t.Error("bulkApplyTemplateKind must be BulkApplyTemplate")
+	}
+	if !strings.Contains(content, `bulkApplyWorkflowKind = "BulkApplyWorkflow"`) {
+		t.Error("bulkApplyWorkflowKind must be BulkApplyWorkflow")
+	}
+}
+
+// ── Source analysis: templates.go — sensitive value masking ───────────────────
+
+func TestSource_SensitiveValueMasking(t *testing.T) {
+	src, err := os.ReadFile("templates.go")
+	if err != nil {
+		t.Fatalf("failed to read templates.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "func isSensitiveBulkApplyValue(") {
+		t.Error("isSensitiveBulkApplyValue function must exist")
+	}
+	if !strings.Contains(content, "func maskBulkApplyValue(") {
+		t.Error("maskBulkApplyValue function must exist")
+	}
+}
+
+func TestUnit_IsSensitiveBulkApplyValue(t *testing.T) {
+	tests := []struct {
+		kind string
+		name string
+		want bool
+	}{
+		{"VK", "DB_PASSWORD", true},
+		{"VK", "API_SECRET", true},
+		{"VK", "AUTH_TOKEN", true},
+		{"VK", "PRIVATE_KEY", true},
+		{"VK", "APP_ENDPOINT", false},
+		{"VK", "BASE_URL", false},
+		{"VE", "DB_PASSWORD", false}, // VE family is never sensitive
+		{"VK", "CLIENT_ID", false},
+	}
+	for _, tt := range tests {
+		got := isSensitiveBulkApplyValue(tt.kind, tt.name)
+		if got != tt.want {
+			t.Errorf("isSensitiveBulkApplyValue(%q, %q) = %v, want %v", tt.kind, tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestUnit_MaskBulkApplyValue(t *testing.T) {
+	if got := maskBulkApplyValue("VK", "DB_PASSWORD", "supersecret"); got != "***" {
+		t.Errorf("sensitive value should be masked, got %q", got)
+	}
+	if got := maskBulkApplyValue("VK", "APP_ENDPOINT", "https://example.com"); got != "https://example.com" {
+		t.Errorf("non-sensitive value should not be masked, got %q", got)
+	}
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+func extractFn(code, sig string) string {
+	i := strings.Index(code, sig)
+	if i < 0 {
+		return ""
+	}
+	rest := code[i:]
+	next := strings.Index(rest[1:], "\nfunc ")
+	if next < 0 {
+		return rest
+	}
+	return rest[:next+1]
+}


### PR DESCRIPTION
## Summary
5개 패키지 테스트 0 → 73개 테스트 추가.

| Package | Tests | Coverage |
|---------|-------|----------|
| admin/ | 15 | session, TOTP, passkey, cookie, reveal window |
| approval/ | 14 | HTML escape, OTP, body limits, challenge lifecycle |
| bulk/ | 15 | template allowlist, atomic write, masking, workflow |
| configs/ | 11 | route auth, key format, bulk ops |
| secrets/ | 18 | resolve disabled, cipher auth, ref gen, fields |

## Test plan
- [x] All 11 packages have tests
- [x] VC: 156 tests pass
- [x] LV: 127 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)