### PR TITLE
test: add domain-level tests for critical Go packages

### DIFF
--- a/services/localvault/internal/api/api_test.go
+++ b/services/localvault/internal/api/api_test.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// Domain-level tests for LocalVault internal/api
+// These verify the core invariants of the Server type that all
+// higher-level features (heartbeat, unlock, secret management) rely on.
+// ══════════════════════════════════════════════════════════════════
+
+// --- DeriveDBKeyFromKEK ---
+
+// Guarantees: The same KEK always produces the same DB encryption key.
+// Without this property, a vault that was encrypted with one key
+// could not be reopened after restart.
+func TestDeriveDBKeyFromKEK_Deterministic(t *testing.T) {
+	kek := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	key1 := DeriveDBKeyFromKEK(kek)
+	key2 := DeriveDBKeyFromKEK(kek)
+	if key1 != key2 {
+		t.Errorf("DeriveDBKeyFromKEK is not deterministic: %q != %q", key1, key2)
+	}
+	if len(key1) != 64 {
+		t.Errorf("expected 64-char hex string, got length %d", len(key1))
+	}
+}
+
+// Guarantees: Different KEKs produce different DB encryption keys.
+// This ensures that a wrong password cannot accidentally open the database.
+func TestDeriveDBKeyFromKEK_DifferentKEKs(t *testing.T) {
+	kek1 := []byte("0123456789abcdef0123456789abcdef")
+	kek2 := []byte("fedcba9876543210fedcba9876543210")
+	key1 := DeriveDBKeyFromKEK(kek1)
+	key2 := DeriveDBKeyFromKEK(kek2)
+	if key1 == key2 {
+		t.Error("different KEKs must produce different DB keys")
+	}
+}
+
+// --- Identity copy semantics ---
+
+// Guarantees: Identity() returns a defensive copy.
+// Callers modifying the returned struct must not corrupt server state.
+func TestIdentity_CopySemantics(t *testing.T) {
+	s := &Server{}
+	original := &NodeIdentity{
+		NodeID:    "node-1",
+		Version:   1,
+		VaultHash: "abc123",
+		VaultName: "test-vault",
+	}
+	s.SetIdentity(original)
+
+	// Get a copy and mutate it
+	copy := s.Identity()
+	copy.NodeID = "MUTATED"
+	copy.VaultName = "MUTATED"
+
+	// Server state must be unaffected
+	got := s.Identity()
+	if got.NodeID != "node-1" {
+		t.Errorf("Identity() did not return a copy: NodeID was mutated to %q", got.NodeID)
+	}
+	if got.VaultName != "test-vault" {
+		t.Errorf("Identity() did not return a copy: VaultName was mutated to %q", got.VaultName)
+	}
+}
+
+// --- SetIdentity / Identity roundtrip ---
+
+// Guarantees: SetIdentity followed by Identity returns the same values.
+func TestSetIdentity_Identity_Roundtrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity *NodeIdentity
+	}{
+		{
+			name: "full identity",
+			identity: &NodeIdentity{
+				NodeID:    "node-abc",
+				Version:   42,
+				VaultHash: "deadbeef",
+				VaultName: "my-vault",
+			},
+		},
+		{
+			name: "empty strings",
+			identity: &NodeIdentity{
+				NodeID:    "",
+				Version:   0,
+				VaultHash: "",
+				VaultName: "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{}
+			s.SetIdentity(tt.identity)
+			got := s.Identity()
+			if got == nil {
+				t.Fatal("Identity() returned nil after SetIdentity")
+			}
+			if got.NodeID != tt.identity.NodeID {
+				t.Errorf("NodeID = %q, want %q", got.NodeID, tt.identity.NodeID)
+			}
+			if got.Version != tt.identity.Version {
+				t.Errorf("Version = %d, want %d", got.Version, tt.identity.Version)
+			}
+			if got.VaultHash != tt.identity.VaultHash {
+				t.Errorf("VaultHash = %q, want %q", got.VaultHash, tt.identity.VaultHash)
+			}
+			if got.VaultName != tt.identity.VaultName {
+				t.Errorf("VaultName = %q, want %q", got.VaultName, tt.identity.VaultName)
+			}
+		})
+	}
+}
+
+// Guarantees: Identity() returns nil when no identity has been set.
+func TestIdentity_NilWhenUnset(t *testing.T) {
+	s := &Server{}
+	if got := s.Identity(); got != nil {
+		t.Errorf("Identity() = %+v, want nil when no identity set", got)
+	}
+}
+
+// --- IsLocked initial state ---
+
+// Guarantees: A server created with nil KEK starts in locked state.
+// This ensures no data can be accessed before the vault password is provided.
+func TestIsLocked_InitialState(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+	if !s.IsLocked() {
+		t.Error("server must start locked when created with nil KEK")
+	}
+}
+
+// Guarantees: A server created with a non-nil KEK starts unlocked.
+func TestIsLocked_UnlockedWithKEK(t *testing.T) {
+	kek := []byte("0123456789abcdef0123456789abcdef")
+	s := NewServer(nil, kek, nil)
+	defer s.Close()
+	if s.IsLocked() {
+		t.Error("server must start unlocked when created with non-nil KEK")
+	}
+}
+
+// --- Salt ---
+
+// Guarantees: Salt() returns the value set via SetDBPath.
+// The salt is essential for KEK derivation — losing it means losing vault access.
+func TestSalt_ReturnsValueAfterSetDBPath(t *testing.T) {
+	s := &Server{}
+	salt := []byte("test-salt-value-32-bytes-long!!")
+	s.SetDBPath("/tmp/test.db", salt)
+	got := s.Salt()
+	if got == nil {
+		t.Fatal("Salt() returned nil after SetDBPath")
+	}
+	if !bytes.Equal(got, salt) {
+		t.Errorf("Salt() = %x, want %x", got, salt)
+	}
+}
+
+// Guarantees: Salt() returns nil when no salt has been set.
+func TestSalt_NilWhenUnset(t *testing.T) {
+	s := &Server{}
+	if got := s.Salt(); got != nil {
+		t.Errorf("Salt() = %x, want nil when no salt set", got)
+	}
+}
+
+// --- agentAuthHeader ---
+
+// Guarantees: agentAuthHeader returns empty string when server is locked.
+// This prevents any authenticated communication with VaultCenter before
+// the vault is unlocked, which would be a security violation.
+func TestAgentAuthHeader_EmptyWhenLocked(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+	if !s.IsLocked() {
+		t.Fatal("precondition: server must be locked")
+	}
+	if got := s.agentAuthHeader(); got != "" {
+		t.Errorf("agentAuthHeader() = %q, want empty string when locked", got)
+	}
+}
+
+// --- VaultUnlockKey lifecycle ---
+
+// Guarantees: VaultUnlockKey set/get/clear cycle works correctly.
+// The vault unlock key is held in memory temporarily until VC confirms storage.
+func TestVaultUnlockKey_Lifecycle(t *testing.T) {
+	s := &Server{}
+
+	// Initially empty
+	if got := s.VaultUnlockKey(); got != "" {
+		t.Errorf("VaultUnlockKey() = %q, want empty initially", got)
+	}
+
+	// Set
+	s.SetVaultUnlockKey("my-secret-password")
+	if got := s.VaultUnlockKey(); got != "my-secret-password" {
+		t.Errorf("VaultUnlockKey() = %q, want %q", got, "my-secret-password")
+	}
+
+	// Clear
+	s.ClearVaultUnlockKey()
+	if got := s.VaultUnlockKey(); got != "" {
+		t.Errorf("VaultUnlockKey() = %q, want empty after clear", got)
+	}
+}
+
+// --- GetKEK copy semantics ---
+
+// Guarantees: GetKEK returns a copy, not the internal slice.
+// Callers must not be able to corrupt the server's KEK by modifying the returned slice.
+func TestGetKEK_ReturnsCopy(t *testing.T) {
+	kek := []byte("0123456789abcdef0123456789abcdef")
+	s := NewServer(nil, kek, nil)
+	defer s.Close()
+
+	got := s.GetKEK()
+	// Mutate the returned slice
+	for i := range got {
+		got[i] = 0xff
+	}
+
+	// Server's KEK must be unaffected
+	kek2 := s.GetKEK()
+	if bytes.Equal(kek2, got) {
+		t.Error("GetKEK must return a copy — mutating the result corrupted server state")
+	}
+}

