### PR TITLE
Align localvault installers with VC-managed unlock

### DIFF
--- a/docs/setup/localvault/proxmox-lxc-debian.md
+++ b/docs/setup/localvault/proxmox-lxc-debian.md
@@ -5,23 +5,20 @@
 ```bash
 pct exec <CTID> -- bash -c "cd /root/veilkey-selfhosted && \
   docker compose exec -T localvault sh -c \
-    'echo \"<MASTER_PASSWORD>\" | veilkey-localvault init --root --center https://vaultcenter:10181'"
+    'VEILKEY_DB_PATH=/data/veilkey.db veilkey-localvault init --root --center https://vaultcenter:10181'"
 
 pct exec <CTID> -- bash -c "cd /root/veilkey-selfhosted && docker compose restart localvault"
 
-pct exec <CTID> -- bash -c "curl -sk -X POST https://localhost:<LV_PORT>/api/unlock \
-  -H 'Content-Type: application/json' \
-  -d '{\"password\":\"<MASTER_PASSWORD>\"}'"
+pct exec <CTID> -- bash -c "curl -sk https://localhost:<LV_PORT>/health"
 ```
 
 ## Standalone (on any LXC or host)
 
-Use the install script — handles build, TLS, init, start, unlock:
+Use the install script — handles build, TLS, init, start, bootstrap auto-unlock, and health check:
 
 ```bash
 cd veilkey-selfhosted
 VEILKEY_CENTER_URL=https://<VC_HOST>:<VC_PORT> \
-VEILKEY_PASSWORD='<MASTER_PASSWORD>' \
 VEILKEY_LABEL=<VAULT_NAME> \
 VEILKEY_BULK_APPLY_ALLOWED_PATHS=<PATHS> \
   bash install/proxmox-lxc-debian/install-localvault.sh

--- a/install/common/install-localvault.md
+++ b/install/common/install-localvault.md
@@ -36,10 +36,10 @@ bash install/common/install-localvault.sh
 The installer:
 
 1. Builds binary (or downloads from `VEILKEY_BINARY_URL`)
-2. Creates data directory
+2. Creates data directory and self-signed TLS cert
 3. Runs `init --root --center <url> --token <token>` (auto-generated password, VC-managed unlock)
-4. Writes `.env` with all config
-5. Creates + enables systemd service (or nohup fallback)
+4. Writes `.env` with TLS and runtime config
+5. Creates + enables systemd service (or nohup fallback) and waits for `health=ok`
 
 ## Management
 

--- a/install/common/install-localvault.sh
+++ b/install/common/install-localvault.sh
@@ -41,6 +41,10 @@ USE_SYSTEMD="${VEILKEY_SYSTEMD:-1}"
 BINARY_URL="${VEILKEY_BINARY_URL:-}"
 BIN="$BIN_DIR/veilkey-localvault"
 ENV_FILE="$DATA_DIR/.env"
+CERT_DIR="$DATA_DIR/certs"
+TLS_CERT="$CERT_DIR/cert.pem"
+TLS_KEY="$CERT_DIR/key.pem"
+HEALTH_URL="https://127.0.0.1:$PORT/health"
 
 echo "=== VeilKey LocalVault Installer ==="
 echo "  센터: $CENTER_URL"
@@ -56,7 +60,7 @@ elif command -v go &>/dev/null; then
     REPO_DIR="${VEILKEY_REPO_DIR:-$(mktemp -d)}"
     [ -d "$REPO_DIR/.git" ] || git clone --quiet --depth 1 https://github.com/veilkey/veilkey-selfhosted.git "$REPO_DIR"
     cd "$REPO_DIR/services/localvault"
-    CGO_ENABLED=1 go build -o "$BIN" ./cmd
+    GOTOOLCHAIN=auto CGO_ENABLED=1 go build -o "$BIN" ./cmd
 elif [ -f "$BIN" ]; then
     echo "[1/5] 기존 바이너리 사용"
 else
@@ -64,19 +68,35 @@ else
     exit 1
 fi
 
-# [2] Data dir
-echo "[2/5] 데이터 디렉토리..."
-mkdir -p "$DATA_DIR/certs"
+# [2] Data dir + TLS
+echo "[2/5] 데이터 디렉토리 + TLS..."
+mkdir -p "$CERT_DIR"
+if [[ -f "$TLS_CERT" && -f "$TLS_KEY" ]]; then
+    echo "  기존 TLS 인증서 유지"
+else
+    LOCAL_IPS=$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -v '^$' | head -5 || true)
+    SAN="DNS:localhost,DNS:$(hostname),IP:127.0.0.1"
+    for ip in $LOCAL_IPS; do
+        SAN="$SAN,IP:$ip"
+    done
+    openssl req -x509 -newkey rsa:2048 \
+        -keyout "$TLS_KEY" -out "$TLS_CERT" \
+        -days 3650 -nodes \
+        -subj "/CN=$(hostname)" \
+        -addext "subjectAltName=$SAN" \
+        -addext "basicConstraints=critical,CA:FALSE" \
+        -addext "keyUsage=digitalSignature,keyEncipherment" \
+        -addext "extendedKeyUsage=serverAuth" >/dev/null 2>&1
+fi
 
 # [3] Init
-if [ -f "$DATA_DIR/veilkey.db" ]; then
+if [ -f "$DATA_DIR/salt" ]; then
     echo "[3/5] 이미 초기화됨 — 스킵"
 else
     echo "[3/5] 초기화..."
     VEILKEY_TLS_INSECURE="$TLS_INSECURE" \
     VEILKEY_DB_PATH="$DATA_DIR/veilkey.db" \
-    VEILKEY_SALT_PATH="$DATA_DIR/salt" \
-    VEILKEY_CERT_DIR="$DATA_DIR/certs" \
+    VEILKEY_VAULT_NAME="$LABEL" \
     VEILKEY_LABEL="$LABEL" \
     "$BIN" init --root --center "$CENTER_URL" --token "$REG_TOKEN"
 fi
@@ -85,14 +105,20 @@ fi
 echo "[4/5] 환경 설정..."
 cat > "$ENV_FILE" << ENVEOF
 VEILKEY_DB_PATH=$DATA_DIR/veilkey.db
-VEILKEY_SALT_PATH=$DATA_DIR/salt
-VEILKEY_CERT_DIR=$DATA_DIR/certs
+VEILKEY_VAULT_NAME=$LABEL
 VEILKEY_LABEL=$LABEL
 VEILKEY_VAULTCENTER_URL=$CENTER_URL
 VEILKEY_ADDR=:$PORT
 VEILKEY_TLS_INSECURE=$TLS_INSECURE
+VEILKEY_TLS_CERT=$TLS_CERT
+VEILKEY_TLS_KEY=$TLS_KEY
 VEILKEY_TRUSTED_IPS=$TRUSTED_IPS
 ENVEOF
+for extra_key in VEILKEY_BULK_APPLY_ALLOWED_PATHS VEILKEY_BULK_APPLY_ALLOWED_HOOKS VEILKEY_MANAGED_PATHS VEILKEY_CONTEXT_DIR VEILKEY_CONTEXT_FILE; do
+    if [[ -n "${!extra_key:-}" ]]; then
+        printf '%s=%s\n' "$extra_key" "${!extra_key}" >> "$ENV_FILE"
+    fi
+done
 
 # [5] Service
 if [[ "$USE_SYSTEMD" == "1" ]] && command -v systemctl &>/dev/null; then
@@ -111,13 +137,38 @@ RestartSec=5
 WantedBy=multi-user.target
 SVCEOF
     systemctl daemon-reload
-    systemctl enable --now veilkey-localvault
-    sleep 2
-    systemctl is-active --quiet veilkey-localvault && echo "=== 완료 ===" || { journalctl -u veilkey-localvault -n 5; exit 1; }
+    systemctl enable veilkey-localvault >/dev/null 2>&1 || true
+    systemctl restart veilkey-localvault >/dev/null 2>&1 || systemctl start veilkey-localvault
 else
     echo "[5/5] 프로세스 시작..."
+    if [[ -f "$DATA_DIR/localvault.pid" ]]; then
+        OLD_PID=$(cat "$DATA_DIR/localvault.pid" 2>/dev/null || true)
+        if [[ -n "$OLD_PID" ]] && kill -0 "$OLD_PID" 2>/dev/null; then
+            kill "$OLD_PID" 2>/dev/null || true
+            sleep 1
+        fi
+        rm -f "$DATA_DIR/localvault.pid"
+    fi
     cd "$DATA_DIR" && set -a && source "$ENV_FILE" && set +a
     nohup "$BIN" server > "$DATA_DIR/localvault.log" 2>&1 &
     echo $! > "$DATA_DIR/localvault.pid"
-    sleep 2 && echo "=== 완료 (PID: $(cat "$DATA_DIR/localvault.pid")) ==="
 fi
+
+HEALTH=""
+for _ in $(seq 1 20); do
+    HEALTH=$(curl -sk "$HEALTH_URL" 2>/dev/null || true)
+    if [[ "$HEALTH" == *'"status":"ok"'* ]]; then
+        echo "=== 완료 ==="
+        echo "  Health: $HEALTH"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "ERROR: localvault health check failed"
+if [[ "$USE_SYSTEMD" == "1" ]] && command -v systemctl &>/dev/null; then
+    journalctl -u veilkey-localvault -n 20 --no-pager || true
+else
+    tail -20 "$DATA_DIR/localvault.log" || true
+fi
+exit 1

--- a/install/proxmox-lxc-debian/install-localvault.md
+++ b/install/proxmox-lxc-debian/install-localvault.md
@@ -16,7 +16,7 @@ VEILKEY_CENTER_URL=https://<HOST>:<VC_PORT> \
   bash install/proxmox-lxc-debian/install-localvault.sh
 ```
 
