### PR TITLE
fix: start temp ref GC after unlock

### DIFF
--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -87,6 +87,7 @@ type Server struct {
 	bulkHandler     *bulk.Handler
 	pluginRegistry  *plugin.Registry
 	pluginHandler   *plugin.Handler
+	gcStop          chan struct{}
 }
 
 // ── hkm.Deps implementation ──────────────────────────────────────────────────
@@ -454,6 +455,12 @@ func NewServer(database *db.DB, kek []byte, trustedIPs []string) *Server {
 	})
 	srv.pluginHandler = plugin.NewHandler(srv.pluginRegistry, srv)
 
+	// Start GC if already unlocked (KEK provided at startup)
+	if !locked && database != nil {
+		srv.gcStop = make(chan struct{})
+		go StartTempRefGC(database, 5*time.Minute, srv.gcStop)
+	}
+
 	return srv
 }
 
@@ -585,6 +592,10 @@ func (s *Server) Unlock(kek []byte) error {
 	if s.salt != nil {
 		s.approvalHandler = approval.NewHandler(database, s.salt, s.httpClient)
 	}
+
+	// 5. Start background GC for expired temp refs, registration tokens, and stale agents
+	s.gcStop = make(chan struct{})
+	go StartTempRefGC(database, 5*time.Minute, s.gcStop)
 
 	return nil
 }

--- a/services/vaultcenter/internal/api/gc_temp_refs_test.go
+++ b/services/vaultcenter/internal/api/gc_temp_refs_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"veilkey-vaultcenter/internal/db"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// Temp ref GC tests
+//
+// Verifies that the GC goroutine is actually started after unlock
+// and that expired temp refs are cleaned up.
+// ══════════════════════════════════════════════════════════════════
+
+func TestGC_StartedAfterUnlock(t *testing.T) {
+	// NewServer with KEK (unlocked) should have gcStop channel initialized
+	database, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	kek := make([]byte, 32)
+	srv := NewServer(database, kek, []string{"127.0.0.1"})
+
+	if srv.gcStop == nil {
+		t.Error("gcStop channel must be initialized when server starts unlocked")
+	}
+
+	// Stop GC to clean up goroutine
+	close(srv.gcStop)
+}
+
+func TestGC_NotStartedWhenLocked(t *testing.T) {
+	database, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	// nil KEK = locked
+	srv := NewServer(database, nil, []string{"127.0.0.1"})
+
+	if srv.gcStop != nil {
+		t.Error("gcStop channel must be nil when server starts locked")
+	}
+}
+
+func TestGC_DeletesExpiredTempRefs(t *testing.T) {
+	database, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	expiredParts := db.RefParts{Family: "VK", Scope: db.RefScopeTemp, ID: "testgc01"}
+	expiredAt := time.Now().UTC().Add(-1 * time.Hour)
+	if err := database.SaveRefWithExpiry(expiredParts, "cipher1", 1, db.RefStatusTemp, expiredAt, "test-expired"); err != nil {
+		t.Fatalf("failed to insert expired ref: %v", err)
+	}
+
+	futureParts := db.RefParts{Family: "VK", Scope: db.RefScopeTemp, ID: "testgc02"}
+	futureAt := time.Now().UTC().Add(1 * time.Hour)
+	if err := database.SaveRefWithExpiry(futureParts, "cipher2", 1, db.RefStatusTemp, futureAt, "test-valid"); err != nil {
+		t.Fatalf("failed to insert valid ref: %v", err)
+	}
+
+	count, err := database.DeleteExpiredTempRefs()
+	if err != nil {
+		t.Fatalf("GC failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 expired ref deleted, got %d", count)
+	}
+
+	// Verify: expired ref gone, valid ref still present
+	refs, err := database.ListRefs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range refs {
+		if r.RefCanonical == "VK:TEMP:testgc01" {
+			t.Error("expired ref VK:TEMP:testgc01 should have been deleted")
+		}
+	}
+
+	found := false
+	for _, r := range refs {
+		if r.RefCanonical == "VK:TEMP:testgc02" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("valid ref VK:TEMP:testgc02 should still exist")
+	}
+}
+
+func TestGC_GoroutineStopsOnClose(t *testing.T) {
+	database, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		StartTempRefGC(database, 50*time.Millisecond, stop)
+		close(done)
+	}()
+
+	// Let GC run at least one tick
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop and verify it exits
+	close(stop)
+	select {
+	case <-done:
+		// GC goroutine exited — success
+	case <-time.After(2 * time.Second):
+		t.Error("GC goroutine did not stop within 2 seconds after closing stop channel")
+	}
+}


### PR DESCRIPTION
## Summary
- `StartTempRefGC`가 정의만 되고 호출되지 않던 버그 수정
- `Unlock()` 후 5분 간격으로 GC 시작 (만료된 temp refs, registration tokens, stale agents 정리)
- `NewServer()`에서 KEK 제공 시에도 GC 시작
- `gcStop` 채널로 goroutine 정리

## Context
만료된 `VK:TEMP` 참조가 무한히 쌓이는 문제 — GC 함수는 있었지만 실제 호출이 빠져있었음

## Test plan
- [x] `TestGC_StartedAfterUnlock` — unlock 후 gcStop 초기화 확인
- [x] `TestGC_NotStartedWhenLocked` — locked 상태에서 GC 미시작
- [x] `TestGC_DeletesExpiredTempRefs` — 만료 ref 삭제, 유효 ref 유지
- [x] `TestGC_GoroutineStopsOnClose` — stop 채널로 goroutine 정상 종료

🤖 Generated with [Claude Code](https://claude.com/claude-code)