### PR TITLE
feat: 서버 시작 시 평문 DB 자동 암호화 마이그레이션 (#360)

### DIFF
--- a/services/localvault/internal/api/api.go
+++ b/services/localvault/internal/api/api.go
@@ -240,7 +240,15 @@ func (s *Server) Unlock(kek []byte) error {
 
 	database, err := db.New(s.dbPath)
 	if err != nil {
-		return fmt.Errorf("invalid password (cannot open database)")
+		// Attempt plaintext → encrypted migration (#360)
+		if migErr := db.MigrateToEncrypted(s.dbPath, dbKey); migErr != nil {
+			log.Printf("Unlock: encrypted open failed, migration also failed: %v", migErr)
+			return fmt.Errorf("invalid password (cannot open database)")
+		}
+		database, err = db.New(s.dbPath)
+		if err != nil {
+			return fmt.Errorf("invalid password (cannot open database after migration)")
+		}
 	}
 
 	// 3. Verify KEK by decrypting DEK

--- a/services/localvault/internal/db/migrate_encrypt.go
+++ b/services/localvault/internal/db/migrate_encrypt.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// MigrateToEncrypted converts a plaintext SQLite DB to an encrypted SQLCipher DB.
+// Called when opening with DB_KEY fails — the DB might be plaintext from an older version.
+//
+// Returns nil if migration succeeded (caller should retry db.New).
+// Returns error if DB is not plaintext or migration failed.
+func MigrateToEncrypted(dbPath, dbKey string) error {
+	// 1. Open plaintext
+	dsn := dbPath + "?_journal_mode=wal&_busy_timeout=5000"
+	plainDB, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return fmt.Errorf("open plaintext: %w", err)
+	}
+	defer plainDB.Close()
+
+	// 2. Verify readable as plaintext
+	if _, err := plainDB.Exec("SELECT count(*) FROM sqlite_master"); err != nil {
+		return fmt.Errorf("not a valid plaintext DB: %w", err)
+	}
+
+	log.Println("migrate: detected plaintext DB, encrypting...")
+
+	// 3. ATTACH encrypted copy
+	encPath := dbPath + ".encrypted"
+	if _, err := plainDB.Exec(fmt.Sprintf("ATTACH DATABASE '%s' AS encrypted KEY '%s'", encPath, dbKey)); err != nil {
+		return fmt.Errorf("attach encrypted: %w", err)
+	}
+
+	// 4. Export
+	if _, err := plainDB.Exec("SELECT sqlcipher_export('encrypted')"); err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("sqlcipher_export: %w", err)
+	}
+	if _, err := plainDB.Exec("DETACH DATABASE encrypted"); err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("detach: %w", err)
+	}
+	plainDB.Close()
+
+	// 5. Verify encrypted DB is readable with key
+	encDSN := encPath + "?_journal_mode=wal&_busy_timeout=5000&_pragma_key=" + dbKey
+	verifyDB, err := sql.Open("sqlite3", encDSN)
+	if err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("verify encrypted open: %w", err)
+	}
+	if _, err := verifyDB.Exec("SELECT count(*) FROM sqlite_master"); err != nil {
+		verifyDB.Close()
+		_ = os.Remove(encPath)
+		return fmt.Errorf("verify encrypted read: %w", err)
+	}
+	verifyDB.Close()
+
+	// 6. Atomic rename: plaintext → .bak, encrypted → original
+	bakPath := dbPath + ".plaintext.bak"
+	if err := os.Rename(dbPath, bakPath); err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("backup plaintext: %w", err)
+	}
+	if err := os.Rename(encPath, dbPath); err != nil {
+		_ = os.Rename(bakPath, dbPath)
+		return fmt.Errorf("replace with encrypted: %w", err)
+	}
+
+	// Clean up
+	_ = os.Remove(bakPath + "-wal")
+	_ = os.Remove(bakPath + "-shm")
+	_ = os.Remove(bakPath)
+
+	log.Println("migrate: plaintext DB encrypted successfully")
+	return nil
+}

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -541,7 +541,14 @@ func (s *Server) Unlock(kek []byte) error {
 
 	database, err := db.New(s.dbPath)
 	if err != nil {
-		return fmt.Errorf("invalid password (cannot open database)")
+		if migErr := db.MigrateToEncrypted(s.dbPath, dbKey); migErr != nil {
+			log.Printf("Unlock: encrypted open failed, migration also failed: %v", migErr)
+			return fmt.Errorf("invalid password (cannot open database)")
+		}
+		database, err = db.New(s.dbPath)
+		if err != nil {
+			return fmt.Errorf("invalid password (cannot open database after migration)")
+		}
 	}
 
 	// 2. Verify KEK by decrypting DEK

--- a/services/vaultcenter/internal/db/migrate_encrypt.go
+++ b/services/vaultcenter/internal/db/migrate_encrypt.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// MigrateToEncrypted converts a plaintext SQLite DB to an encrypted SQLCipher DB.
+// Called when opening with DB_KEY fails — the DB might be plaintext from an older version.
+//
+// Returns nil if migration succeeded (caller should retry db.New).
+// Returns error if DB is not plaintext or migration failed.
+func MigrateToEncrypted(dbPath, dbKey string) error {
+	// 1. Open plaintext
+	dsn := dbPath + "?_journal_mode=wal&_busy_timeout=5000"
+	plainDB, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return fmt.Errorf("open plaintext: %w", err)
+	}
+	defer plainDB.Close()
+
+	// 2. Verify readable as plaintext
+	if _, err := plainDB.Exec("SELECT count(*) FROM sqlite_master"); err != nil {
+		return fmt.Errorf("not a valid plaintext DB: %w", err)
+	}
+
+	log.Println("migrate: detected plaintext DB, encrypting...")
+
+	// 3. ATTACH encrypted copy
+	encPath := dbPath + ".encrypted"
+	if _, err := plainDB.Exec(fmt.Sprintf("ATTACH DATABASE '%s' AS encrypted KEY '%s'", encPath, dbKey)); err != nil {
+		return fmt.Errorf("attach encrypted: %w", err)
+	}
+
+	// 4. Export
+	if _, err := plainDB.Exec("SELECT sqlcipher_export('encrypted')"); err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("sqlcipher_export: %w", err)
+	}
+	if _, err := plainDB.Exec("DETACH DATABASE encrypted"); err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("detach: %w", err)
+	}
+	plainDB.Close()
+
+	// 5. Verify encrypted DB is readable with key
+	encDSN := encPath + "?_journal_mode=wal&_busy_timeout=5000&_pragma_key=" + dbKey
+	verifyDB, err := sql.Open("sqlite3", encDSN)
+	if err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("verify encrypted open: %w", err)
+	}
+	if _, err := verifyDB.Exec("SELECT count(*) FROM sqlite_master"); err != nil {
+		verifyDB.Close()
+		_ = os.Remove(encPath)
+		return fmt.Errorf("verify encrypted read: %w", err)
+	}
+	verifyDB.Close()
+
+	// 6. Atomic rename: plaintext → .bak, encrypted → original
+	bakPath := dbPath + ".plaintext.bak"
+	if err := os.Rename(dbPath, bakPath); err != nil {
+		_ = os.Remove(encPath)
+		return fmt.Errorf("backup plaintext: %w", err)
+	}
+	if err := os.Rename(encPath, dbPath); err != nil {
+		_ = os.Rename(bakPath, dbPath)
+		return fmt.Errorf("replace with encrypted: %w", err)
+	}
+
+	// Clean up
+	_ = os.Remove(bakPath + "-wal")
+	_ = os.Remove(bakPath + "-shm")
+	_ = os.Remove(bakPath)
+
+	log.Println("migrate: plaintext DB encrypted successfully")
+	return nil
+}


### PR DESCRIPTION
## Summary
Unlock() 시 암호화 DB 열기 실패 → 평문 DB 자동 암호화 마이그레이션.

**흐름:** plaintext open → ATTACH + sqlcipher_export → verify → atomic rename

**적용:** LocalVault + VaultCenter

**안전장치:**
- 잘못된 비밀번호 → 마이그레이션 실패 → 기존 에러
- rename 실패 → 원본 복구
- 이미 암호화 → 첫 db.New() 성공 → 마이그레이션 안 탐

Closes #360

## Test plan
- [x] `go build ./...` passes (LV + VC)
- [ ] 평문 DB → 자동 암호화 후 정상 동작
- [ ] 암호화 DB → 변경 없이 동작
- [ ] 잘못된 비밀번호 → 기존 에러

🤖 Generated with [Claude Code](https://claude.com/claude-code)