-The script handles: source update, build, TLS cert generation, init, start, and unlock.
+The script handles: source update, build, TLS cert generation, `init`, start, bootstrap auto-unlock, and health check.
 
 ## Options
 
@@ -25,7 +25,6 @@ The script handles: source update, build, TLS cert generation, init, start, and 
 | `VEILKEY_CENTER_URL` | - | VaultCenter URL (required) |
 | `VEILKEY_PORT` | `10180` | LocalVault listen port |
 | `VEILKEY_LABEL` | `$(hostname)` | Vault display name |
-| `VEILKEY_PASSWORD` | - | Master password (prompted if not set) |
 | `VEILKEY_BULK_APPLY_ALLOWED_PATHS` | - | Comma-separated absolute paths for bulk-apply targets |
 
 ## What it does
@@ -35,9 +34,9 @@ The script handles: source update, build, TLS cert generation, init, start, and 
 | Source update | - | `git pull` |
 | Build | Go build | Rebuild with latest |
 | TLS certificate | Auto-generate (self-signed, 10yr) | Preserved |
-| .env config | Created | Preserved (bulk paths updated) |
-| Init | Password → KEK → salt | Skipped (salt exists) |
-| Start + unlock | HTTPS start → unlock | Restart → unlock |
+| .env config | Rewritten from current env | Rewritten from current env |
+| Init | Auto-generated vault unlock key → salt/DB | Skipped (salt exists) |
+| Start | HTTPS start + bootstrap auto-unlock | Restart + VC-managed auto-unlock |
 
 ## After install
 

