### PR TITLE
docs: sync outdated references across docs and install

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -235,7 +235,7 @@ Host ports: 11181 (VC), 11180 (LV), 26656 (P2P), 26657 (RPC)
 
 ## Database
 
-Both services use SQLCipher (encrypted SQLite, WAL mode). `VEILKEY_DB_KEY` is **required** — server refuses to start without it. Plain `sqlite3` cannot read the database.
+Both services use SQLCipher (encrypted SQLite, WAL mode). `VEILKEY_DB_KEY` is auto-derived from the master password (KEK) during unlock. No manual setting needed. Plain `sqlite3` cannot read the database.
 
 - **VaultCenter:** agents, token_refs, audit_events, configs, secrets, admin_sessions
 - **LocalVault:** secrets, configs, node_info, functions

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -28,7 +28,7 @@
 | Stale keys | VaultCenter tracks key_version, enforces rotation |
 | Unauthorized agent | Registration token required for first heartbeat |
 | Cross-vault secret access | Agent auth (Bearer token) — each vault can only query its own secrets |
-| DB direct manipulation | SQLCipher encryption — `VEILKEY_DB_KEY` required, plain sqlite3 blocked |
+| DB direct manipulation | SQLCipher encryption — `VEILKEY_DB_KEY` auto-derived from KEK during unlock, plain sqlite3 blocked |
 | Password file on disk | Removed — KEK exists only in memory, entered via `POST /api/unlock` |
 | Admin password hijack | Change requires owner password (KEK verification), not admin session |
 

--- a/docs/setup/env-vars.md
+++ b/docs/setup/env-vars.md
@@ -20,7 +20,7 @@
 |----------|---------|-------------|
 | `VEILKEY_ADDR` | `:10181` / `:10180` | Listen address |
 | `VEILKEY_DB_PATH` | `/data/veilkey.db` | Database path |
-| `VEILKEY_DB_KEY` | **(KEK-derived)** | SQLCipher encryption key. Derived from master password (KEK) during unlock. DB only opens after password entry |
+| `VEILKEY_DB_KEY` | **(auto-derived)** | SQLCipher encryption key. Auto-derived from master password (KEK) during unlock. No manual setting needed |
 | `VEILKEY_TLS_INSECURE` | `0` | Accept self-signed certs (also applies to `init --token` validation) |
 | `VEILKEY_TLS_CERT` | - | TLS certificate path |
 | `VEILKEY_TLS_KEY` | - | TLS private key path |

--- a/docs/setup/localvault/proxmox-lxc-debian.md
+++ b/docs/setup/localvault/proxmox-lxc-debian.md
@@ -22,7 +22,7 @@ Use the install script — handles build, TLS, init, start, unlock:
 cd veilkey-selfhosted
 VEILKEY_CENTER_URL=https://<VC_HOST>:<VC_PORT> \
 VEILKEY_PASSWORD='<MASTER_PASSWORD>' \
-VEILKEY_NAME=<VAULT_NAME> \
+VEILKEY_LABEL=<VAULT_NAME> \
 VEILKEY_BULK_APPLY_ALLOWED_PATHS=<PATHS> \
   bash install/proxmox-lxc-debian/install-localvault.sh
 ```

--- a/docs/setup/localvault/registration.md
+++ b/docs/setup/localvault/registration.md
@@ -18,7 +18,7 @@ docker compose exec -T localvault sh -c \
 docker compose restart localvault
 ```
 
-> **Note:** `VEILKEY_DB_KEY`가 `.env`에 설정되어 있어야 합니다. 없으면 서버가 시작을 거부합니다.
+> **Note:** `VEILKEY_DB_KEY`는 unlock 시 마스터 비밀번호(KEK)에서 자동 파생됩니다. 수동 설정이 필요 없습니다.
 
 3. LocalVault appears in the vault list after heartbeat
 

--- a/docs/vssh-design.md
+++ b/docs/vssh-design.md
@@ -34,7 +34,7 @@ veilkey ssh add coworker.pub --external --label "coworker" # → VK:SSH:def67890
 veilkey ssh generate --type ed25519 --label "deploy-key"   # → VK:SSH:ghi11111
 veilkey ssh list                                            # 전체 목록
 veilkey ssh pubkey VK:SSH:abc12345                          # public key 출력
-veilkey ssh connect root@192.168.2.60                       # 자동 키 선택 + 접속
+veilkey ssh connect root@<HOST_IP>                           # 자동 키 선택 + 접속
 veilkey ssh agent-add VK:SSH:abc12345                       # ssh-agent 로드
 veilkey ssh map VK:SSH:abc12345 --host github.com --user git
 veilkey ssh remove VK:SSH:abc12345

--- a/install/macos/bootstrap/install-all.md
+++ b/install/macos/bootstrap/install-all.md
@@ -49,7 +49,7 @@ See [Post-Install Setup](../../../docs/setup/README.md) for full initialization 
 ## Update
 
 ```bash
-npm update -g veilkey-cli          # CLI update
+npm update -g veilkey              # CLI update
 cd veilkey-selfhosted && git pull  # Server update
 docker compose up --build -d       # Docker rebuild
 ```

--- a/install/proxmox-lxc-debian/install-localvault.md
+++ b/install/proxmox-lxc-debian/install-localvault.md
@@ -24,7 +24,7 @@ The script handles: source update, build, TLS cert generation, init, start, and 
 |---------------------|---------|-------------|
 | `VEILKEY_CENTER_URL` | - | VaultCenter URL (required) |
 | `VEILKEY_PORT` | `10180` | LocalVault listen port |
