### PR TITLE
fix: resolve remaining lint errors (round 2)

### DIFF
--- a/services/localvault/internal/api/security_test.go
+++ b/services/localvault/internal/api/security_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"bytes"
 	"os"
 	"strings"
 	"testing"
@@ -414,8 +415,8 @@ func TestLVChainStoreAdapterSaltParam(t *testing.T) {
 
 func TestBulkApplyValidatesAllBeforeExecution(t *testing.T) {
 	s, _ := os.ReadFile("bulk/apply.go")
-	phase1 := strings.Index(string(s), "Phase 1: Validate ALL")
-	phase2 := strings.Index(string(s), "Phase 2: Execute")
+	phase1 := bytes.Index(s, []byte("Phase 1: Validate ALL"))
+	phase2 := bytes.Index(s, []byte("Phase 2: Execute"))
 	if phase1 < 0 || phase2 < 0 {
 		t.Fatal("bulk apply must have Phase 1 (validate) and Phase 2 (execute)")
 	}
@@ -537,9 +538,3 @@ func TestSubpackageJSONDecodersHaveMaxBytes(t *testing.T) {
 	}
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/services/localvault/internal/commands/init.go
+++ b/services/localvault/internal/commands/init.go
@@ -247,14 +247,17 @@ func fileExists(path string) bool {
 // If force is true and the DB exists, it removes the DB files and returns nil.
 func checkInitDBExists(dbPath string, force bool) error {
 	if _, err := os.Stat(dbPath); err != nil {
-		return nil // DB does not exist, safe to proceed
+		if os.IsNotExist(err) {
+			return nil // DB does not exist, safe to proceed
+		}
+		return fmt.Errorf("checking database path: %w", err)
 	}
 	if !force {
-		return fmt.Errorf("ABORT: Database already exists at %s\n"+
+		return fmt.Errorf("ABORT: database already exists at %s\n"+
 			"  This would destroy all existing secrets.\n"+
 			"  To force re-init, delete the file first:\n"+
 			"    rm %s %s-shm %s-wal\n"+
-			"  Or use --force flag.", dbPath, dbPath, dbPath, dbPath)
+			"  Or use --force flag", dbPath, dbPath, dbPath, dbPath)
 	}
 	log.Printf("WARNING: --force specified, overwriting existing database at %s", dbPath)
 	_ = os.Remove(dbPath)

--- a/services/vaultcenter/internal/tui/tui_test.go
+++ b/services/vaultcenter/internal/tui/tui_test.go
@@ -2101,7 +2101,10 @@ func TestMouse_ClickTabBarSwitchesPage(t *testing.T) {
 	}
 
 	result, _ := m.Update(mouseMsg)
-	model := result.(Model)
+	model, ok := result.(Model)
+	if !ok {
+		t.Fatal("expected result to be Model")
+	}
 	if model.activePage != pageVaults {
 		t.Fatalf("expected pageVaults, got %d", model.activePage)
 	}
@@ -2181,7 +2184,10 @@ func TestMouse_ClickOnLoginPageIgnored(t *testing.T) {
 		Button: tea.MouseButtonLeft,
 	}
 	result, _ := m.Update(mouseMsg)
-	model := result.(Model)
+	model, ok := result.(Model)
+	if !ok {
+		t.Fatal("expected result to be Model")
+	}
 	if model.activePage != pageLogin {
 		t.Fatal("mouse click should not switch page on login")
 	}
@@ -2443,7 +2449,10 @@ func TestModel_NumberKeySwitchesPage(t *testing.T) {
 
 	// Press "2" to switch to vaults
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
-	model := result.(Model)
+	model, ok := result.(Model)
+	if !ok {
+		t.Fatal("expected result to be Model")
+	}
 	if model.activePage != pageVaults {
 		t.Fatalf("expected pageVaults, got %d", model.activePage)
 	}


### PR DESCRIPTION
## Summary
- Use two-value type assertions in VaultCenter tui_test.go (3 unchecked assertions)
- Use `bytes.Index` instead of `strings.Index(string(s), ...)` in LocalVault security_test.go
- Remove custom `max()` function that shadows Go 1.21 predeclared `max`
- Fix nilerr: properly check `os.IsNotExist` before returning nil in LocalVault init.go
- Remove trailing period from error string in init.go

## Test plan
- [x] `go build ./...` passes in both services
- [x] `go test ./...` passes in both services

🤖 Generated with [Claude Code](https://claude.com/claude-code)