--- a/services/localvault/internal/api/http_security_test.go
+++ b/services/localvault/internal/api/http_security_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// HTTP handler security tests for LocalVault
+// These verify that the HTTP layer rejects malformed or oversized
+// requests before they reach business logic.
+// ══════════════════════════════════════════════════════════════════
+
+// --- Large body rejected ---
+
+// Guarantees: POST /api/unlock rejects bodies larger than 1 MiB.
+// Without this, an attacker could send a multi-GB request to exhaust memory.
+func TestHTTP_LargeBody_Rejected(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+
+	// Build a body larger than 1 MiB (the MaxBytesReader limit in handleUnlock)
+	bigBody := `{"password":"` + strings.Repeat("a", 1<<20) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/unlock", strings.NewReader(bigBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleUnlock(rec, req)
+
+	// Should get 400 (bad request due to MaxBytesReader) or password too long
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("oversized body: got status %d, want 400", rec.Code)
+	}
+}
+
+// --- Empty JSON body ---
+
+// Guarantees: POST /api/unlock with empty JSON body returns 400.
+// The handler must not panic or crash on empty input.
+func TestHTTP_EmptyJSONBody_Rejected(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/unlock", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleUnlock(rec, req)
+
+	// Empty password field should be rejected
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty JSON body: got status %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "password is required") {
+		t.Errorf("expected 'password is required' message, got %s", rec.Body.String())
+	}
+}
+
+// --- Missing Content-Type handled gracefully ---
+
+// Guarantees: POST /api/unlock without Content-Type header is handled gracefully.
+// Go's json.Decoder does not require Content-Type, but the handler must still
+// process the body correctly or reject it without crashing.
+func TestHTTP_MissingContentType_Handled(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/unlock", strings.NewReader(`{"password":"test"}`))
+	// Deliberately not setting Content-Type
+	rec := httptest.NewRecorder()
+
+	s.handleUnlock(rec, req)
+
+	// Should process the JSON body regardless of Content-Type header.
+	// Since the server is locked and has no DB, it will fail at the unlock step
+	// (not at content-type validation), which is the correct behavior.
+	// Any status other than a panic/500 is acceptable.
+	if rec.Code == 0 {
+		t.Error("handler must return a valid HTTP status code")
+	}
+}
+
+// --- Health endpoint always responds ---
+
+// Guarantees: /health returns 200 even when the server is locked.
+// This is critical for orchestrators (Docker, systemd) to know the process is alive.
+func TestHTTP_Health_AlwaysResponds(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	s.handleHealth(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("health check: got status %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "locked") {
+		t.Errorf("locked server health must report locked status, got %s", rec.Body.String())
+	}
+}
+
+// --- requireUnlocked middleware ---
+
+// Guarantees: Protected endpoints return 503 when server is locked.
+func TestHTTP_RequireUnlocked_Returns503WhenLocked(t *testing.T) {
+	s := NewServer(nil, nil, nil)
+	defer s.Close()
+
+	handler := s.requireUnlocked(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("locked server: got status %d, want 503", rec.Code)
+	}
+}

--- a/services/localvault/internal/api/secrets/cipher_test.go
+++ b/services/localvault/internal/api/secrets/cipher_test.go
@@ -1,0 +1,175 @@
+package secrets
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// Domain-level cipher tests for LocalVault secrets
+// The secrets package stores ciphertext encrypted with AES-256-GCM
+// via the agent's DEK. These tests verify the fundamental encryption
+// invariants that all secret storage depends on.
+// ══════════════════════════════════════════════════════════════════
+
+// --- Secret encrypt/decrypt roundtrip ---
+
+// Guarantees: A secret value encrypted with a DEK can be recovered with the same DEK.
+// This is the core secret storage contract: when VaultCenter pushes an encrypted
+// secret to LocalVault, it must be decryptable for bulk-apply file rendering.
+func TestSecretEncryptDecrypt_Roundtrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"simple password", []byte("hunter2")},
+		{"JSON credentials", []byte(`{"username":"admin","password":"s3cret"}`)},
+		{"empty value", []byte("")},
+		{"binary token", []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}},
+		{"multiline PEM key", []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----\n")},
+	}
+
+	dek, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ciphertext, nonce, err := crypto.Encrypt(dek, tt.plaintext)
+			if err != nil {
+				t.Fatalf("Encrypt failed: %v", err)
+			}
+
+			decrypted, err := crypto.Decrypt(dek, ciphertext, nonce)
+			if err != nil {
+				t.Fatalf("Decrypt failed: %v", err)
+			}
+
+			if !bytes.Equal(decrypted, tt.plaintext) {
+				t.Errorf("roundtrip failed: got %q, want %q", decrypted, tt.plaintext)
+			}
+		})
+	}
+}
+
+// --- Different KEKs produce different ciphertext ---
+
+// Guarantees: The same plaintext encrypted with different keys produces different ciphertext.
+// This ensures key isolation between vaults: secrets from one vault cannot be
+// confused with or decrypted by another vault's key.
+func TestDifferentKEKs_ProduceDifferentCiphertext(t *testing.T) {
+	key1, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey (key1) failed: %v", err)
+	}
+	key2, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey (key2) failed: %v", err)
+	}
+
+	plaintext := []byte("same-secret-for-both-keys")
+
+	ct1, _, err := crypto.Encrypt(key1, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt with key1 failed: %v", err)
+	}
+	ct2, _, err := crypto.Encrypt(key2, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt with key2 failed: %v", err)
+	}
+
+	if bytes.Equal(ct1, ct2) {
+		t.Error("different keys must produce different ciphertext")
+	}
+}
+
+// --- Tampered ciphertext fails decrypt ---
+
+// Guarantees: Tampered ciphertext is detected and rejected.
+// AES-GCM provides authenticated encryption: any bit flip in the ciphertext
+// causes decryption to fail. This prevents an attacker who has DB access
+// from silently modifying secret values.
+func TestTamperedCiphertext_FailsDecrypt(t *testing.T) {
+	tests := []struct {
+		name   string
+		tamper func(ct []byte, nonce []byte) ([]byte, []byte)
+	}{
+		{
+			name: "flipped ciphertext byte",
+			tamper: func(ct, nonce []byte) ([]byte, []byte) {
+				tampered := make([]byte, len(ct))
+				copy(tampered, ct)
+				tampered[0] ^= 0xff
+				return tampered, nonce
+			},
+		},
+		{
+			name: "flipped nonce byte",
+			tamper: func(ct, nonce []byte) ([]byte, []byte) {
+				tampered := make([]byte, len(nonce))
+				copy(tampered, nonce)
+				tampered[0] ^= 0xff
+				return ct, tampered
+			},
+		},
+		{
+			name: "truncated ciphertext",
+			tamper: func(ct, nonce []byte) ([]byte, []byte) {
+				if len(ct) < 2 {
+					return ct, nonce
+				}
+				return ct[:len(ct)-1], nonce
+			},
+		},
+		{
+			name: "appended byte to ciphertext",
+			tamper: func(ct, nonce []byte) ([]byte, []byte) {
+				return append(ct, 0x42), nonce
+			},
+		},
+	}
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plaintext := []byte("integrity-protected-secret")
+			ct, nonce, err := crypto.Encrypt(key, plaintext)
+			if err != nil {
+				t.Fatalf("Encrypt failed: %v", err)
+			}
+
+			tamperedCT, tamperedNonce := tt.tamper(ct, nonce)
+			_, err = crypto.Decrypt(key, tamperedCT, tamperedNonce)
+			if err == nil {
+				t.Error("Decrypt with tampered data must return error")
+			}
+		})
+	}
+}
+
+// --- Cross-key decryption fails ---
+
+// Guarantees: Ciphertext from one DEK cannot be decrypted with a different DEK.
+// This ensures vault isolation: even if an attacker obtains the ciphertext
+// from one vault's database, they cannot decrypt it with another vault's key.
+func TestCrossKeyDecrypt_Fails(t *testing.T) {
+	key1, _ := crypto.GenerateKey()
+	key2, _ := crypto.GenerateKey()
+
+	ct, nonce, err := crypto.Encrypt(key1, []byte("vault-A-secret"))
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	_, err = crypto.Decrypt(key2, ct, nonce)
+	if err == nil {
+		t.Error("decrypting with wrong key must fail")
+	}
+}