-| `VEILKEY_NAME` | `$(hostname)` | Vault display name |
+| `VEILKEY_LABEL` | `$(hostname)` | Vault display name |
 | `VEILKEY_PASSWORD` | - | Master password (prompted if not set) |
 | `VEILKEY_BULK_APPLY_ALLOWED_PATHS` | - | Comma-separated absolute paths for bulk-apply targets |
 

--- a/install/proxmox-lxc-debian/install-localvault.sh
+++ b/install/proxmox-lxc-debian/install-localvault.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # Options (env vars):
 #   VEILKEY_CENTER_URL=                         VaultCenter URL (required)
 #   VEILKEY_PORT=10180                          LocalVault listen port
-#   VEILKEY_NAME=$(hostname)                    Vault display name
+#   VEILKEY_LABEL=$(hostname)                    Vault display name
 #   VEILKEY_PASSWORD=                           Master password (prompted if not set)
 #   VEILKEY_BULK_APPLY_ALLOWED_PATHS=           Comma-separated absolute paths for bulk-apply
 #
@@ -27,7 +27,7 @@ fi
 
 CENTER_URL="${VEILKEY_CENTER_URL:-}"
 PORT="${VEILKEY_PORT:-10180}"
-VAULT_NAME="${VEILKEY_NAME:-$(hostname)}"
+VAULT_NAME="${VEILKEY_LABEL:-$(hostname)}"
 BULK_PATHS="${VEILKEY_BULK_APPLY_ALLOWED_PATHS:-}"
 
 if [[ -z "$CENTER_URL" ]]; then

--- a/install/proxmox-lxc-debian/install-veilkey.md
+++ b/install/proxmox-lxc-debian/install-veilkey.md
@@ -210,12 +210,12 @@ pct exec <CTID> -- bash -c "curl -sk -X POST https://localhost:<VC_PORT>/api/key
 
 # Resolve
 pct exec <CTID> -- bash -c "cd /root/veilkey-selfhosted && \
-  docker compose exec -T veil veilkey-cli resolve VK:LOCAL:yyyyyyyy"
+  docker compose exec -T veil veilkey resolve VK:LOCAL:yyyyyyyy"
 # Expected: hello-veilkey
 
 # PTY masking test
 pct exec <CTID> -- bash -c "cd /root/veilkey-selfhosted && \
-  docker compose exec veil veilkey-cli wrap-pty sh -c 'echo hello-veilkey'"
+  docker compose exec veil veilkey wrap-pty sh -c 'echo hello-veilkey'"
 # Expected: VK:LOCAL:yyyyyyyy (masked!)
 ```
 

--- a/install/proxmox-lxc-debian/install-veilkey.sh
+++ b/install/proxmox-lxc-debian/install-veilkey.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 # Options (env vars):
 #   CTID=110                          Container ID (default: next available)
 #   CT_HOSTNAME=veilkey               Hostname (default: veilkey)
-#   CT_IP=10.50.0.110/16              IP address (required)
-#   CT_GW=10.50.0.1                   Gateway (required)
+#   CT_IP=<IP>/<MASK>                 IP address (required)
+#   CT_GW=<GATEWAY>                   Gateway (required)
 #   CT_BRIDGE=vmbr1                   Network bridge (default: vmbr1)
 #   CT_PASSWORD=                      Root password (prompted if not set)
 #   CT_MEMORY=2048                    Memory in MB (default: 2048)


### PR DESCRIPTION
## Summary

- **`veilkey-cli` → `veilkey`** in user-facing command examples (install-veilkey.md, install-all.md). Binary names in install scripts left unchanged.
- **`VEILKEY_DB_KEY`**: updated from "required" to "auto-derived from master password (KEK) during unlock" across architecture.md, registration.md, security-model.md, env-vars.md
- **`VEILKEY_NAME` → `VEILKEY_LABEL`** in proxmox-lxc-debian.md, install-localvault.md, install-localvault.sh
- **Hardcoded IPs replaced** with `<placeholder>` format (192.168.2.60 in vssh-design.md, 10.50.x in install-veilkey.sh comments)
- CIDR ranges (10.0.0.0/8, 192.168.0.0/16) kept as-is — they document trusted IP defaults

## Files changed (11)

| File | Changes |
|------|---------|
| docs/architecture.md | VEILKEY_DB_KEY description |
| docs/security-model.md | VEILKEY_DB_KEY description |
| docs/setup/env-vars.md | VEILKEY_DB_KEY description |
| docs/setup/localvault/registration.md | VEILKEY_DB_KEY note (Korean) |
| docs/setup/localvault/proxmox-lxc-debian.md | VEILKEY_NAME → VEILKEY_LABEL |
| docs/vssh-design.md | hardcoded IP → placeholder |
| install/macos/bootstrap/install-all.md | veilkey-cli → veilkey |
| install/proxmox-lxc-debian/install-veilkey.md | veilkey-cli → veilkey |
| install/proxmox-lxc-debian/install-veilkey.sh | hardcoded IPs → placeholders |
| install/proxmox-lxc-debian/install-localvault.md | VEILKEY_NAME → VEILKEY_LABEL |
| install/proxmox-lxc-debian/install-localvault.sh | VEILKEY_NAME → VEILKEY_LABEL |

## Test plan

- [ ] Verify install-localvault.sh still works with `VEILKEY_LABEL` env var
- [ ] Verify no broken links or references in documentation
- [ ] Grep for any remaining `VEILKEY_NAME` references outside of code

🤖 Generated with [Claude Code](https://claude.com/claude-code)