### PR TITLE
fix: restore log output after recovery test

### DIFF
--- a/services/vaultcenter/internal/api/recovery_test.go
+++ b/services/vaultcenter/internal/api/recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -34,7 +35,7 @@ func TestPanicRecoveryMiddleware(t *testing.T) {
 func TestPanicRecoveryLogsStack(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
-	defer log.SetOutput(nil)
+	defer log.SetOutput(os.Stderr)
 
 	panicking := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		panic("stack trace test")


### PR DESCRIPTION
## Summary
- `TestPanicRecoveryLogsStack`에서 `defer log.SetOutput(nil)` 호출 → 글로벌 로거 writer가 nil로 설정
- 이후 `TestSSH_List_Empty` 등 `log.Printf` 사용하는 테스트에서 nil pointer dereference 패닉 발생
- `log.SetOutput(os.Stderr)`로 변경하여 기본 출력 복원

## Test plan
- [x] `go test ./...` 전체 PASS (기존 `TestSSH_List_Empty` 패닉 해소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)