--- a/services/vaultcenter/internal/api/hkm/hkm_domain_test.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_domain_test.go
@@ -1,0 +1,201 @@
+package hkm
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// Domain-level tests for VaultCenter HKM handler layer
+// These verify the critical agent management invariants:
+// authentication, heartbeat registration, and rate limiting.
+// ══════════════════════════════════════════════════════════════════
+
+// --- Heartbeat: valid registration token ---
+
+// Guarantees: Heartbeat accepts a registration_token field for new agent registration.
+// Without this, new LocalVault nodes cannot join the cluster.
+func TestSource_Heartbeat_AcceptsRegistrationToken(t *testing.T) {
+	src, err := os.ReadFile("hkm_agent_heartbeat.go")
+	if err != nil {
+		t.Fatalf("failed to read hkm_agent_heartbeat.go: %v", err)
+	}
+	content := string(src)
+
+	// Request struct must accept registration_token
+	if !strings.Contains(content, `json:"registration_token"`) {
+		t.Error("heartbeat request must accept registration_token field")
+	}
+	// On success, must return node identity info
+	if !strings.Contains(content, `"status"`) {
+		t.Error("heartbeat response must include status field")
+	}
+	if !strings.Contains(content, "StatusOK") || !strings.Contains(content, "200") {
+		// Check for respondJSON with 200 or StatusOK
+		if !strings.Contains(content, "http.StatusOK") {
+			t.Error("heartbeat must return 200 on successful registration")
+		}
+	}
+}
+
+// --- Heartbeat: invalid token ---
+
+// Guarantees: Heartbeat rejects invalid/expired registration tokens with 403.
+// This prevents unauthorized nodes from joining the cluster.
+func TestSource_Heartbeat_RejectsInvalidToken(t *testing.T) {
+	src, err := os.ReadFile("hkm_agent_heartbeat.go")
+	if err != nil {
+		t.Fatalf("failed to read hkm_agent_heartbeat.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "ConsumeRegistrationToken") {
+		t.Error("heartbeat must atomically consume registration token to prevent reuse")
+	}
+	if !strings.Contains(content, "StatusForbidden") {
+		t.Error("heartbeat must return 403 for invalid/expired tokens")
+	}
+	if !strings.Contains(content, "invalid, expired, or already used registration token") {
+		t.Error("heartbeat must provide clear error message for rejected tokens")
+	}
+}
+
+// --- Heartbeat: vault_unlock_key not stored without auth ---
+
+// Guarantees: On existing agents, vault_unlock_key injection requires agent auth.
+// Without this check, any client that knows a node_id could inject a fake unlock key.
+func TestSource_Heartbeat_VaultUnlockKeyRequiresAuth(t *testing.T) {
+	src, err := os.ReadFile("hkm_agent_heartbeat.go")
+	if err != nil {
+		t.Fatalf("failed to read hkm_agent_heartbeat.go: %v", err)
+	}
+	content := string(src)
+
+	// Must verify agent identity before storing vault_unlock_key on existing agents
+	if !strings.Contains(content, "authenticateAgentBySecret") {
+		t.Error("vault_unlock_key update on existing agent must verify agent_secret")
+	}
+	if !strings.Contains(content, "authedAgent.NodeID != nodeID") {
+		t.Error("vault_unlock_key must verify the authenticated agent matches the requesting node")
+	}
+	if !strings.Contains(content, "rejected vault_unlock_key") {
+		t.Error("must log rejection when auth fails for vault_unlock_key")
+	}
+}
+
+// --- Agent unlock key: requires auth middleware ---
+
+// Guarantees: The unlock-key endpoint requires agent authentication.
+// Without this, any client could fetch vault passwords from VaultCenter.
+func TestSource_AgentUnlockKey_RequiresAuth(t *testing.T) {
+	src, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(src)
+
+	// The route must be wrapped with agentAuth middleware
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "agents/unlock-key") {
+			if !strings.Contains(line, "agentAuth(") {
+				t.Error("GET /api/agents/unlock-key must be wrapped with agentAuth middleware")
+			}
+			return
+		}
+	}
+	t.Error("agents/unlock-key route not found in handler.go")
+}
+
+// Guarantees: handleAgentUnlockKey checks the context-injected auth key.
+func TestSource_AgentUnlockKey_ChecksContextAuth(t *testing.T) {
+	src, err := os.ReadFile("hkm_agent_unlock_key.go")
+	if err != nil {
+		t.Fatalf("failed to read hkm_agent_unlock_key.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "agentAuthKey") {
+		t.Error("handleAgentUnlockKey must verify agent authentication from context")
+	}
+	if !strings.Contains(content, "StatusUnauthorized") {
+		t.Error("handleAgentUnlockKey must return 401 when auth is missing")
+	}
+}
+
+// --- Rate limiter ---
+
+// Guarantees: The unlock-key rate limiter blocks the 6th request within 1 minute.
+// This prevents brute-force attacks on the auto-unlock endpoint.
+func TestCheckUnlockKeyRateLimit_BlocksSixthRequest(t *testing.T) {
+	// Reset limiter state for this test
+	unlockKeyLimiter.mu.Lock()
+	delete(unlockKeyLimiter.windows, "test-agent-rate")
+	unlockKeyLimiter.mu.Unlock()
+
+	agentHash := "test-agent-rate"
+
+	// First 5 requests should be allowed (limit is 5)
+	for i := 1; i <= unlockKeyRateLimit; i++ {
+		if !checkUnlockKeyRateLimit(agentHash) {
+			t.Errorf("request %d should be allowed (limit=%d)", i, unlockKeyRateLimit)
+		}
+	}
+
+	// 6th request should be blocked
+	if checkUnlockKeyRateLimit(agentHash) {
+		t.Errorf("request %d should be blocked (exceeds limit=%d per %v)", unlockKeyRateLimit+1, unlockKeyRateLimit, unlockKeyRateWindow)
+	}
+
+	// Cleanup
+	unlockKeyLimiter.mu.Lock()
+	delete(unlockKeyLimiter.windows, agentHash)
+	unlockKeyLimiter.mu.Unlock()
+}
+
+// Guarantees: The rate limiter correctly reports the 429 status code.
+func TestSource_AgentUnlockKey_RateLimiterReturns429(t *testing.T) {
+	src, err := os.ReadFile("hkm_agent_unlock_key.go")
+	if err != nil {
+		t.Fatalf("failed to read hkm_agent_unlock_key.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, "checkUnlockKeyRateLimit") {
+		t.Error("handleAgentUnlockKey must call checkUnlockKeyRateLimit")
+	}
+	if !strings.Contains(content, "StatusTooManyRequests") {
+		t.Error("rate-limited requests must return 429 Too Many Requests")
+	}
+	if !strings.Contains(content, "Retry-After") {
+		t.Error("rate-limited responses must include Retry-After header")
+	}
+}
+
+// Guarantees: Different agents have independent rate limit windows.
+func TestCheckUnlockKeyRateLimit_IndependentPerAgent(t *testing.T) {
+	agent1 := "test-agent-independent-1"
+	agent2 := "test-agent-independent-2"
+
+	// Cleanup
+	unlockKeyLimiter.mu.Lock()
+	delete(unlockKeyLimiter.windows, agent1)
+	delete(unlockKeyLimiter.windows, agent2)
+	unlockKeyLimiter.mu.Unlock()
+
+	// Exhaust agent1's limit
+	for i := 0; i < unlockKeyRateLimit; i++ {
+		checkUnlockKeyRateLimit(agent1)
+	}
+
+	// agent2 should still be allowed
+	if !checkUnlockKeyRateLimit(agent2) {
+		t.Error("rate limit for one agent must not affect another agent")
+	}
+
+	// Cleanup
+	unlockKeyLimiter.mu.Lock()
+	delete(unlockKeyLimiter.windows, agent1)
+	delete(unlockKeyLimiter.windows, agent2)
+	unlockKeyLimiter.mu.Unlock()
+}

--- a/services/vaultcenter/internal/api/http_security_test.go
+++ b/services/vaultcenter/internal/api/http_security_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// HTTP handler security tests for VaultCenter
+// These verify that the HTTP layer rejects malformed or oversized
+// requests before they reach business logic.
+// ══════════════════════════════════════════════════════════════════
+
+// --- Large body rejected ---
+
+// Guarantees: decodeJSON rejects bodies larger than 1 MiB.
+// This prevents memory exhaustion attacks on all JSON-accepting endpoints.
+func TestHTTP_LargeBody_Rejected(t *testing.T) {
+	bigBody := strings.Repeat("x", 1<<20+1)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(bigBody))
+	var dst map[string]any
+	err := decodeJSON(req, &dst)
+	if err == nil {
+		t.Error("decodeJSON must reject bodies larger than maxJSONBody (1 MiB)")
+	}
+}
+
+// --- Empty JSON body ---
+
+// Guarantees: decodeJSON with empty JSON object does not crash.
+// Handlers that call decodeJSON must receive a valid (though empty) struct.
+func TestHTTP_EmptyJSONBody_Decoded(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	var dst struct {
+		Name string `json:"name"`
+	}
+	err := decodeJSON(req, &dst)
+	if err != nil {
+		t.Errorf("empty JSON object should decode without error, got: %v", err)
+	}
+	if dst.Name != "" {
+		t.Errorf("expected empty Name, got %q", dst.Name)
+	}
+}
+
+// --- Missing Content-Type handled gracefully ---
+
+// Guarantees: decodeJSON processes JSON bodies regardless of Content-Type header.
+// Go's json.Decoder does not inspect Content-Type, but we verify the handler
+// does not crash or reject valid JSON due to missing header.
+func TestHTTP_MissingContentType_Handled(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"test"}`))
+	// Deliberately not setting Content-Type
+	var dst struct {
+		Name string `json:"name"`
+	}
+	err := decodeJSON(req, &dst)
+	if err != nil {
+		t.Errorf("valid JSON without Content-Type should decode, got: %v", err)
+	}
+	if dst.Name != "test" {
+		t.Errorf("Name = %q, want %q", dst.Name, "test")
+	}
+}
+
+// --- maxJSONBody constant ---
+
+// Guarantees: maxJSONBody is exactly 1 MiB.
+// Changing this value would affect all endpoints; this test catches accidental changes.
+func TestHTTP_MaxJSONBody_Is1MiB(t *testing.T) {
+	if maxJSONBody != 1<<20 {
+		t.Errorf("maxJSONBody = %d, want %d (1 MiB)", maxJSONBody, 1<<20)
+	}
+}
+
+// --- Security headers middleware ---
+
+// Guarantees: securityHeadersMiddleware sets all required security headers.
+func TestHTTP_SecurityHeaders_AllPresent(t *testing.T) {
+	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	required := map[string]string{
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+	}
+	for header, want := range required {
+		got := rec.Header().Get(header)
+		if got != want {
+			t.Errorf("header %s = %q, want %q", header, got, want)
+		}
+	}
+}

--- a/services/vaultcenter/internal/db/encryption_test.go
+++ b/services/vaultcenter/internal/db/encryption_test.go
@@ -1,0 +1,172 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/veilkey/veilkey-go-package/crypto"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// Domain-level encryption tests for VaultCenter DB layer
+// The DB stores secrets encrypted with AES-256-GCM via the crypto package.
+// These tests verify the invariants that the entire secret management
+// system depends on.
+// ══════════════════════════════════════════════════════════════════
+
+// --- Encrypt/Decrypt roundtrip ---
+
+// Guarantees: Data encrypted with a key can be decrypted with the same key.
+// This is the fundamental contract of envelope encryption: KEK wraps DEK,
+// DEK wraps secret values. If this roundtrip fails, all stored secrets are lost.
+func TestEncryptDecrypt_Roundtrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"short secret", []byte("my-password")},
+		{"empty data", []byte("")},
+		{"binary data", []byte{0x00, 0x01, 0xff, 0xfe, 0x80}},
+		{"large payload", bytes.Repeat([]byte("A"), 1024*64)},
+		{"unicode text", []byte("비밀키-テスト-секрет")},
+	}
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ciphertext, nonce, err := crypto.Encrypt(key, tt.plaintext)
+			if err != nil {
+				t.Fatalf("Encrypt failed: %v", err)
+			}
+
+			decrypted, err := crypto.Decrypt(key, ciphertext, nonce)
+			if err != nil {
+				t.Fatalf("Decrypt failed: %v", err)
+			}
+
+			if !bytes.Equal(decrypted, tt.plaintext) {
+				t.Errorf("roundtrip failed: got %q, want %q", decrypted, tt.plaintext)
+			}
+		})
+	}
+}
+
+// --- Decrypt with wrong key fails ---
+
+// Guarantees: Ciphertext encrypted with one key cannot be decrypted with a different key.
+// This is the core confidentiality property: without the correct KEK, the
+// encrypted DEK (and therefore all secrets) are inaccessible.
+func TestDecrypt_WrongKey_Fails(t *testing.T) {
+	key1, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+	key2, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	plaintext := []byte("sensitive-data")
+	ciphertext, nonce, err := crypto.Encrypt(key1, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	_, err = crypto.Decrypt(key2, ciphertext, nonce)
+	if err == nil {
+		t.Error("Decrypt with wrong key must return error, got nil")
+	}
+}
+
+// --- Encrypt produces different ciphertext (nonce uniqueness) ---
+
+// Guarantees: Two encryptions of the same plaintext with the same key produce
+// different ciphertext. This proves that a fresh random nonce is used each time,
+// which is essential for AES-GCM security. Reusing a nonce would allow an
+// attacker to recover plaintext.
+func TestEncrypt_ProducesDifferentCiphertext(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	plaintext := []byte("same-data-encrypted-twice")
+
+	ct1, nonce1, err := crypto.Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("first Encrypt failed: %v", err)
+	}
+
+	ct2, nonce2, err := crypto.Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("second Encrypt failed: %v", err)
+	}
+
+	if bytes.Equal(ct1, ct2) {
+		t.Error("two encryptions of same data must produce different ciphertext (nonce reuse detected)")
+	}
+	if bytes.Equal(nonce1, nonce2) {
+		t.Error("two encryptions must use different nonces")
+	}
+}
+
+// --- DEK envelope encryption roundtrip ---
+
+// Guarantees: A DEK encrypted with EncryptDEK can be recovered with DecryptDEK.
+// This is the envelope encryption pattern used for all agent DEKs.
+func TestDEK_EnvelopeEncryption_Roundtrip(t *testing.T) {
+	kek, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey (KEK) failed: %v", err)
+	}
+	dek, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey (DEK) failed: %v", err)
+	}
+
+	encDEK, nonce, err := crypto.EncryptDEK(kek, dek)
+	if err != nil {
+		t.Fatalf("EncryptDEK failed: %v", err)
+	}
+
+	recovered, err := crypto.DecryptDEK(kek, encDEK, nonce)
+	if err != nil {
+		t.Fatalf("DecryptDEK failed: %v", err)
+	}
+
+	if !bytes.Equal(recovered, dek) {
+		t.Error("DEK roundtrip failed: recovered DEK does not match original")
+	}
+}
+
+// --- Tampered ciphertext detection ---
+
+// Guarantees: AES-GCM detects tampered ciphertext and returns an error.
+// This is the integrity property: any modification to the ciphertext or nonce
+// is detected, preventing silent data corruption.
+func TestDecrypt_TamperedCiphertext_Fails(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	plaintext := []byte("integrity-test")
+	ciphertext, nonce, err := crypto.Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	// Tamper with the ciphertext
+	tampered := make([]byte, len(ciphertext))
+	copy(tampered, ciphertext)
+	tampered[0] ^= 0xff
+
+	_, err = crypto.Decrypt(key, tampered, nonce)
+	if err == nil {
+		t.Error("Decrypt with tampered ciphertext must return error")
+	}
+}


### PR DESCRIPTION
## Summary
- Add 6 new test files with 1013 lines of domain-level tests across LocalVault and VaultCenter
- Tests cover 5 critical areas: Server API invariants, HKM handler auth/rate-limiting, DB encryption primitives, secret cipher operations, and HTTP handler security
- All tests pass (`go test ./...` in both services)

## Test breakdown

| # | Package | Tests added | Key coverage |
|---|---------|------------|-------------|
| 1 | `localvault/internal/api` | 12 | DeriveDBKeyFromKEK determinism, Identity copy semantics, IsLocked initial state, Salt lifecycle, agentAuthHeader guard |
| 2 | `vaultcenter/internal/api/hkm` | 8 | Heartbeat token validation, vault_unlock_key auth, rate limiter unit test (6th request block), per-agent independence |
| 3 | `vaultcenter/internal/db` | 6 | Encrypt/Decrypt roundtrip, wrong-key rejection, nonce uniqueness, DEK envelope, tamper detection |
| 4 | `localvault/internal/api/secrets` | 4 | Cipher roundtrip, key divergence, tampered ciphertext (4 variants), cross-key isolation |
| 5 | Both services | 8 | Large body rejection, empty JSON body, missing Content-Type, security headers |

## Test plan
- [x] `go test ./...` passes in `services/localvault/`
- [x] `go test ./...` passes in `services/vaultcenter/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)