--- a/install/proxmox-lxc-debian/install-localvault.sh
+++ b/install/proxmox-lxc-debian/install-localvault.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Standalone LocalVault installer for Proxmox host / LXC
-# Builds, installs, initializes, and starts a LocalVault.
-# Connects to an existing VaultCenter.
-# Re-running updates (git pull + rebuild + restart).
+# Standalone LocalVault installer for Proxmox host / LXC.
+# Builds, initializes, and starts a LocalVault using VC-managed unlock.
 #
 # Usage:
 #   VEILKEY_CENTER_URL=https://<HOST>:<VC_PORT> \
@@ -13,8 +11,7 @@ set -euo pipefail
 # Options (env vars):
 #   VEILKEY_CENTER_URL=                         VaultCenter URL (required)
 #   VEILKEY_PORT=10180                          LocalVault listen port
-#   VEILKEY_LABEL=$(hostname)                    Vault display name
-#   VEILKEY_PASSWORD=                           Master password (prompted if not set)
+#   VEILKEY_LABEL=$(hostname)                   Vault display name
 #   VEILKEY_BULK_APPLY_ALLOWED_PATHS=           Comma-separated absolute paths for bulk-apply
 #
 # ⚠️  이 스크립트의 실행으로 발생하는 모든 결과에 대한
