### PR TITLE
fix: error message leakage + registration token body limit

### DIFF
--- a/services/vaultcenter/internal/api/handle_registration_tokens.go
+++ b/services/vaultcenter/internal/api/handle_registration_tokens.go
@@ -38,6 +38,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 		Label            string `json:"label"`
 		ExpiresInMinutes int    `json:"expires_in_minutes"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxJSONBody)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_archive.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_archive.go
@@ -13,7 +13,7 @@ func (h *Handler) handleAgentArchive(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.deps.DB().ArchiveAgent(nodeID); err != nil {
 		log.Printf("agent: archive failed node=%s: %v", nodeID, err)
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "agent not found")
 		return
 	}
 	log.Printf("agent: archived node=%s", nodeID)
@@ -31,7 +31,7 @@ func (h *Handler) handleAgentUnarchive(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.deps.DB().UnarchiveAgent(nodeID); err != nil {
 		log.Printf("agent: unarchive failed node=%s: %v", nodeID, err)
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "agent not found")
 		return
 	}
 	log.Printf("agent: unarchived node=%s", nodeID)

--- a/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_agent_unregister.go
@@ -15,7 +15,7 @@ func (h *Handler) handleAgentUnregisterByNode(w http.ResponseWriter, r *http.Req
 	}
 	if _, err := h.deps.SubmitTx(r.Context(), chain.TxDeleteAgent, chain.DeleteAgentPayload{NodeID: nodeID}); err != nil {
 		log.Printf("agent: delete failed node=%s: %v", nodeID, err)
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "agent not found or delete failed")
 		return
 	}
 	log.Printf("agent: unregistered node=%s", nodeID)

--- a/services/vaultcenter/internal/api/security_test.go
+++ b/services/vaultcenter/internal/api/security_test.go
@@ -440,3 +440,43 @@ func TestKeyVersionMismatchHasRetryCap(t *testing.T) {
 		t.Error("must cap retry stage at schedule length")
 	}
 }
+
+// ══ Error message leakage prevention ════════════════════════════
+
+func TestAgentArchiveNoRawError(t *testing.T) {
+	s, _ := os.ReadFile("hkm/hkm_agent_archive.go")
+	c := string(s)
+	if strings.Contains(c, "err.Error()") {
+		t.Error("agent archive must not expose raw error in HTTP response")
+	}
+}
+
+func TestAgentUnregisterNoRawError(t *testing.T) {
+	s, _ := os.ReadFile("hkm/hkm_agent_unregister.go")
+	c := string(s)
+	// respondError with err.Error() leaks internal details
+	for _, line := range strings.Split(c, "\n") {
+		if strings.Contains(line, "respondError") && strings.Contains(line, "err.Error()") {
+			t.Error("agent unregister must not expose raw error in HTTP response")
+		}
+	}
+}
+
+func TestRegistrationTokenCreateHasMaxBytes(t *testing.T) {
+	s, _ := os.ReadFile("handle_registration_tokens.go")
+	b := extractFn(string(s), "func (s *Server) handleCreateRegistrationToken(")
+	if !strings.Contains(b, "MaxBytesReader") {
+		t.Error("registration token create must have MaxBytesReader")
+	}
+}
+
+func TestSMTPErrorNoCredentials(t *testing.T) {
+	s, _ := os.ReadFile("../mailer/mailer.go")
+	c := string(s)
+	// Error messages must not wrap internal errors (which may contain credentials)
+	for _, line := range strings.Split(c, "\n") {
+		if strings.Contains(line, "fmt.Errorf") && strings.Contains(line, "%w") {
+			t.Errorf("mailer must not wrap errors (may leak SMTP credentials): %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/services/vaultcenter/internal/mailer/mailer.go
+++ b/services/vaultcenter/internal/mailer/mailer.go
@@ -63,10 +63,10 @@ func sendSMTP(from, to, subject, body string) error {
 
 	m := mail.NewMsg()
 	if err := m.From(from); err != nil {
-		return fmt.Errorf("smtp from: %w", err)
+		return fmt.Errorf("invalid sender address")
 	}
 	if err := m.To(to); err != nil {
-		return fmt.Errorf("smtp to: %w", err)
+		return fmt.Errorf("invalid recipient address")
 	}
 	m.Subject(subject)
 	m.SetBodyString(mail.TypeTextPlain, body)
@@ -82,9 +82,12 @@ func sendSMTP(from, to, subject, body string) error {
 		mail.WithTLSPolicy(tlsPolicy),
 	)
 	if err != nil {
-		return fmt.Errorf("smtp client: %w", err)
+		return fmt.Errorf("smtp client initialization failed")
 	}
-	return c.DialAndSend(m)
+	if err := c.DialAndSend(m); err != nil {
+		return fmt.Errorf("smtp send failed")
+	}
+	return nil
 }
 
 // readSecretEnv reads a secret from KEY_FILE (file path) first, falling back to KEY (direct value).


### PR DESCRIPTION
SMTP credential 누출 방지, raw DB 에러 노출 제거, MaxBytesReader 추가, 테스트 4개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)