### PR TITLE
feat: Hook 의존성 토폴로지 정렬 (#325)

### DIFF
--- a/services/vaultcenter/internal/plugin/handler.go
+++ b/services/vaultcenter/internal/plugin/handler.go
@@ -217,9 +217,11 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	hooks, _ := inst.Hooks(ctx)
-	hookName := ""
-	if len(hooks) > 0 {
-		hookName = hooks[0].Name
+	sortedHooks, sortErr := SortHooks(hooks)
+	if sortErr != nil {
+		log.Printf("plugin sync hook sort %s: %v", name, sortErr)
+		respondError(w, http.StatusInternalServerError, "hook dependency cycle detected")
+		return
 	}
 	agentURL, err := h.sync.FindAgentURL(vault)
 	if err != nil {
@@ -227,14 +229,17 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "vault not reachable")
 		return
 	}
-	step := map[string]any{"name": "plugin-sync", "format": "raw", "target_path": paths[0], "content": output}
-	if hookName != "" {
-		step["hook"] = hookName
+	// Build steps: one content step + sorted hooks
+	steps := []any{map[string]any{"name": "plugin-sync", "format": "raw", "target_path": paths[0], "content": output}}
+	var hookNames []string
+	for _, h := range sortedHooks {
+		steps = append(steps, map[string]any{"name": h.Name, "hook": h.Name})
+		hookNames = append(hookNames, h.Name)
 	}
-	payload, _ := json.Marshal(map[string]any{"name": "plugin-sync", "steps": []any{step}})
-	req, _ := http.NewRequest("POST", strings.TrimRight(agentURL, "/")+"/api/bulk-apply/execute", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := h.sync.HTTPClient().Do(req)
+	payload, _ := json.Marshal(map[string]any{"name": "plugin-sync", "steps": steps})
+	syncReq, _ := http.NewRequest("POST", strings.TrimRight(agentURL, "/")+"/api/bulk-apply/execute", bytes.NewReader(payload))
+	syncReq.Header.Set("Content-Type", "application/json")
+	resp, err := h.sync.HTTPClient().Do(syncReq)
 	if err != nil {
 		log.Printf("plugin sync push %s: %v", vault, err)
 		respondError(w, http.StatusBadGateway, "push to vault failed")
@@ -250,7 +255,7 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 	_ = json.Unmarshal(respBody, &result)
 	respondJSON(w, http.StatusOK, map[string]any{
 		"status": "synced", "plugin": name, "vault": vault,
-		"target_path": paths[0], "hook": hookName, "result": result,
+		"target_path": paths[0], "hooks": hookNames, "result": result,
 	})
 }
 

--- a/services/vaultcenter/internal/plugin/hooks.go
+++ b/services/vaultcenter/internal/plugin/hooks.go
@@ -1,0 +1,63 @@
+package plugin
+
+import "fmt"
+
+// SortHooks performs a topological sort on hooks based on their Depends fields.
+// Uses Kahn's algorithm. Returns an error if a cycle is detected.
+// Unknown dependencies (plugin not loaded) are logged and skipped.
+func SortHooks(hooks []HookDef) ([]HookDef, error) {
+	if len(hooks) <= 1 {
+		return hooks, nil
+	}
+
+	// Build name → hook map
+	byName := make(map[string]HookDef, len(hooks))
+	for _, h := range hooks {
+		byName[h.Name] = h
+	}
+
+	// Build adjacency and in-degree
+	inDegree := make(map[string]int, len(hooks))
+	dependents := make(map[string][]string) // dep → list of hooks that depend on it
+
+	for _, h := range hooks {
+		if _, ok := inDegree[h.Name]; !ok {
+			inDegree[h.Name] = 0
+		}
+		for _, dep := range h.Depends {
+			if _, known := byName[dep]; !known {
+				// Dependency from unloaded plugin — skip
+				continue
+			}
+			inDegree[h.Name]++
+			dependents[dep] = append(dependents[dep], h.Name)
+		}
+	}
+
+	// Kahn's algorithm
+	var queue []string
+	for _, h := range hooks {
+		if inDegree[h.Name] == 0 {
+			queue = append(queue, h.Name)
+		}
+	}
+
+	var sorted []HookDef
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		sorted = append(sorted, byName[name])
+
+		for _, dep := range dependents[name] {
+			inDegree[dep]--
+			if inDegree[dep] == 0 {
+				queue = append(queue, dep)
+			}
+		}
+	}
+
+	if len(sorted) != len(hooks) {
+		return nil, fmt.Errorf("cycle detected in hook dependencies")
+	}
+	return sorted, nil
+}

--- a/services/vaultcenter/internal/plugin/hooks_test.go
+++ b/services/vaultcenter/internal/plugin/hooks_test.go
@@ -1,0 +1,135 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSortHooks_Empty(t *testing.T) {
+	sorted, err := SortHooks(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 0 {
+		t.Fatalf("expected empty, got %d", len(sorted))
+	}
+}
+
+func TestSortHooks_Single(t *testing.T) {
+	hooks := []HookDef{{Name: "reload_systemd", Cmd: []string{"systemctl", "daemon-reload"}}}
+	sorted, err := SortHooks(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 1 || sorted[0].Name != "reload_systemd" {
+		t.Fatalf("got %v", sorted)
+	}
+}
+
+func TestSortHooks_LinearDeps(t *testing.T) {
+	// reload_systemd → restart_mattermost (restart depends on reload)
+	hooks := []HookDef{
+		{Name: "restart_mattermost", Cmd: []string{"systemctl", "restart", "mattermost"}, Depends: []string{"reload_systemd"}},
+		{Name: "reload_systemd", Cmd: []string{"systemctl", "daemon-reload"}},
+	}
+	sorted, err := SortHooks(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2, got %d", len(sorted))
+	}
+	if sorted[0].Name != "reload_systemd" {
+		t.Errorf("expected reload_systemd first, got %s", sorted[0].Name)
+	}
+	if sorted[1].Name != "restart_mattermost" {
+		t.Errorf("expected restart_mattermost second, got %s", sorted[1].Name)
+	}
+}
+
+func TestSortHooks_DiamondDeps(t *testing.T) {
+	// A → B, A → C, B → D, C → D  (D must be first, A must be last)
+	hooks := []HookDef{
+		{Name: "A", Depends: []string{"B", "C"}},
+		{Name: "B", Depends: []string{"D"}},
+		{Name: "C", Depends: []string{"D"}},
+		{Name: "D"},
+	}
+	sorted, err := SortHooks(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sorted[0].Name != "D" {
+		t.Errorf("D must be first, got %s", sorted[0].Name)
+	}
+	// A must be last
+	if sorted[3].Name != "A" {
+		t.Errorf("A must be last, got %s", sorted[3].Name)
+	}
+}
+
+func TestSortHooks_CycleDetected(t *testing.T) {
+	hooks := []HookDef{
+		{Name: "A", Depends: []string{"B"}},
+		{Name: "B", Depends: []string{"A"}},
+	}
+	_, err := SortHooks(hooks)
+	if err == nil {
+		t.Fatal("expected cycle error")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("expected cycle error, got: %v", err)
+	}
+}
+
+func TestSortHooks_UnknownDepSkipped(t *testing.T) {
+	// restart_mattermost depends on "systemd-sync:reload_systemd" which is not in the list
+	hooks := []HookDef{
+		{Name: "restart_mattermost", Depends: []string{"systemd-sync:reload_systemd"}},
+	}
+	sorted, err := SortHooks(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(sorted))
+	}
+}
+
+func TestSortHooks_NoDeps(t *testing.T) {
+	hooks := []HookDef{
+		{Name: "hook_a"},
+		{Name: "hook_b"},
+		{Name: "hook_c"},
+	}
+	sorted, err := SortHooks(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 3 {
+		t.Fatalf("expected 3, got %d", len(sorted))
+	}
+}
+
+func TestSortHooks_ThreeLevelChain(t *testing.T) {
+	// C → B → A (A runs first)
+	hooks := []HookDef{
+		{Name: "C", Depends: []string{"B"}},
+		{Name: "A"},
+		{Name: "B", Depends: []string{"A"}},
+	}
+	sorted, err := SortHooks(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := map[string]int{}
+	for i, h := range sorted {
+		idx[h.Name] = i
+	}
+	if idx["A"] >= idx["B"] {
+		t.Errorf("A must come before B")
+	}
+	if idx["B"] >= idx["C"] {
+		t.Errorf("B must come before C")
+	}
+}


### PR DESCRIPTION
## Summary
- `SortHooks()`: Kahn's algorithm 기반 토폴로지 정렬
- 순환 의존 감지 → 에러
- 미설치 플러그인 의존 → skip
- `handleSync`에서 정렬된 순서로 모든 hook을 bulk-apply에 전달 (기존: 첫 번째 hook만)

## 예시
```
reload_systemd (no deps) → restart_mattermost (depends: reload_systemd)
```
정렬 결과: `[reload_systemd, restart_mattermost]` — reload가 먼저 실행

## 테스트 8개
- empty, single, linear deps, diamond deps
- cycle detection, unknown dep skip
- no deps, 3-level chain

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)