### PR TITLE
fix: support vaultcenter plugin sync via CLI

### DIFF
--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -261,7 +261,7 @@ func (s *Server) FindAgentRecord(hashOrLabel string) (*db.Agent, error) {
 }
 
 func (s *Server) FetchAgentCiphertext(agentURL, ref string) (name string, ciphertext []byte, nonce []byte, err error) {
-	resp, httpErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathCipher, ref))
+	resp, httpErr := s.agentGET(agentURL, httputil.AgentPathCipher+"/"+ref, "")
 	if httpErr != nil {
 		return "", nil, nil, fmt.Errorf("agent unreachable: %w", httpErr)
 	}
@@ -278,6 +278,37 @@ func (s *Server) FetchAgentCiphertext(agentURL, ref string) (name string, cipher
 		return "", nil, nil, fmt.Errorf("invalid agent response: %w", decErr)
 	}
 	return data.Name, data.Ciphertext, data.Nonce, nil
+}
+
+func (s *Server) fetchAgentCiphertextAuthorized(agentURL, ref, agentSecret string) (name string, ciphertext []byte, nonce []byte, err error) {
+	resp, httpErr := s.agentGET(agentURL, httputil.AgentPathCipher+"/"+ref, agentSecret)
+	if httpErr != nil {
+		return "", nil, nil, fmt.Errorf("agent unreachable: %w", httpErr)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", nil, nil, fmt.Errorf("agent returned %d", resp.StatusCode)
+	}
+	var data struct {
+		Name       string `json:"name"`
+		Ciphertext []byte `json:"ciphertext"`
+		Nonce      []byte `json:"nonce"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&data); decErr != nil {
+		return "", nil, nil, fmt.Errorf("invalid agent response: %w", decErr)
+	}
+	return data.Name, data.Ciphertext, data.Nonce, nil
+}
+
+func (s *Server) agentGET(agentURL, path, agentSecret string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, httputil.JoinPath(agentURL, path), nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(agentSecret) != "" {
+		req.Header.Set("Authorization", "Bearer "+agentSecret)
+	}
+	return s.httpClient.Do(req)
 }
 
 func (s *Server) AgentURL(ip string, port int) string {
@@ -306,16 +337,17 @@ func (s *Server) ResolveTemplateValue(vaultHash, kind, name string) (string, boo
 		return "", false
 	}
 	agentURL := s.AgentURL(agent.IP, agent.Port)
+	agentSecret := s.decryptAgentSecret(agent.AgentSecretEnc, agent.AgentSecretNonce)
 	if kind == "secret" {
-		return s.resolveBulkApplySecretValue(agentURL, agent.DEK, agent.DEKNonce, name)
+		return s.resolveBulkApplySecretValue(agentURL, agentSecret, agent.DEK, agent.DEKNonce, name)
 	}
-	return s.resolveBulkApplyConfigValue(agentURL, name)
+	return s.resolveBulkApplyConfigValue(agentURL, agentSecret, name)
 }
 
-func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce []byte, name string) (string, bool) {
+func (s *Server) resolveBulkApplySecretValue(agentURL, agentSecret string, encDEK, encNonce []byte, name string) (string, bool) {
 	// Resolve name → ref via agent's secret meta endpoint.
 	ref := name
-	if metaResp, metaErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathSecretMeta, name)); metaErr == nil {
+	if metaResp, metaErr := s.agentGET(agentURL, httputil.AgentPathSecretMeta+"/"+name, agentSecret); metaErr == nil {
 		defer metaResp.Body.Close()
 		if metaResp.StatusCode == 200 {
 			var meta struct {
@@ -335,7 +367,7 @@ func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce [
 
 	// Try fetching ciphertext by resolved ref.
 	for _, candidate := range uniqueStrings(ref, name) {
-		_, ciphertext, nonce, err := s.FetchAgentCiphertext(agentURL, candidate)
+		_, ciphertext, nonce, err := s.fetchAgentCiphertextAuthorized(agentURL, candidate, agentSecret)
 		if err != nil {
 			continue
 		}
@@ -346,7 +378,7 @@ func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce [
 	}
 
 	// Last resort: agent's own resolve endpoint.
-	resp, resolveErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathResolve, name))
+	resp, resolveErr := s.agentGET(agentURL, httputil.AgentPathResolve+"/"+name, agentSecret)
 	if resolveErr != nil {
 		return "", false
 	}
@@ -377,8 +409,8 @@ func uniqueStrings(vals ...string) []string {
 	return out
 }
 
-func (s *Server) resolveBulkApplyConfigValue(agentURL, key string) (string, bool) {
-	resp, err := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathConfigs, key))
+func (s *Server) resolveBulkApplyConfigValue(agentURL, agentSecret, key string) (string, bool) {
+	resp, err := s.agentGET(agentURL, httputil.AgentPathConfigs+"/"+key, agentSecret)
 	if err != nil {
 		return "", false
 	}

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -246,6 +246,12 @@ func (d *DB) GetAgentByLabel(label string) (*Agent, error) {
 func (d *DB) GetAgentByHash(agentHash string) (*Agent, error) {
 	return dbFirst[Agent](d, "agent hash "+agentHash+" not found", "agent_hash = ?", agentHash)
 }
+func (d *DB) GetAgentByVaultHash(vaultHash string) (*Agent, error) {
+	return dbFirst[Agent](d, "agent vault hash "+vaultHash+" not found", "vault_hash = ?", vaultHash)
+}
+func (d *DB) GetAgentByVaultName(vaultName string) (*Agent, error) {
+	return dbFirst[Agent](d, "agent vault name "+vaultName+" not found", "vault_name = ?", vaultName)
+}
 func (d *DB) GetAgentBySecretHash(secretHash string) (*Agent, error) {
 	return dbFirst[Agent](d, "agent with secret hash not found", "agent_secret_hash = ?", secretHash)
 }
@@ -293,12 +299,25 @@ func (d *DB) RestoreDeletedAgent(nodeID string) error {
 }
 
 func (d *DB) GetAgentRecord(hashOrLabel string) (*Agent, error) {
-	if len(hashOrLabel) == 8 {
-		if agent, err := d.GetAgentByHash(hashOrLabel); err == nil {
+	id := strings.TrimSpace(hashOrLabel)
+	if id == "" {
+		return nil, fmt.Errorf("agent identifier is empty")
+	}
+	if len(id) == 8 {
+		if agent, err := d.GetAgentByHash(id); err == nil {
 			return agent, nil
 		}
 	}
-	return d.GetAgentByLabel(hashOrLabel)
+	if agent, err := d.GetAgentByVaultHash(id); err == nil {
+		return agent, nil
+	}
+	if agent, err := d.GetAgentByNodeID(id); err == nil {
+		return agent, nil
+	}
+	if agent, err := d.GetAgentByVaultName(id); err == nil {
+		return agent, nil
+	}
+	return d.GetAgentByLabel(id)
 }
 
 func (d *DB) UpdateAgentDEK(nodeID string, agentHash string, dek, dekNonce []byte) error {

--- a/services/vaultcenter/internal/plugin/handler.go
+++ b/services/vaultcenter/internal/plugin/handler.go
@@ -208,7 +208,22 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	output := h.resolvePlaceholders(vault, rendered.Output)
-	paths, _ := inst.Paths(ctx)
+
+	var (
+		paths []string
+		hooks []HookDef
+	)
+	if initResult, initErr := inst.Init(ctx, input.Input); initErr != nil {
+		log.Printf("plugin sync init %s: %v", name, initErr)
+		respondError(w, http.StatusInternalServerError, "plugin init failed")
+		return
+	} else if initResult != nil {
+		paths = append(paths, initResult.Paths...)
+		hooks = append(hooks, initResult.Hooks...)
+	}
+	if len(paths) == 0 {
+		paths, _ = inst.Paths(ctx)
+	}
 	if len(paths) == 0 {
 		respondError(w, http.StatusInternalServerError, "no target paths")
 		return
@@ -218,7 +233,9 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "validation failed")
 		return
 	}
-	hooks, _ := inst.Hooks(ctx)
+	if len(hooks) == 0 {
+		hooks, _ = inst.Hooks(ctx)
+	}
 	sortedHooks, sortErr := SortHooks(hooks)
 	if sortErr != nil {
 		log.Printf("plugin sync hook sort %s: %v", name, sortErr)
@@ -231,12 +248,31 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "vault not reachable")
 		return
 	}
-	// Build steps: one content step + sorted hooks
-	steps := []any{map[string]any{"name": "plugin-sync", "format": "raw", "target_path": paths[0], "content": output}}
+	// LocalVault bulk-apply validates every step as a file write, so hooks must be
+	// attached to a content-bearing step instead of being emitted as hook-only steps.
+	stepCap := len(sortedHooks)
+	if stepCap == 0 {
+		stepCap = 1
+	}
+	steps := make([]any, 0, stepCap)
 	var hookNames []string
-	for _, h := range sortedHooks {
-		steps = append(steps, map[string]any{"name": h.Name, "hook": h.Name})
-		hookNames = append(hookNames, h.Name)
+	if len(sortedHooks) == 0 {
+		steps = append(steps, map[string]any{
+			"name":        "plugin-sync",
+			"format":      "raw",
+			"target_path": paths[0],
+			"content":     output,
+		})
+	} else {
+		hook := sortedHooks[0]
+		steps = append(steps, map[string]any{
+			"name":        hook.Name,
+			"format":      "raw",
+			"target_path": paths[0],
+			"content":     output,
+			"hook":        hook.Name,
+		})
+		hookNames = append(hookNames, hook.Name)
 	}
 	payload, _ := json.Marshal(map[string]any{"name": "plugin-sync", "steps": steps})
 	syncReq, _ := http.NewRequest("POST", strings.TrimRight(agentURL, "/")+"/api/bulk-apply/execute", bytes.NewReader(payload))

--- a/services/veil-cli/src/api.rs
+++ b/services/veil-cli/src/api.rs
@@ -174,6 +174,44 @@ impl VeilKeyClient {
         req.call()
     }
 
+    pub fn plugins_list(&self) -> Result<Vec<serde_json::Value>, String> {
+        let url = format!("{}/api/plugins", self.base_url);
+        let resp = self
+            .raw_get(&url)
+            .map_err(|e| format!("plugins list failed: {}", e))?;
+        let result: serde_json::Value = resp
+            .into_json()
+            .map_err(|e| format!("decode failed: {}", e))?;
+        result["plugins"]
+            .as_array()
+            .cloned()
+            .ok_or_else(|| "missing plugins in response".to_string())
+    }
+
+    pub fn plugin_sync(
+        &self,
+        vault: &str,
+        plugin: &str,
+        action: &str,
+        input: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let url = format!(
+            "{}/api/vaults/{}/plugins/{}/sync",
+            self.base_url,
+            urlencoding::encode(vault),
+            urlencoding::encode(plugin)
+        );
+        let body = serde_json::json!({
+            "action": action,
+            "input": input,
+        });
+        let resp = self
+            .raw_post(&url, &body)
+            .map_err(|e| format!("plugin sync failed: {}", e))?;
+        resp.into_json()
+            .map_err(|e| format!("decode failed: {}", e))
+    }
+
     pub fn issue(&self, value: &str) -> Result<String, String> {
         let value = value.trim_end_matches(['\r', '\n']);
         {

--- a/services/veil-cli/src/bin/veilkey_cli.rs
+++ b/services/veil-cli/src/bin/veilkey_cli.rs
@@ -19,6 +19,15 @@ fn resolve_api_url() -> Option<String> {
     None
 }
 
+fn resolve_vaultcenter_url() -> Option<String> {
+    if let Ok(v) = std::env::var("VEILKEY_VAULTCENTER_URL") {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    None
+}
+
 fn print_usage() {
     eprintln!(
         r#"Usage:
@@ -52,6 +61,8 @@ fn print_usage() {
   veilkey cleanup [--json]          Clean up stale tracked refs
   veilkey ref-audit [--json]        Audit tracked refs
   veilkey inventory [--json]        Show vault inventory
+  veilkey plugin list               List installed plugins
+  veilkey plugin sync ...           Run plugin sync against a vault
   veilkey traefik <sub>              Manage Traefik config (init|status|destroy)
   veilkey status                    Show status
   veilkey version                   Show version
@@ -109,6 +120,7 @@ fn main() {
         "cleanup",
         "ref-audit",
         "inventory",
+        "plugin",
     ];
 
     let subcmd = raw_args.get(1).map(String::as_str).unwrap_or("");
@@ -1115,6 +1127,14 @@ fn main() {
             }
         }
         "version" => println!("veilkey {}", VERSION),
+        "plugin" => {
+            let vc_url = resolve_vaultcenter_url().unwrap_or_else(|| {
+                eprintln!("ERROR: VEILKEY_VAULTCENTER_URL is required for plugin commands.");
+                eprintln!("  export VEILKEY_VAULTCENTER_URL=<vaultcenter-url>");
+                process::exit(1);
+            });
+            commands::cmd_plugin(&cmd_args, &vc_url, &log_path, patterns_file.as_deref())
+        }
         "traefik" => {
             commands::cmd_traefik(&cmd_args, &api_url, &log_path, patterns_file.as_deref())
         }

--- a/services/veil-cli/src/commands.rs
+++ b/services/veil-cli/src/commands.rs
@@ -590,6 +590,174 @@ fn traefik_destroy(args: &[String], api_url: &str) {
     }
 }
 
+pub fn cmd_plugin(args: &[String], api_url: &str, _log_path: &str, _patterns_file: Option<&str>) {
+    if args.is_empty() {
+        eprintln!("Usage: veilkey plugin <list|sync> [args]");
+        eprintln!("  list");
+        eprintln!("  sync --vault <vault> --plugin <name> --action <action> --input-json <json>");
+        eprintln!("  sync --vault <vault> --plugin <name> --action <action> --input-file <path>");
+        process::exit(1);
+    }
+    match args[0].as_str() {
+        "list" => plugin_list(api_url),
+        "sync" => plugin_sync(&args[1..], api_url),
+        other => {
+            eprintln!("Unknown plugin subcommand: {}", other);
+            process::exit(1);
+        }
+    }
+}
+
+fn plugin_list(api_url: &str) {
+    let client = VeilKeyClient::new(api_url);
+    let password = std::env::var("VEILKEY_PASSWORD")
+        .unwrap_or_else(|_| rpassword::prompt_password("VeilKey password: ").unwrap_or_default());
+    if let Err(e) = client.admin_login(&password) {
+        eprintln!("[veilkey] login failed: {}", e);
+        process::exit(1);
+    }
+    match client.plugins_list() {
+        Ok(plugins) => {
+            if plugins.is_empty() {
+                println!("No plugins installed");
+                return;
+            }
+            println!(
+                "\x1b[0;36m{:<24} {:<10} {:<8} {}\x1b[0m",
+                "NAME", "VERSION", "LOADED", "DESCRIPTION"
+            );
+            println!("{}", "─".repeat(80));
+            for plugin in plugins {
+                println!(
+                    "{:<24} {:<10} {:<8} {}",
+                    plugin["name"].as_str().unwrap_or("-"),
+                    plugin["version"].as_str().unwrap_or("-"),
+                    if plugin["loaded"].as_bool().unwrap_or(false) {
+                        "yes"
+                    } else {
+                        "no"
+                    },
+                    plugin["description"].as_str().unwrap_or("-"),
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("ERROR: plugin list failed: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn plugin_sync(args: &[String], api_url: &str) {
+    let mut vault: Option<String> = None;
+    let mut plugin: Option<String> = None;
+    let mut action: Option<String> = None;
+    let mut input_json: Option<String> = None;
+    let mut input_file: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--vault" if i + 1 < args.len() => {
+                vault = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--vault=") => {
+                vault = Some(a["--vault=".len()..].to_string());
+                i += 1;
+            }
+            "--plugin" if i + 1 < args.len() => {
+                plugin = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--plugin=") => {
+                plugin = Some(a["--plugin=".len()..].to_string());
+                i += 1;
+            }
+            "--action" if i + 1 < args.len() => {
+                action = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--action=") => {
+                action = Some(a["--action=".len()..].to_string());
+                i += 1;
+            }
+            "--input-json" if i + 1 < args.len() => {
+                input_json = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--input-json=") => {
+                input_json = Some(a["--input-json=".len()..].to_string());
+                i += 1;
+            }
+            "--input-file" if i + 1 < args.len() => {
+                input_file = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--input-file=") => {
+                input_file = Some(a["--input-file=".len()..].to_string());
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    let vault = vault.unwrap_or_else(|| {
+        eprintln!("ERROR: --vault is required");
+        process::exit(1);
+    });
+    let plugin = plugin.unwrap_or_else(|| {
+        eprintln!("ERROR: --plugin is required");
+        process::exit(1);
+    });
+    let action = action.unwrap_or_else(|| {
+        eprintln!("ERROR: --action is required");
+        process::exit(1);
+    });
+
+    let raw_input = if let Some(path) = input_file {
+        std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            eprintln!("ERROR: cannot read {}: {}", path, e);
+            process::exit(1);
+        })
+    } else if let Some(json) = input_json {
+        json
+    } else {
+        eprintln!("ERROR: --input-json or --input-file is required");
+        process::exit(1);
+    };
+
+    let input: serde_json::Value = serde_json::from_str(&raw_input).unwrap_or_else(|e| {
+        eprintln!("ERROR: invalid input JSON: {}", e);
+        process::exit(1);
+    });
+
+    let client = VeilKeyClient::new(api_url);
+    let password = std::env::var("VEILKEY_PASSWORD")
+        .unwrap_or_else(|_| rpassword::prompt_password("VeilKey password: ").unwrap_or_default());
+    if let Err(e) = client.admin_login(&password) {
+        eprintln!("[veilkey] login failed: {}", e);
+        process::exit(1);
+    }
+    match client.plugin_sync(&vault, &plugin, &action, &input) {
+        Ok(result) => {
+            println!(
+                "plugin synced: vault={} plugin={} action={}",
+                vault, plugin, action
+            );
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string())
+            );
+        }
+        Err(e) => {
+            eprintln!("ERROR: plugin sync failed: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
 pub fn cmd_proxy(args: &[String]) {
     let mut listen = String::new();
     let mut allow_hosts: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary
- fix VaultCenter plugin sync so plugin init paths, vault lookup, and LocalVault bulk-apply hooks work for GitLab env management
- add `veilkey plugin list` and `veilkey plugin sync` commands that use `VEILKEY_VAULTCENTER_URL` and admin login
- validate the CLI path against the live `gitlab-lv` vault and `docker-compose-sync` plugin

## Verification
- `cd services/vaultcenter && go test ./internal/plugin/... ./internal/api/... ./internal/db/...`
- `cd services/veil-cli && cargo check`
- `VEILKEY_VAULTCENTER_URL=http://10.50.0.110:11181 VEILKEY_PASSWORD=... cargo run --bin veilkey-cli -- plugin list`
- `VEILKEY_VAULTCENTER_URL=http://10.50.0.110:11181 VEILKEY_PASSWORD=... cargo run --bin veilkey-cli -- plugin sync --vault gitlab-lv --plugin docker-compose-sync --action generate_env --input-json '{"service_dir":"/opt/gitlab","project":"gitlab","vars":{"GITLAB_OIDC_CLIENT_SECRET":"{{ vk.GITLAB_OIDC_CLIENT_SECRET }}"}}'`