@@ -38,15 +35,6 @@ if [[ -z "$CENTER_URL" ]]; then
     exit 1
 fi
 
-if [[ -z "${VEILKEY_PASSWORD:-}" ]]; then
-    read -s -p "Master password: " VEILKEY_PASSWORD
-    echo ""
-    if [[ -z "$VEILKEY_PASSWORD" ]]; then
-        echo "ERROR: Password cannot be empty."
-        exit 1
-    fi
-fi
-
 REPO_ROOT="$(pwd)"
 INSTALL_DIR="$REPO_ROOT/.localvault"
 DATA_DIR="$INSTALL_DIR/data"
@@ -55,6 +43,8 @@ PID_FILE="$INSTALL_DIR/localvault.pid"
 LOG_FILE="$INSTALL_DIR/localvault.log"
 BIN="$INSTALL_DIR/veilkey-localvault"
 ENV_FILE="$INSTALL_DIR/.env"
+HEALTH_URL="https://127.0.0.1:$PORT/health"
+STATUS_URL="https://127.0.0.1:$PORT/api/status"
 
 echo "=== LocalVault installer ==="
 echo ""
@@ -65,31 +55,31 @@ echo "  Center URL:  $CENTER_URL"
 [[ -n "$BULK_PATHS" ]] && echo "  Bulk paths:  $BULK_PATHS"
 echo ""
 
-# --- [1/8] Check Go ---
+# --- [1/7] Check Go ---
 if ! command -v go &>/dev/null; then
     echo "ERROR: Go not found."
     echo "  Install: apt install golang"
     exit 1
 fi
-echo "[1/8] Go $(go version | grep -oE 'go[0-9]+\.[0-9]+') OK"
+echo "[1/7] Go $(go version | grep -oE 'go[0-9]+\.[0-9]+') OK"
 
-# --- [2/8] Update source ---
-echo "[2/8] Updating source..."
+# --- [2/7] Update source ---
+echo "[2/7] Updating source..."
 if git rev-parse --is-inside-work-tree &>/dev/null; then
     git pull --quiet 2>/dev/null || echo "  git pull skipped (detached or no remote)"
 fi
 echo "  Source up to date."
 
-# --- [3/8] Build ---
-echo "[3/8] Building LocalVault..."
+# --- [3/7] Build ---
+echo "[3/7] Building LocalVault..."
 mkdir -p "$INSTALL_DIR"
 cd services/localvault
-CGO_ENABLED=1 go build -o "$BIN" ./cmd 2>&1 | tail -5
+GOTOOLCHAIN=auto CGO_ENABLED=1 go build -o "$BIN" ./cmd 2>&1 | tail -5
 cd "$REPO_ROOT"
 echo "  Built: $BIN"
 
-# --- [4/8] TLS certificate ---
-echo "[4/8] TLS certificate..."
+# --- [4/7] TLS certificate ---
+echo "[4/7] TLS certificate..."
 if [ -f "$TLS_DIR/cert.pem" ] && [ -f "$TLS_DIR/key.pem" ]; then
     echo "  Existing certificate preserved."
 else
