### PR TITLE
fix: update test for exported DeriveDBKeyFromKEK

### DIFF
--- a/services/localvault/internal/commands/server_test.go
+++ b/services/localvault/internal/commands/server_test.go
@@ -57,8 +57,8 @@ func TestDBKeyDerivedFromKEK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read api.go: %v", err)
 	}
-	if !contains(string(apiSrc), "deriveDBKeyFromKEK") {
-		t.Error("api.go must derive DB key from KEK via deriveDBKeyFromKEK()")
+	if !contains(string(apiSrc), "DeriveDBKeyFromKEK") {
+		t.Error("api.go must derive DB key from KEK via DeriveDBKeyFromKEK()")
 	}
 }
 


### PR DESCRIPTION
소스 스캔 테스트가 소문자 deriveDBKeyFromKEK를 찾고 있었는데 PR #384에서 대문자로 export됨. CI 실패 수정.