### PR TITLE
test: add VE entry coverage for masker and server mask-map handler

### DIFF
--- a/services/vaultcenter/internal/api/hkm/hkm_mask_map_test.go
+++ b/services/vaultcenter/internal/api/hkm/hkm_mask_map_test.go
@@ -1,0 +1,238 @@
+package hkm
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ══════════════════════════════════════════════════════════════════
+// Source-level tests for handleMaskMap VE entry construction.
+// Verifies invariants: deduplication, active-only filtering,
+// VE ref format, and VK/VE separation.
+// ══════════════════════════════════════════════════════════════════
+
+func readMaskMapSource(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile("hkm_mask_map.go")
+	if err != nil {
+		t.Fatalf("failed to read hkm_mask_map.go: %v", err)
+	}
+	return string(src)
+}
+
+// --- VE deduplication ---
+
+// Guarantees: VE entries are deduplicated by value to prevent repeated
+// tagging of the same config value across multiple vaults.
+func TestSource_MaskMap_VE_DeduplicatesByValue(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, "veSeenValues") {
+		t.Error("must use veSeenValues map for VE deduplication")
+	}
+	// Check the dedup guard inside the config loop
+	if !strings.Contains(src, "veSeenValues[cfg.Value]") {
+		t.Error("must check veSeenValues before adding VE entry")
+	}
+	if !strings.Contains(src, `veSeenValues[cfg.Value] = true`) {
+		t.Error("must mark VE value as seen after adding")
+	}
+}
+
+// --- VE skips VK secret values ---
+
+// Guarantees: VE entries skip values that already appear as VK secrets.
+// Without this, a config value like "10.0.0.5" that also happens to be
+// a secret value would be double-masked.
+func TestSource_MaskMap_VE_SkipsVKSecretValues(t *testing.T) {
+	src := readMaskMapSource(t)
+	// veSeenValues must be seeded with existing secret values
+	if !strings.Contains(src, "for _, e := range entries") {
+		t.Error("must seed veSeenValues with existing secret entry values")
+	}
+	if !strings.Contains(src, "veSeenValues[e.Value] = true") {
+		t.Error("must mark secret values as seen before processing VE configs")
+	}
+}
+
+// --- VE only includes active configs ---
+
+// Guarantees: Only configs with Status == "active" are included.
+// Deleted or disabled configs must not appear in the mask map.
+func TestSource_MaskMap_VE_FiltersActiveOnly(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, `cfg.Status != "active"`) {
+		t.Error("must filter configs by Status == active")
+	}
+}
+
+// --- VE skips empty values ---
+
+// Guarantees: Configs with empty Value are skipped.
+func TestSource_MaskMap_VE_SkipsEmptyValue(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, `cfg.Value == ""`) {
+		t.Error("must skip configs with empty Value")
+	}
+}
+
+// --- VE ref format ---
+
+// Guarantees: VE references follow the format "VE:<scope>:<key>".
+func TestSource_MaskMap_VE_RefFormat(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, `"VE:" + cfg.Scope + ":" + cfg.Key`) {
+		t.Error("VE ref must be constructed as VE:<scope>:<key>")
+	}
+}
+
+// --- VE uses agent VaultName ---
+
+// Guarantees: Each VE entry records the vault name of its source agent.
+func TestSource_MaskMap_VE_RecordsVaultName(t *testing.T) {
+	src := readMaskMapSource(t)
+	// Check that VE maskEntry uses agent.VaultName
+	if !strings.Contains(src, "agent.VaultName") {
+		t.Error("VE entries must record agent.VaultName")
+	}
+}
+
+// --- VE skips agents without IP ---
+
+// Guarantees: Agents with empty IP are skipped when fetching configs,
+// because we can't reach their /api/configs endpoint.
+func TestSource_MaskMap_VE_SkipsAgentWithoutIP(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, `agent.IP == ""`) {
+		t.Error("must skip agents with empty IP for VE config fetch")
+	}
+}
+
+// --- Config fetch failure is graceful ---
+
+// Guarantees: If fetching /api/configs from an agent fails,
+// the handler continues to the next agent without crashing.
+func TestSource_MaskMap_VE_ConfigFetchFailureGraceful(t *testing.T) {
+	src := readMaskMapSource(t)
+	// After configErr, must continue (not return/panic)
+	if !strings.Contains(src, "configErr != nil") {
+		t.Error("must handle config fetch error")
+	}
+	// Check that the error handling continues rather than returns
+	configErrIdx := strings.Index(src, "configErr != nil")
+	if configErrIdx == -1 {
+		t.Fatal("configErr check not found")
+	}
+	afterErr := src[configErrIdx : configErrIdx+100]
+	if !strings.Contains(afterErr, "continue") {
+		t.Error("config fetch error must continue to next agent, not return")
+	}
+}
+
+// --- JSON decode failure is graceful ---
+
+// Guarantees: If the config JSON response is malformed, the handler
+// continues without adding any VE entries for that agent.
+func TestSource_MaskMap_VE_JSONDecodeFailureGraceful(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, "json.NewDecoder") {
+		t.Error("must use json.NewDecoder for config response")
+	}
+	// The decode is inside an if-err-nil guard
+	if !strings.Contains(src, "Decode(&configData); err == nil") {
+		t.Error("must guard JSON decode with err == nil check")
+	}
+}
+
+// --- Response body is always closed ---
+
+// Guarantees: configResp.Body is closed after reading, preventing
+// connection leaks even on decode failure.
+func TestSource_MaskMap_VE_ClosesResponseBody(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, "configResp.Body.Close()") {
+		t.Error("must close config response body to prevent connection leaks")
+	}
+}
+
+// --- VE entries mixed with VK in single response ---
+
+// Guarantees: The response uses a single "entries" array containing
+// both VK secrets and VE configs (no separate ve_entries field).
+func TestSource_MaskMap_SingleEntriesArray(t *testing.T) {
+	src := readMaskMapSource(t)
+	// Must NOT have a separate "ve_entries" field in response
+	if strings.Contains(src, `"ve_entries"`) {
+		t.Error("response must NOT have separate ve_entries field — all entries in one array")
+	}
+	// VE entries are appended to the same entries slice
+	if !strings.Contains(src, "entries = append(entries, maskEntry{") {
+		t.Error("VE entries must be appended to same entries slice as VK secrets")
+	}
+}
+
+// --- Long-poll version tracking ---
+
+// Guarantees: The mask-map endpoint supports long polling via version parameter.
+func TestSource_MaskMap_LongPollSupport(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, "clientVersion") {
+		t.Error("must accept client version for long polling")
+	}
+	if !strings.Contains(src, "MaskMapWait") {
+		t.Error("must wait on MaskMapWait channel for long polling")
+	}
+	if !strings.Contains(src, `"changed"`) {
+		t.Error("response must include changed field for long polling")
+	}
+}
+
+// --- Response includes count ---
+
+// Guarantees: The response includes a count field matching entries length.
+func TestSource_MaskMap_ResponseIncludesCount(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, `"count"`) {
+		t.Error("response must include count field")
+	}
+	if !strings.Contains(src, "len(entries)") {
+		t.Error("count must equal len(entries)")
+	}
+}
+
+// --- Agent auth for config fetch ---
+
+// Guarantees: Config fetch requests include agent auth headers.
+func TestSource_MaskMap_VE_ConfigFetchAuthenticated(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, "setAgentAuthHeader") {
+		t.Error("config fetch must include agent auth headers")
+	}
+}
+
+// --- SSH refs also included ---
+
+// Guarantees: SSH keys stored on VaultCenter are included in the mask map.
+func TestSource_MaskMap_IncludesSSHRefs(t *testing.T) {
+	src := readMaskMapSource(t)
+	if !strings.Contains(src, "RefScopeSSH") {
+		t.Error("must include SSH scope refs in mask map")
+	}
+	if !strings.Contains(src, `"vaultcenter"`) {
+		t.Error("SSH refs must be attributed to vaultcenter vault")
+	}
+}
+
+// --- Trusted IP only ---
+
+// Guarantees: The mask-map endpoint is protected by trusted IP filter.
+func TestSource_MaskMap_TrustedIPOnly(t *testing.T) {
+	handlerSrc, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("failed to read handler.go: %v", err)
+	}
+	content := string(handlerSrc)
+	if !strings.Contains(content, `trusted(ready(h.handleMaskMap))`) {
+		t.Error("mask-map endpoint must be wrapped in trusted() middleware")
+	}
+}