@@ -112,41 +102,41 @@ else
     echo "  Certificate generated (SAN: $SAN)"
 fi
 
-# --- [5/8] Setup .env ---
-echo "[5/8] Setting up config..."
+# --- [5/7] Setup .env ---
+echo "[5/7] Setting up config..."
 mkdir -p "$DATA_DIR"
 
-if [ -f "$ENV_FILE" ]; then
-    echo "  Existing config preserved: $ENV_FILE"
-    # Update bulk-apply paths if provided
-    if [[ -n "$BULK_PATHS" ]]; then
-        if grep -q "^VEILKEY_BULK_APPLY_ALLOWED_PATHS=" "$ENV_FILE" 2>/dev/null; then
-            sed -i "s|^VEILKEY_BULK_APPLY_ALLOWED_PATHS=.*|VEILKEY_BULK_APPLY_ALLOWED_PATHS=$BULK_PATHS|" "$ENV_FILE"
-        else
-            echo "VEILKEY_BULK_APPLY_ALLOWED_PATHS=$BULK_PATHS" >> "$ENV_FILE"
-        fi
-        echo "  Updated bulk-apply paths."
-    fi
-else
-    cat > "$ENV_FILE" << ENVEOF
+cat > "$ENV_FILE" << ENVEOF
 VEILKEY_DB_PATH=$DATA_DIR/veilkey.db
 VEILKEY_ADDR=:$PORT
 VEILKEY_TRUSTED_IPS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1
-VEILKEY_MODE=root
 VEILKEY_VAULT_NAME=$VAULT_NAME
+VEILKEY_LABEL=$VAULT_NAME
 VEILKEY_VAULTCENTER_URL=$CENTER_URL
 VEILKEY_TLS_INSECURE=1
 VEILKEY_TLS_CERT=$TLS_DIR/cert.pem
 VEILKEY_TLS_KEY=$TLS_DIR/key.pem
 ENVEOF
-    if [[ -n "$BULK_PATHS" ]]; then
-        echo "VEILKEY_BULK_APPLY_ALLOWED_PATHS=$BULK_PATHS" >> "$ENV_FILE"
-    fi
-    echo "  Config created: $ENV_FILE"
+if [[ -n "$BULK_PATHS" ]]; then
+    echo "VEILKEY_BULK_APPLY_ALLOWED_PATHS=$BULK_PATHS" >> "$ENV_FILE"
+fi
+echo "  Config written: $ENV_FILE"
+
+# --- [6/7] Init ---
+echo "[6/7] Initializing..."
+if [ -f "$DATA_DIR/salt" ]; then
+    echo "  Already initialized (salt exists). Skipping init."
+else
+    cd "$INSTALL_DIR"
+    set -a
+    source "$ENV_FILE"
+    set +a
+    "$BIN" init --root --center "$CENTER_URL"
+    cd "$REPO_ROOT"
 fi
 
-# --- [6/8] Stop existing process ---
-echo "[6/8] Checking existing process..."
+# --- [7/7] Start ---
+echo "[7/7] Starting LocalVault..."
 if [ -f "$PID_FILE" ]; then
     OLD_PID=$(cat "$PID_FILE" 2>/dev/null || echo "")
     if [[ -n "$OLD_PID" ]] && kill -0 "$OLD_PID" 2>/dev/null; then
@@ -157,63 +147,58 @@ if [ -f "$PID_FILE" ]; then
     rm -f "$PID_FILE"
 fi
 
-# --- [7/8] Init (if not already initialized) ---
-echo "[7/8] Initializing..."
-if [ -f "$DATA_DIR/salt" ]; then
-    echo "  Already initialized (salt exists). Skipping init."
-else
-    cd "$INSTALL_DIR"
-    set -a; source "$ENV_FILE"; set +a
-    echo "$VEILKEY_PASSWORD" | "$BIN" init --root --center "$CENTER_URL"
-    cd "$REPO_ROOT"
-fi
-
-# --- [8/8] Start + unlock ---
-echo "[8/8] Starting LocalVault..."
 cd "$INSTALL_DIR"