--- a/services/veil-cli/src/pty/masker.rs
+++ b/services/veil-cli/src/pty/masker.rs
@@ -1183,6 +1183,143 @@ mod tests {
         assert!(!src.contains("stdin_ve_map"));
     }
 
+    // ── VE + ANSI interaction ─────────────────────────────────────
+
+    #[test]
+    fn test_ve_value_in_ansi_colored_output() {
+        let ve = vec![("config-value".to_string(), "VE:LOCAL:CFG".to_string())];
+        let input = format!("{}config-value{}", "\x1b[1m", "\x1b[0m");
+        let (output, _) = mask_with_ve(&input, &[], &ve, "");
+        assert!(output.contains(GREEN), "VE must be green even inside ANSI");
+        let visible = strip_ansi(&output);
+        assert!(visible.contains("config-value"));
+    }
+
+    #[test]
+    fn test_ve_value_with_embedded_ansi_no_panic() {
+        let ve = vec![("\x1b[31mred\x1b[0m".to_string(), "VE:LOCAL:COLOR".to_string())];
+        let (output, _) = mask_with_ve("show \x1b[31mred\x1b[0m here", &[], &ve, "");
+        let _ = strip_ansi(&output); // must not panic
+    }
+
+    #[test]
+    fn test_ve_after_vk_no_ref_corruption() {
+        // VK replaces "db-password" → colorized ref. VE "LOCAL" must not
+        // colorize inside the ref (ansi_aware_replace skips ANSI segments).
+        let map = vec![("db-password".to_string(), "VK:LOCAL:dbp12345".to_string())];
+        let ve = vec![("LOCAL".to_string(), "VE:LOCAL:SCOPE".to_string())];
+        let (output, _) = mask_with_ve("db-password here", &map, &ve, "");
+        let visible = strip_ansi(&output);
+        assert!(!visible.contains("db-password"));
+    }
+
+    // ── VE + cross-chunk ─────────────────────────────────────────────
+
+    #[test]
+    fn test_ve_split_across_chunks_not_detected() {
+        // VE has no cross-chunk detection — split values are NOT colorized
+        let ve = vec![("database".to_string(), "VE:LOCAL:DB_TYPE".to_string())];
+        let (output1, tail1) = mask_with_ve("data", &[], &ve, "");
+        assert!(!output1.contains(GREEN));
+        let (output2, _) = mask_with_ve("base-server", &[], &ve, &tail1);
+        assert!(!output2.contains(GREEN),
+            "VE split across chunks should not be detected (by design)");
+    }
+
+    #[test]
+    fn test_ve_full_value_in_single_chunk() {
+        let ve = vec![("database".to_string(), "VE:LOCAL:DB_TYPE".to_string())];
+        let (output, _) = mask_with_ve("type=database", &[], &ve, "");
+        assert!(output.contains(GREEN));
+    }
+
+    #[test]
+    fn test_ve_in_second_chunk_fully() {
+        let ve = vec![("production".to_string(), "VE:LOCAL:ENV".to_string())];
+        let (_, tail) = mask_with_ve("env=", &[], &ve, "");
+        let (output, _) = mask_with_ve("production ready", &[], &ve, &tail);
+        assert!(output.contains(GREEN));
+    }
+
+    // ── VE + VK overlap edge cases ───────────────────────────────────
+
+    #[test]
+    fn test_ve_substring_of_vk_secret() {
+        // VE "db-host" is substring of VK "my-db-host-password" — VK masks first
+        let map = vec![("my-db-host-password".to_string(), "VK:LOCAL:dbh12345".to_string())];
+        let ve = vec![("db-host".to_string(), "VE:LOCAL:DB_HOST".to_string())];
+        let (output, _) = mask_with_ve("cred=my-db-host-password", &map, &ve, "");
+        let visible = strip_ansi(&output);
+        assert!(!visible.contains("my-db-host-password"));
+        assert!(!visible.contains("db-host"),
+            "VE substring vanishes when VK masks the containing secret");
+    }
+
+    #[test]
+    fn test_vk_substring_of_ve_value() {
+        // VK "prod" is substring of VE "production"
+        let map = vec![("prod".to_string(), "VK:LOCAL:prd12345".to_string())];
+        let ve = vec![("production".to_string(), "VE:LOCAL:ENV".to_string())];
+        let (output, _) = mask_with_ve("env=production", &map, &ve, "");
+        let visible = strip_ansi(&output);
+        assert!(!visible.contains("prod"), "VK masks 'prod' even inside 'production'");
+    }
+
+    #[test]
+    fn test_ve_and_vk_same_value() {
+        // Same value as both VK and VE — VK takes precedence
+        let map = vec![("shared-value-1234".to_string(), "VK:LOCAL:sh123456".to_string())];
+        let ve = vec![("shared-value-1234".to_string(), "VE:LOCAL:SHARED".to_string())];
+        let (output, _) = mask_with_ve("data=shared-value-1234", &map, &ve, "");
+        let visible = strip_ansi(&output);
+        assert!(!visible.contains("shared-value-1234"), "VK takes precedence");
+    }
+
+    #[test]
+    fn test_ve_adjacent_to_vk() {
+        let map = vec![("SECRET".to_string(), "VK:LOCAL:sec12345".to_string())];
+        let ve = vec![("CONFIG".to_string(), "VE:LOCAL:CFG".to_string())];
+        let (output, _) = mask_with_ve("SECRETCONFIG", &map, &ve, "");
+        let visible = strip_ansi(&output);
+        assert!(!visible.contains("SECRET"));
+        assert!(visible.contains("CONFIG"));
+    }
+
+    // ── colorize_ve_ref unit tests ───────────────────────────────────
+
+    #[test]
+    fn test_colorize_ve_ref_format() {
+        let result = colorize_ve_ref("my-config", "VE:LOCAL:CFG");
+        assert_eq!(result, format!("{}my-config{}", GREEN, RESET));
+    }
+
+    #[test]
+    fn test_colorize_ve_ref_empty() {
+        let result = colorize_ve_ref("", "VE:LOCAL:CFG");
+        assert_eq!(result, format!("{}{}", GREEN, RESET));
+    }
+
+    #[test]
+    fn test_colorize_ve_ref_ignores_ref_param() {
+        let r1 = colorize_ve_ref("val", "VE:LOCAL:A");
+        let r2 = colorize_ve_ref("val", "VE:HOST:B");
+        assert_eq!(r1, r2, "VE ref param must not affect output color");
+    }
+
+    #[test]
+    fn test_colorize_ve_ref_unicode() {
+        let result = colorize_ve_ref("한글설정", "VE:LOCAL:KR");
+        assert!(result.contains("한글설정"));
+        assert!(result.starts_with(GREEN));
+        assert!(result.ends_with(RESET));
+    }
+
+    #[test]
+    fn test_colorize_ve_ref_special_chars() {
+        let result = colorize_ve_ref("p@ss/w0rd!#$", "VE:LOCAL:SP");
+        assert!(result.contains("p@ss/w0rd!#$"));
+    }
+
     #[test]
     fn test_mask_output_recent_input_skips() {
         // When the secret was recently typed as input, masking is skipped


### PR DESCRIPTION
## Summary

- **masker.rs**: VE + ANSI 상호작용, cross-chunk 동작, VK/VE 겹침 엣지케이스, colorize_ve_ref 유닛 테스트 15개
- **hkm_mask_map_test.go**: 서버 측 mask-map 핸들러 VE 생성 로직 소스 가드 테스트 16개 (신규 파일)

## Test plan

- [x] Rust lib 350 tests pass
- [x] Go hkm package 16 new tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)