-set -a; source "$ENV_FILE"; set +a
-SAVED_PASSWORD="$VEILKEY_PASSWORD"
-unset VEILKEY_PASSWORD
+set -a
+source "$ENV_FILE"
+set +a
 nohup "$BIN" server > "$LOG_FILE" 2>&1 &
 echo $! > "$PID_FILE"
 NEW_PID=$(cat "$PID_FILE")
 cd "$REPO_ROOT"
 
-sleep 3
-if kill -0 "$NEW_PID" 2>/dev/null; then
-    # Unlock via HTTPS (TLS enabled)
-    UNLOCK=$(curl -sk -X POST "https://127.0.0.1:$PORT/api/unlock" \
-        -H 'Content-Type: application/json' \
-        -d "{\"password\":\"$SAVED_PASSWORD\"}" 2>/dev/null || echo '{"error":"failed"}')
-
-    if echo "$UNLOCK" | grep -q '"unlocked"'; then
-        HEALTH=$(curl -sk "https://127.0.0.1:$PORT/health" 2>/dev/null || echo "")
-        echo ""
-        echo "=== Installation complete ==="
-        echo ""
-        echo "  Status: $HEALTH"
-        echo "  PID:    $NEW_PID"
-        echo "  Port:   $PORT (HTTPS)"
-        echo "  Log:    $LOG_FILE"
-        echo "  Data:   $DATA_DIR"
-        echo "  TLS:    $TLS_DIR/cert.pem"
-        echo "  Center: $CENTER_URL"
-        [[ -n "$BULK_PATHS" ]] && echo "  Bulk:   $BULK_PATHS"
-        echo ""
-        echo "Management:"
-        echo "  tail -f $LOG_FILE"
-        echo "  kill \$(cat $PID_FILE)"
-        echo "  bash install/proxmox-lxc-debian/uninstall-localvault.sh"
-        echo ""
-    else
-        echo ""
-        echo "⚠️  Started but unlock failed: $UNLOCK"
-        echo "  Log: tail -20 $LOG_FILE"
-    fi
-else
+sleep 1
+if ! kill -0 "$NEW_PID" 2>/dev/null; then
     echo ""
     echo "❌ Start failed"
     echo "  Log: tail -20 $LOG_FILE"
     tail -20 "$LOG_FILE"
     exit 1
 fi
+
+HEALTH=""
+for _ in $(seq 1 20); do
+    HEALTH=$(curl -sk "$HEALTH_URL" 2>/dev/null || true)
+    if [[ "$HEALTH" == *'"status":"ok"'* ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if [[ "$HEALTH" != *'"status":"ok"'* ]]; then
+    echo ""
+    echo "❌ LocalVault health check failed"
+    echo "  Health: ${HEALTH:-<empty>}"
+    echo "  Log: tail -40 $LOG_FILE"
+    tail -40 "$LOG_FILE"
+    exit 1
+fi
+
+STATUS_JSON=$(curl -sk "$STATUS_URL" 2>/dev/null || true)
+echo ""
+echo "=== Installation complete ==="
+echo ""
+echo "  Health: $HEALTH"
+echo "  Status: ${STATUS_JSON:-<empty>}"
+echo "  PID:    $NEW_PID"
+echo "  Port:   $PORT (HTTPS)"
+echo "  Log:    $LOG_FILE"
+echo "  Data:   $DATA_DIR"
+echo "  TLS:    $TLS_DIR/cert.pem"
+echo "  Center: $CENTER_URL"
+[[ -n "$BULK_PATHS" ]] && echo "  Bulk:   $BULK_PATHS"
+echo ""
+echo "Management:"
+echo "  tail -f $LOG_FILE"
+echo "  kill \$(cat $PID_FILE)"
+echo "  bash install/proxmox-lxc-debian/uninstall-localvault.sh"
+echo ""

--- a/services/localvault/internal/commands/init.go
+++ b/services/localvault/internal/commands/init.go
@@ -54,7 +54,7 @@ func RunInit() {
 		fmt.Println("  --force     Force re-initialization (WARNING: destroys existing data)")
 		fmt.Println("  --token     Registration token from VaultCenter")
 		fmt.Println("  --center    VaultCenter URL (alternative to token)")
-		fmt.Println("  Password is read from stdin (pipe) or interactive TTY prompt.")
+		fmt.Println("  Unlock key is auto-generated and transferred to VaultCenter on first heartbeat.")
 		os.Exit(1)
 	}
 

--- a/services/veil-cli/src/bin/veil.rs
+++ b/services/veil-cli/src/bin/veil.rs
@@ -83,6 +83,27 @@ fn load_env_file(path: &str) {
     }
 }
 
+fn find_repo_install_script() -> Option<String> {
+    let cwd = env::current_dir().ok()?;
+    for dir in cwd.ancestors() {
+        let common = dir
+            .join("install")
+            .join("common")
+            .join("install-localvault.sh");
+        if common.exists() {
+            return Some(common.to_string_lossy().to_string());
+        }
+        let proxmox = dir
+            .join("install")
+            .join("proxmox-lxc-debian")
+            .join("install-localvault.sh");
+        if proxmox.exists() {
+            return Some(proxmox.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
 fn main() {
     // Auto-load .veilkey/env from current or parent dirs
     // Clear legacy env vars first so .veilkey/env takes precedence
@@ -169,25 +190,30 @@ trap 'rm -f "$HISTFILE"' EXIT
                         process::exit(1);
                     }
 
-                    let gist_url = "https://gist.githubusercontent.com/dalsoop/11e00346263678340189cdfdc79644b5/raw/install-localvault.sh";
-                    let script = format!(
-                        "VEILKEY_CENTER_URL='{}' VEILKEY_PORT='{}' curl -sL '{}?{}' | bash",
-                        center_url,
-                        port,
-                        gist_url,
-                        std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs()
-                    );
-                    let status = process::Command::new("bash")
-                        .arg("-c")
-                        .arg(&script)
-                        .status()
-                        .unwrap_or_else(|e| {
-                            eprintln!("veil localvault: failed to run installer: {}", e);
-                            process::exit(1);
-                        });
+                    let status = if let Some(script_path) = find_repo_install_script() {
+                        process::Command::new("bash")
+                            .arg(script_path)
+                            .env("VEILKEY_CENTER_URL", &center_url)
+                            .env("VEILKEY_PORT", port.to_string())
+                            .status()
+                    } else {
+                        let gist_url = "https://gist.githubusercontent.com/dalsoop/11e00346263678340189cdfdc79644b5/raw/install-localvault.sh";
+                        let script = format!(
+                            "VEILKEY_CENTER_URL='{}' VEILKEY_PORT='{}' curl -sL '{}?{}' | bash",
+                            center_url,
+                            port,
+                            gist_url,
+                            std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs()
+                        );
+                        process::Command::new("bash").arg("-c").arg(&script).status()
+                    }
+                    .unwrap_or_else(|e| {
+                        eprintln!("veil localvault: failed to run installer: {}", e);
+                        process::exit(1);
+                    });
                     process::exit(status.code().unwrap_or(1));
                 }
                 "stop" => {


### PR DESCRIPTION
## Summary
- align LocalVault installers with VC-managed unlock instead of password/stdin unlock
- regenerate installer env/runtime config around TLS cert paths, salt-based init checks, and health polling
- make `veil localvault init|update` prefer repo-local installer scripts before falling back to the gist
- update setup docs and init CLI help text to match the new bootstrap/heartbeat flow

## Validation
- `bash -n install/proxmox-lxc-debian/install-localvault.sh`
- `bash -n install/common/install-localvault.sh`
- `cd services/localvault && go test ./internal/commands/...`
- `cargo check -p veil-cli-rs --manifest-path Cargo.toml`
- standalone installer smoke test: `init -> server -> health ok`
