### PR TITLE
fix: secure plugin-managed runtime env sync

### DIFF
--- a/scripts/veilkey-compose-secure-hook.sh
+++ b/scripts/veilkey-compose-secure-hook.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+steps_json="${VEILKEY_BULK_APPLY_STEPS_JSON:-[]}"
+lv_url="${VEILKEY_LOCALVAULT_URL:-https://127.0.0.1:10180}"
+agent_secret_file="${VEILKEY_LOCALVAULT_AGENT_SECRET_FILE:-/opt/veilkey-localvault/data/agent_secret}"
+runtime_env_content="${VEILKEY_RUNTIME_ENV_CONTENT:-}"
+
+python3 - "$steps_json" "$lv_url" "$agent_secret_file" "$runtime_env_content" "${1:-}" "${2:-}" <<'PY'
+import json
+import os
+import pathlib
+import ssl
+import sys
+import urllib.request
+
+steps = json.loads(sys.argv[1] or "[]")
+lv_url = sys.argv[2].rstrip("/")
+agent_secret_file = pathlib.Path(sys.argv[3])
+runtime_env_content = sys.argv[4]
+service_dir_arg = sys.argv[5].strip()
+project_arg = sys.argv[6].strip()
+ssl_ctx = ssl._create_unverified_context()
+agent_secret = agent_secret_file.read_text().strip() if agent_secret_file.exists() else ""
+
+if steps:
+    target = pathlib.Path(steps[0]["target_path"])
+    service_dir = target.parent
+    project = project_arg or service_dir.name
+else:
+    if not service_dir_arg:
+        raise SystemExit("no bulk-apply steps or service_dir argument supplied")
+    service_dir = pathlib.Path(service_dir_arg)
+    project = project_arg or service_dir.name
+    target = service_dir / ".env.veil"
+
+runtime_dir = pathlib.Path("/run/veilkey/docker-compose")
+runtime_dir.mkdir(parents=True, exist_ok=True)
+runtime_env = runtime_dir / f"{project}.env"
+
+def resolve_value(value: str) -> str:
+    if value.startswith(("VK:LOCAL:", "VK:EXTERNAL:", "VK:TEMP:")):
+        req = urllib.request.Request(
+            f"{lv_url}/api/resolve/{value}",
+            headers={"Authorization": f"Bearer {agent_secret}"},
+        )
+        with urllib.request.urlopen(req, context=ssl_ctx) as resp:
+            return json.load(resp)["value"]
+    if value.startswith("VE:LOCAL:"):
+        key = value[len("VE:LOCAL:"):]
+        req = urllib.request.Request(
+            f"{lv_url}/api/configs/{key}",
+            headers={"Authorization": f"Bearer {agent_secret}"},
+        )
+        with urllib.request.urlopen(req, context=ssl_ctx) as resp:
+            return json.load(resp)["value"]
+    return value
+
+if runtime_env_content:
+    runtime_env.write_text(runtime_env_content if runtime_env_content.endswith("\n") else runtime_env_content + "\n")
+else:
+    lines = []
+    for raw_line in target.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            lines.append(raw_line)
+            continue
+        key, sep, value = raw_line.partition("=")
+        if not sep:
+            raise SystemExit(f"invalid env line: {raw_line}")
+        lines.append(f"{key}={resolve_value(value)}")
+    runtime_env.write_text("\n".join(lines) + "\n")
+os.chmod(runtime_env, 0o600)
+
+compose_file = service_dir / "docker-compose.yml"
+os.execvp(
+    "bash",
+    [
+        "bash",
+        "-lc",
+        f"trap 'rm -f {runtime_env}' EXIT; docker compose -f {compose_file} up -d --force-recreate",
+    ],
+)
+PY

--- a/services/localvault/internal/api/bulk/apply.go
+++ b/services/localvault/internal/api/bulk/apply.go
@@ -19,6 +19,7 @@ type bulkApplyStep struct {
 	TargetPath string `json:"target_path"`
 	Content    string `json:"content"`
 	Hook       string `json:"hook"`
+	HookEnv    map[string]string `json:"hook_env,omitempty"`
 }
 
 type bulkApplyWorkflowRequest struct {
@@ -251,17 +252,52 @@ func applyBulkApplyStep(step bulkApplyStep, registry *FormatRegistry) error {
 	return provider.Apply(step.TargetPath, step.Content)
 }
 
-func runAllowedHook(name string) (string, error) {
+func runAllowedHook(name string, envVars map[string]string) (string, error) {
 	cmdv, ok := getAllowedBulkApplyHook(name)
 	if !ok {
 		return "", fmt.Errorf("hook is not allowed: %s", name)
 	}
 	cmd := exec.Command(cmdv[0], cmdv[1:]...)
+	cmd.Env = os.Environ()
+	for key, value := range envVars {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return strings.TrimSpace(string(out)), fmt.Errorf("%s: %s", err.Error(), strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func hookEnv(req bulkApplyWorkflowRequest, hook string) map[string]string {
+	payload := make([]map[string]string, 0, len(req.Steps))
+	targets := make([]string, 0, len(req.Steps))
+	envVars := map[string]string{}
+	for _, step := range req.Steps {
+		if strings.TrimSpace(step.Hook) != strings.TrimSpace(hook) {
+			continue
+		}
+		payload = append(payload, map[string]string{
+			"name":        step.Name,
+			"format":      step.Format,
+			"target_path": step.TargetPath,
+			"hook":        step.Hook,
+		})
+		targets = append(targets, step.TargetPath)
+		for key, value := range step.HookEnv {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			envVars[key] = value
+		}
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	envVars["VEILKEY_BULK_APPLY_WORKFLOW"] = req.Name
+	envVars["VEILKEY_BULK_APPLY_HOOK"] = hook
+	envVars["VEILKEY_BULK_APPLY_STEPS_JSON"] = string(payloadJSON)
+	envVars["VEILKEY_BULK_APPLY_TARGET_PATHS"] = strings.Join(targets, ":")
+	return envVars
 }
 
 func orderedHooks(steps []bulkApplyStep) []string {
@@ -525,7 +561,7 @@ func (h *Handler) handleBulkApplyExecute(w http.ResponseWriter, r *http.Request)
 		})
 	}
 	for _, hook := range hooks {
-		output, err := runAllowedHook(hook)
+		output, err := runAllowedHook(hook, hookEnv(req, hook))
 		hookRow := map[string]any{
 			"name":   hook,
 			"status": "ok",

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -261,7 +261,7 @@ func (s *Server) FindAgentRecord(hashOrLabel string) (*db.Agent, error) {
 }
 
 func (s *Server) FetchAgentCiphertext(agentURL, ref string) (name string, ciphertext []byte, nonce []byte, err error) {
-	resp, httpErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathCipher, ref))
+	resp, httpErr := s.agentGET(agentURL, httputil.AgentPathCipher+"/"+ref, "")
 	if httpErr != nil {
 		return "", nil, nil, fmt.Errorf("agent unreachable: %w", httpErr)
 	}
@@ -278,6 +278,37 @@ func (s *Server) FetchAgentCiphertext(agentURL, ref string) (name string, cipher
 		return "", nil, nil, fmt.Errorf("invalid agent response: %w", decErr)
 	}
 	return data.Name, data.Ciphertext, data.Nonce, nil
+}
+
+func (s *Server) fetchAgentCiphertextAuthorized(agentURL, ref, agentSecret string) (name string, ciphertext []byte, nonce []byte, err error) {
+	resp, httpErr := s.agentGET(agentURL, httputil.AgentPathCipher+"/"+ref, agentSecret)
+	if httpErr != nil {
+		return "", nil, nil, fmt.Errorf("agent unreachable: %w", httpErr)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", nil, nil, fmt.Errorf("agent returned %d", resp.StatusCode)
+	}
+	var data struct {
+		Name       string `json:"name"`
+		Ciphertext []byte `json:"ciphertext"`
+		Nonce      []byte `json:"nonce"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&data); decErr != nil {
+		return "", nil, nil, fmt.Errorf("invalid agent response: %w", decErr)
+	}
+	return data.Name, data.Ciphertext, data.Nonce, nil
+}
+
+func (s *Server) agentGET(agentURL, path, agentSecret string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, httputil.JoinPath(agentURL, path), nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(agentSecret) != "" {
+		req.Header.Set("Authorization", "Bearer "+agentSecret)
+	}
+	return s.httpClient.Do(req)
 }
 
 func (s *Server) AgentURL(ip string, port int) string {
@@ -306,16 +337,17 @@ func (s *Server) ResolveTemplateValue(vaultHash, kind, name string) (string, boo
 		return "", false
 	}
 	agentURL := s.AgentURL(agent.IP, agent.Port)
+	agentSecret := s.decryptAgentSecret(agent.AgentSecretEnc, agent.AgentSecretNonce)
 	if kind == "secret" {
-		return s.resolveBulkApplySecretValue(agentURL, agent.DEK, agent.DEKNonce, name)
+		return s.resolveBulkApplySecretValue(agentURL, agentSecret, agent.DEK, agent.DEKNonce, name)
 	}
-	return s.resolveBulkApplyConfigValue(agentURL, name)
+	return s.resolveBulkApplyConfigValue(agentURL, agentSecret, name)
 }
 
-func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce []byte, name string) (string, bool) {
+func (s *Server) resolveBulkApplySecretValue(agentURL, agentSecret string, encDEK, encNonce []byte, name string) (string, bool) {
 	// Resolve name → ref via agent's secret meta endpoint.
 	ref := name
-	if metaResp, metaErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathSecretMeta, name)); metaErr == nil {
+	if metaResp, metaErr := s.agentGET(agentURL, httputil.AgentPathSecretMeta+"/"+name, agentSecret); metaErr == nil {
 		defer metaResp.Body.Close()
 		if metaResp.StatusCode == 200 {
 			var meta struct {
@@ -335,7 +367,7 @@ func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce [
 
 	// Try fetching ciphertext by resolved ref.
 	for _, candidate := range uniqueStrings(ref, name) {
-		_, ciphertext, nonce, err := s.FetchAgentCiphertext(agentURL, candidate)
+		_, ciphertext, nonce, err := s.fetchAgentCiphertextAuthorized(agentURL, candidate, agentSecret)
 		if err != nil {
 			continue
 		}
@@ -346,7 +378,7 @@ func (s *Server) resolveBulkApplySecretValue(agentURL string, encDEK, encNonce [
 	}
 
 	// Last resort: agent's own resolve endpoint.
-	resp, resolveErr := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathResolve, name))
+	resp, resolveErr := s.agentGET(agentURL, httputil.AgentPathResolve+"/"+name, agentSecret)
 	if resolveErr != nil {
 		return "", false
 	}
@@ -377,8 +409,8 @@ func uniqueStrings(vals ...string) []string {
 	return out
 }
 
-func (s *Server) resolveBulkApplyConfigValue(agentURL, key string) (string, bool) {
-	resp, err := s.httpClient.Get(httputil.JoinPath(agentURL, httputil.AgentPathConfigs, key))
+func (s *Server) resolveBulkApplyConfigValue(agentURL, agentSecret, key string) (string, bool) {
+	resp, err := s.agentGET(agentURL, httputil.AgentPathConfigs+"/"+key, agentSecret)
 	if err != nil {
 		return "", false
 	}

--- a/services/vaultcenter/internal/api/api.go
+++ b/services/vaultcenter/internal/api/api.go
@@ -344,6 +344,22 @@ func (s *Server) ResolveTemplateValue(vaultHash, kind, name string) (string, boo
 	return s.resolveBulkApplyConfigValue(agentURL, agentSecret, name)
 }
 
+func (s *Server) ResolveTemplateRef(vaultHash, kind, name string) (string, bool) {
+	agent, err := s.FindAgentRecord(vaultHash)
+	if err != nil {
+		return "", false
+	}
+	if agent.BlockedAt != nil || agent.RebindRequired {
+		return "", false
+	}
+	agentURL := s.AgentURL(agent.IP, agent.Port)
+	agentSecret := s.decryptAgentSecret(agent.AgentSecretEnc, agent.AgentSecretNonce)
+	if kind == "secret" {
+		return s.resolveBulkApplySecretRef(agentURL, agentSecret, name)
+	}
+	return s.resolveBulkApplyConfigRef(name)
+}
+
 func (s *Server) resolveBulkApplySecretValue(agentURL, agentSecret string, encDEK, encNonce []byte, name string) (string, bool) {
 	// Resolve name → ref via agent's secret meta endpoint.
 	ref := name
@@ -393,6 +409,50 @@ func (s *Server) resolveBulkApplySecretValue(agentURL, agentSecret string, encDE
 		return "", false
 	}
 	return data.Value, strings.TrimSpace(data.Value) != ""
+}
+
+func (s *Server) resolveBulkApplySecretRef(agentURL, agentSecret, name string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	if strings.HasPrefix(name, "VK:LOCAL:") || strings.HasPrefix(name, "VK:EXTERNAL:") {
+		return name, true
+	}
+	resp, err := s.agentGET(agentURL, httputil.AgentPathSecretMeta+"/"+name, agentSecret)
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", false
+	}
+	var data struct {
+		Ref   string `json:"ref"`
+		Token string `json:"token"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&data) != nil {
+		return "", false
+	}
+	ref := strings.TrimSpace(data.Ref)
+	if ref == "" {
+		ref = strings.TrimSpace(data.Token)
+	}
+	if ref != "" && !strings.Contains(ref, ":") {
+		ref = "VK:LOCAL:" + ref
+	}
+	return ref, ref != ""
+}
+
+func (s *Server) resolveBulkApplyConfigRef(key string) (string, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", false
+	}
+	if strings.HasPrefix(key, "VE:LOCAL:") {
+		return key, true
+	}
+	return "VE:LOCAL:" + key, true
 }
 
 // uniqueStrings returns a deduplicated slice preserving order.

--- a/services/vaultcenter/internal/db/db_agent.go
+++ b/services/vaultcenter/internal/db/db_agent.go
@@ -246,6 +246,12 @@ func (d *DB) GetAgentByLabel(label string) (*Agent, error) {
 func (d *DB) GetAgentByHash(agentHash string) (*Agent, error) {
 	return dbFirst[Agent](d, "agent hash "+agentHash+" not found", "agent_hash = ?", agentHash)
 }
+func (d *DB) GetAgentByVaultHash(vaultHash string) (*Agent, error) {
+	return dbFirst[Agent](d, "agent vault hash "+vaultHash+" not found", "vault_hash = ?", vaultHash)
+}
+func (d *DB) GetAgentByVaultName(vaultName string) (*Agent, error) {
+	return dbFirst[Agent](d, "agent vault name "+vaultName+" not found", "vault_name = ?", vaultName)
+}
 func (d *DB) GetAgentBySecretHash(secretHash string) (*Agent, error) {
 	return dbFirst[Agent](d, "agent with secret hash not found", "agent_secret_hash = ?", secretHash)
 }
@@ -293,12 +299,25 @@ func (d *DB) RestoreDeletedAgent(nodeID string) error {
 }
 
 func (d *DB) GetAgentRecord(hashOrLabel string) (*Agent, error) {
-	if len(hashOrLabel) == 8 {
-		if agent, err := d.GetAgentByHash(hashOrLabel); err == nil {
+	id := strings.TrimSpace(hashOrLabel)
+	if id == "" {
+		return nil, fmt.Errorf("agent identifier is empty")
+	}
+	if len(id) == 8 {
+		if agent, err := d.GetAgentByHash(id); err == nil {
 			return agent, nil
 		}
 	}
-	return d.GetAgentByLabel(hashOrLabel)
+	if agent, err := d.GetAgentByVaultHash(id); err == nil {
+		return agent, nil
+	}
+	if agent, err := d.GetAgentByNodeID(id); err == nil {
+		return agent, nil
+	}
+	if agent, err := d.GetAgentByVaultName(id); err == nil {
+		return agent, nil
+	}
+	return d.GetAgentByLabel(id)
 }
 
 func (d *DB) UpdateAgentDEK(nodeID string, agentHash string, dek, dekNonce []byte) error {

--- a/services/vaultcenter/internal/plugin/dockercompose_integration_test.go
+++ b/services/vaultcenter/internal/plugin/dockercompose_integration_test.go
@@ -21,8 +21,13 @@ func TestDockerComposeSyncPlugin(t *testing.T) {
 	t.Run("init_custom_dir", func(t *testing.T) {
 		r, _ := inst.Init(ctx, map[string]any{"service_dir": "/opt/activepieces", "project": "activepieces"})
 		found := false
-		for _, p := range r.Paths { if strings.Contains(p, "activepieces") { found = true } }
+		for _, p := range r.Paths {
+			if strings.Contains(p, "activepieces") {
+				found = true
+			}
+		}
 		if !found { t.Errorf("paths = %v", r.Paths) }
+		if r.Paths[0] != "/opt/activepieces/.env.veil" { t.Errorf("env ref path = %q", r.Paths[0]) }
 		if r.Hooks[0].Name != "recreate_activepieces" { t.Errorf("hook = %q", r.Hooks[0].Name) }
 	})
 	t.Run("validate_env_ok", func(t *testing.T) {
@@ -38,5 +43,6 @@ func TestDockerComposeSyncPlugin(t *testing.T) {
 			"vars": map[string]any{"AP_DB_PASSWORD": "VK:LOCAL:db-pw", "AP_FRONTEND_URL": "http://10.50.0.103:8080"},
 		})
 		if !strings.Contains(r.Output, "AP_DB_PASSWORD=VK:LOCAL:db-pw") { t.Error("missing var") }
+		if r.ResolveMode != "ref" { t.Errorf("resolve_mode = %q", r.ResolveMode) }
 	})
 }

--- a/services/vaultcenter/internal/plugin/handler.go
+++ b/services/vaultcenter/internal/plugin/handler.go
@@ -208,7 +208,22 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	output := h.resolvePlaceholders(vault, rendered.Output)
-	paths, _ := inst.Paths(ctx)
+
+	var (
+		paths []string
+		hooks []HookDef
+	)
+	if initResult, initErr := inst.Init(ctx, input.Input); initErr != nil {
+		log.Printf("plugin sync init %s: %v", name, initErr)
+		respondError(w, http.StatusInternalServerError, "plugin init failed")
+		return
+	} else if initResult != nil {
+		paths = append(paths, initResult.Paths...)
+		hooks = append(hooks, initResult.Hooks...)
+	}
+	if len(paths) == 0 {
+		paths, _ = inst.Paths(ctx)
+	}
 	if len(paths) == 0 {
 		respondError(w, http.StatusInternalServerError, "no target paths")
 		return
@@ -218,7 +233,9 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "validation failed")
 		return
 	}
-	hooks, _ := inst.Hooks(ctx)
+	if len(hooks) == 0 {
+		hooks, _ = inst.Hooks(ctx)
+	}
 	sortedHooks, sortErr := SortHooks(hooks)
 	if sortErr != nil {
 		log.Printf("plugin sync hook sort %s: %v", name, sortErr)
@@ -231,12 +248,31 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadGateway, "vault not reachable")
 		return
 	}
-	// Build steps: one content step + sorted hooks
-	steps := []any{map[string]any{"name": "plugin-sync", "format": "raw", "target_path": paths[0], "content": output}}
+	// LocalVault bulk-apply validates every step as a file write, so hooks must be
+	// attached to a content-bearing step instead of being emitted as hook-only steps.
+	stepCap := len(sortedHooks)
+	if stepCap == 0 {
+		stepCap = 1
+	}
+	steps := make([]any, 0, stepCap)
 	var hookNames []string
-	for _, h := range sortedHooks {
-		steps = append(steps, map[string]any{"name": h.Name, "hook": h.Name})
-		hookNames = append(hookNames, h.Name)
+	if len(sortedHooks) == 0 {
+		steps = append(steps, map[string]any{
+			"name":        "plugin-sync",
+			"format":      "raw",
+			"target_path": paths[0],
+			"content":     output,
+		})
+	} else {
+		hook := sortedHooks[0]
+		steps = append(steps, map[string]any{
+			"name":        hook.Name,
+			"format":      "raw",
+			"target_path": paths[0],
+			"content":     output,
+			"hook":        hook.Name,
+		})
+		hookNames = append(hookNames, hook.Name)
 	}
 	payload, _ := json.Marshal(map[string]any{"name": "plugin-sync", "steps": steps})
 	syncReq, _ := http.NewRequest("POST", strings.TrimRight(agentURL, "/")+"/api/bulk-apply/execute", bytes.NewReader(payload))

--- a/services/vaultcenter/internal/plugin/handler.go
+++ b/services/vaultcenter/internal/plugin/handler.go
@@ -15,6 +15,7 @@ type SyncDeps interface {
 	FindAgentURL(hashOrLabel string) (string, error)
 	HTTPClient() *http.Client
 	ResolveTemplateValue(vaultHash, kind, name string) (string, bool)
+	ResolveTemplateRef(vaultHash, kind, name string) (string, bool)
 }
 
 type Handler struct {
@@ -207,7 +208,12 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "render validation failed")
 		return
 	}
-	output := h.resolvePlaceholders(vault, rendered.Output)
+	resolveAsRef := strings.EqualFold(rendered.ResolveMode, "ref")
+	output := h.resolvePlaceholders(vault, rendered.Output, resolveAsRef)
+	runtimeOutput := output
+	if resolveAsRef {
+		runtimeOutput = h.resolvePlaceholders(vault, rendered.Output, false)
+	}
 
 	var (
 		paths []string
@@ -265,13 +271,19 @@ func (h *Handler) handleSync(w http.ResponseWriter, r *http.Request) {
 		})
 	} else {
 		hook := sortedHooks[0]
-		steps = append(steps, map[string]any{
+		step := map[string]any{
 			"name":        hook.Name,
 			"format":      "raw",
 			"target_path": paths[0],
 			"content":     output,
 			"hook":        hook.Name,
-		})
+		}
+		if resolveAsRef {
+			step["hook_env"] = map[string]string{
+				"VEILKEY_RUNTIME_ENV_CONTENT": runtimeOutput,
+			}
+		}
+		steps = append(steps, step)
 		hookNames = append(hookNames, hook.Name)
 	}
 	payload, _ := json.Marshal(map[string]any{"name": "plugin-sync", "steps": steps})
@@ -356,7 +368,7 @@ func (h *Handler) registerDomainsFromSync(vault string, input map[string]any) {
 	}
 }
 
-func (h *Handler) resolvePlaceholders(vault, text string) string {
+func (h *Handler) resolvePlaceholders(vault, text string, asRef bool) string {
 	if h.sync == nil {
 		return text
 	}
@@ -383,7 +395,15 @@ func (h *Handler) resolvePlaceholders(vault, text string) string {
 		case "ve":
 			kind = "config"
 		}
-		resolved, ok := h.sync.ResolveTemplateValue(vault, kind, parts[1])
+		var (
+			resolved string
+			ok       bool
+		)
+		if asRef {
+			resolved, ok = h.sync.ResolveTemplateRef(vault, kind, parts[1])
+		} else {
+			resolved, ok = h.sync.ResolveTemplateValue(vault, kind, parts[1])
+		}
 		if ok {
 			result = result[:start] + resolved + result[start+end+3:]
 		} else {

--- a/services/vaultcenter/internal/plugin/protocol.go
+++ b/services/vaultcenter/internal/plugin/protocol.go
@@ -42,8 +42,9 @@ type RenderRequest struct {
 
 // RenderResult is returned by plugin_render().
 type RenderResult struct {
-	Output string `json:"output"`
-	Error  string `json:"error,omitempty"`
+	Output      string `json:"output"`
+	ResolveMode string `json:"resolve_mode,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 // PluginManifest is the on-disk metadata stored alongside .wasm files.

--- a/services/veil-cli/src/api.rs
+++ b/services/veil-cli/src/api.rs
@@ -174,6 +174,44 @@ impl VeilKeyClient {
         req.call()
     }
 
+    pub fn plugins_list(&self) -> Result<Vec<serde_json::Value>, String> {
+        let url = format!("{}/api/plugins", self.base_url);
+        let resp = self
+            .raw_get(&url)
+            .map_err(|e| format!("plugins list failed: {}", e))?;
+        let result: serde_json::Value = resp
+            .into_json()
+            .map_err(|e| format!("decode failed: {}", e))?;
+        result["plugins"]
+            .as_array()
+            .cloned()
+            .ok_or_else(|| "missing plugins in response".to_string())
+    }
+
+    pub fn plugin_sync(
+        &self,
+        vault: &str,
+        plugin: &str,
+        action: &str,
+        input: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let url = format!(
+            "{}/api/vaults/{}/plugins/{}/sync",
+            self.base_url,
+            urlencoding::encode(vault),
+            urlencoding::encode(plugin)
+        );
+        let body = serde_json::json!({
+            "action": action,
+            "input": input,
+        });
+        let resp = self
+            .raw_post(&url, &body)
+            .map_err(|e| format!("plugin sync failed: {}", e))?;
+        resp.into_json()
+            .map_err(|e| format!("decode failed: {}", e))
+    }
+
     pub fn issue(&self, value: &str) -> Result<String, String> {
         let value = value.trim_end_matches(['\r', '\n']);
         {

--- a/services/veil-cli/src/bin/veilkey_cli.rs
+++ b/services/veil-cli/src/bin/veilkey_cli.rs
@@ -19,6 +19,15 @@ fn resolve_api_url() -> Option<String> {
     None
 }
 
+fn resolve_vaultcenter_url() -> Option<String> {
+    if let Ok(v) = std::env::var("VEILKEY_VAULTCENTER_URL") {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    None
+}
+
 fn print_usage() {
     eprintln!(
         r#"Usage:
@@ -52,6 +61,8 @@ fn print_usage() {
   veilkey cleanup [--json]          Clean up stale tracked refs
   veilkey ref-audit [--json]        Audit tracked refs
   veilkey inventory [--json]        Show vault inventory
+  veilkey plugin list               List installed plugins
+  veilkey plugin sync ...           Run plugin sync against a vault
   veilkey traefik <sub>              Manage Traefik config (init|status|destroy)
   veilkey status                    Show status
   veilkey version                   Show version
@@ -109,6 +120,7 @@ fn main() {
         "cleanup",
         "ref-audit",
         "inventory",
+        "plugin",
     ];
 
     let subcmd = raw_args.get(1).map(String::as_str).unwrap_or("");
@@ -1115,6 +1127,14 @@ fn main() {
             }
         }
         "version" => println!("veilkey {}", VERSION),
+        "plugin" => {
+            let vc_url = resolve_vaultcenter_url().unwrap_or_else(|| {
+                eprintln!("ERROR: VEILKEY_VAULTCENTER_URL is required for plugin commands.");
+                eprintln!("  export VEILKEY_VAULTCENTER_URL=<vaultcenter-url>");
+                process::exit(1);
+            });
+            commands::cmd_plugin(&cmd_args, &vc_url, &log_path, patterns_file.as_deref())
+        }
         "traefik" => {
             commands::cmd_traefik(&cmd_args, &api_url, &log_path, patterns_file.as_deref())
         }

--- a/services/veil-cli/src/bin/veilkey_cli.rs
+++ b/services/veil-cli/src/bin/veilkey_cli.rs
@@ -38,6 +38,7 @@ fn print_usage() {
   veilkey wrap-pty [command]        Interactive PTY + auto-replace (default: bash)
   veilkey exec <command...>         Resolve VK: hashes + run command
   veilkey create [value]            Create a temp ref (VK:TEMP:xxx)
+  veilkey unlock                    Unlock VaultCenter with the master password
   veilkey resolve <VK:ref>          Decrypt and print a VeilKey reference
   veilkey secret add <name> [val]   Create + promote to vault (one step)
   veilkey secret list [--vault url] List secrets in vault
@@ -77,6 +78,8 @@ Environment:
   VEILKEY_LOCALVAULT_URL       Preferred localvault URL
   VEILKEY_VAULTCENTER_URL      VaultCenter URL (for health/config commands)
   VEILKEY_API                  Legacy endpoint variable (fallback)
+  VEILKEY_PASSWORD_FILE        Read admin password from file for VaultCenter commands
+  VEILKEY_MASTER_PASSWORD_FILE Read master password from file for unlock
   VEILKEY_STATE_DIR            State directory (default: $TMPDIR/veilkey-cli)
 "#
     );
@@ -121,6 +124,7 @@ fn main() {
         "ref-audit",
         "inventory",
         "plugin",
+        "unlock",
     ];
 
     let subcmd = raw_args.get(1).map(String::as_str).unwrap_or("");
@@ -219,6 +223,23 @@ fn main() {
         "paste-mode" => commands::cmd_paste_mode(&cmd_args),
         "clear" => commands::cmd_clear(&log_path),
         "status" => commands::cmd_status(&api_url, &log_path, patterns_file.as_deref(), VERSION),
+        "unlock" => {
+            let vc_url = resolve_vaultcenter_url().unwrap_or_else(|| {
+                eprintln!("ERROR: VEILKEY_VAULTCENTER_URL is required for unlock.");
+                process::exit(1);
+            });
+            let password = commands::read_master_password();
+            if password.is_empty() {
+                eprintln!("[veilkey] master password is required");
+                process::exit(1);
+            }
+            let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
+            if let Err(e) = client.unlock(&password) {
+                eprintln!("[veilkey] unlock failed: {}", e);
+                process::exit(1);
+            }
+            println!("VaultCenter unlocked");
+        }
         "resolve" => {
             // Must be interactive TTY — block pipe usage for security
             if unsafe { libc::isatty(0) } == 0 {
@@ -229,7 +250,7 @@ fn main() {
                 eprintln!("Usage: veilkey resolve <VK:ref>");
                 process::exit(1);
             });
-            let password = rpassword::prompt_password("VeilKey password: ").unwrap_or_default();
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&api_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -248,9 +269,7 @@ fn main() {
                 eprintln!("Usage: veilkey function <list|add|remove> [name]");
                 process::exit(1);
             });
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&api_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -318,9 +337,7 @@ fn main() {
                 eprintln!("Usage: veilkey secret <add|list|get|delete> [args]");
                 process::exit(1);
             });
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&api_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -555,9 +572,7 @@ fn main() {
                 eprintln!("Value cannot be empty");
                 process::exit(1);
             }
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&api_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -576,9 +591,7 @@ fn main() {
                 eprintln!("Usage: veilkey ssh <add|list|pubkey|remove> [args]");
                 process::exit(1);
             });
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&api_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -650,9 +663,7 @@ fn main() {
                 process::exit(1);
             });
             let json_flag = cmd_args.iter().any(|a| a == "--json");
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -706,9 +717,7 @@ fn main() {
                 process::exit(1);
             });
             let json_flag = cmd_args.iter().any(|a| a == "--json");
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -815,9 +824,7 @@ fn main() {
                 eprintln!("Usage: veilkey config <search|bulk-update|bulk-set> [args]");
                 process::exit(1);
             });
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -947,9 +954,7 @@ fn main() {
                 .and_then(|i| cmd_args.get(i + 1))
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(20);
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -1004,9 +1009,7 @@ fn main() {
                     process::exit(0);
                 }
             }
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -1041,9 +1044,7 @@ fn main() {
                 process::exit(1);
             });
             let json_flag = cmd_args.iter().any(|a| a == "--json");
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -1075,9 +1076,7 @@ fn main() {
                 process::exit(1);
             });
             let json_flag = cmd_args.iter().any(|a| a == "--json");
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);
@@ -1104,9 +1103,7 @@ fn main() {
                 process::exit(1);
             });
             let json_flag = cmd_args.iter().any(|a| a == "--json");
-            let password = std::env::var("VEILKEY_PASSWORD").unwrap_or_else(|_| {
-                rpassword::prompt_password("VeilKey password: ").unwrap_or_default()
-            });
+            let password = commands::read_admin_password();
             let client = veil_cli_rs::api::VeilKeyClient::new(&vc_url);
             if let Err(e) = client.admin_login(&password) {
                 eprintln!("[veilkey] login failed: {}", e);

--- a/services/veil-cli/src/commands.rs
+++ b/services/veil-cli/src/commands.rs
@@ -590,6 +590,174 @@ fn traefik_destroy(args: &[String], api_url: &str) {
     }
 }
 
+pub fn cmd_plugin(args: &[String], api_url: &str, _log_path: &str, _patterns_file: Option<&str>) {
+    if args.is_empty() {
+        eprintln!("Usage: veilkey plugin <list|sync> [args]");
+        eprintln!("  list");
+        eprintln!("  sync --vault <vault> --plugin <name> --action <action> --input-json <json>");
+        eprintln!("  sync --vault <vault> --plugin <name> --action <action> --input-file <path>");
+        process::exit(1);
+    }
+    match args[0].as_str() {
+        "list" => plugin_list(api_url),
+        "sync" => plugin_sync(&args[1..], api_url),
+        other => {
+            eprintln!("Unknown plugin subcommand: {}", other);
+            process::exit(1);
+        }
+    }
+}
+
+fn plugin_list(api_url: &str) {
+    let client = VeilKeyClient::new(api_url);
+    let password = std::env::var("VEILKEY_PASSWORD")
+        .unwrap_or_else(|_| rpassword::prompt_password("VeilKey password: ").unwrap_or_default());
+    if let Err(e) = client.admin_login(&password) {
+        eprintln!("[veilkey] login failed: {}", e);
+        process::exit(1);
+    }
+    match client.plugins_list() {
+        Ok(plugins) => {
+            if plugins.is_empty() {
+                println!("No plugins installed");
+                return;
+            }
+            println!(
+                "\x1b[0;36m{:<24} {:<10} {:<8} {}\x1b[0m",
+                "NAME", "VERSION", "LOADED", "DESCRIPTION"
+            );
+            println!("{}", "─".repeat(80));
+            for plugin in plugins {
+                println!(
+                    "{:<24} {:<10} {:<8} {}",
+                    plugin["name"].as_str().unwrap_or("-"),
+                    plugin["version"].as_str().unwrap_or("-"),
+                    if plugin["loaded"].as_bool().unwrap_or(false) {
+                        "yes"
+                    } else {
+                        "no"
+                    },
+                    plugin["description"].as_str().unwrap_or("-"),
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("ERROR: plugin list failed: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn plugin_sync(args: &[String], api_url: &str) {
+    let mut vault: Option<String> = None;
+    let mut plugin: Option<String> = None;
+    let mut action: Option<String> = None;
+    let mut input_json: Option<String> = None;
+    let mut input_file: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--vault" if i + 1 < args.len() => {
+                vault = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--vault=") => {
+                vault = Some(a["--vault=".len()..].to_string());
+                i += 1;
+            }
+            "--plugin" if i + 1 < args.len() => {
+                plugin = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--plugin=") => {
+                plugin = Some(a["--plugin=".len()..].to_string());
+                i += 1;
+            }
+            "--action" if i + 1 < args.len() => {
+                action = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--action=") => {
+                action = Some(a["--action=".len()..].to_string());
+                i += 1;
+            }
+            "--input-json" if i + 1 < args.len() => {
+                input_json = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--input-json=") => {
+                input_json = Some(a["--input-json=".len()..].to_string());
+                i += 1;
+            }
+            "--input-file" if i + 1 < args.len() => {
+                input_file = Some(args[i + 1].clone());
+                i += 2;
+            }
+            a if a.starts_with("--input-file=") => {
+                input_file = Some(a["--input-file=".len()..].to_string());
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    let vault = vault.unwrap_or_else(|| {
+        eprintln!("ERROR: --vault is required");
+        process::exit(1);
+    });
+    let plugin = plugin.unwrap_or_else(|| {
+        eprintln!("ERROR: --plugin is required");
+        process::exit(1);
+    });
+    let action = action.unwrap_or_else(|| {
+        eprintln!("ERROR: --action is required");
+        process::exit(1);
+    });
+
+    let raw_input = if let Some(path) = input_file {
+        std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            eprintln!("ERROR: cannot read {}: {}", path, e);
+            process::exit(1);
+        })
+    } else if let Some(json) = input_json {
+        json
+    } else {
+        eprintln!("ERROR: --input-json or --input-file is required");
+        process::exit(1);
+    };
+
+    let input: serde_json::Value = serde_json::from_str(&raw_input).unwrap_or_else(|e| {
+        eprintln!("ERROR: invalid input JSON: {}", e);
+        process::exit(1);
+    });
+
+    let client = VeilKeyClient::new(api_url);
+    let password = std::env::var("VEILKEY_PASSWORD")
+        .unwrap_or_else(|_| rpassword::prompt_password("VeilKey password: ").unwrap_or_default());
+    if let Err(e) = client.admin_login(&password) {
+        eprintln!("[veilkey] login failed: {}", e);
+        process::exit(1);
+    }
+    match client.plugin_sync(&vault, &plugin, &action, &input) {
+        Ok(result) => {
+            println!(
+                "plugin synced: vault={} plugin={} action={}",
+                vault, plugin, action
+            );
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string())
+            );
+        }
+        Err(e) => {
+            eprintln!("ERROR: plugin sync failed: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
 pub fn cmd_proxy(args: &[String]) {
     let mut listen = String::new();
     let mut allow_hosts: Vec<String> = Vec::new();

--- a/services/veil-cli/src/commands.rs
+++ b/services/veil-cli/src/commands.rs
@@ -10,6 +10,42 @@ use crate::state::{current_paste_mode, set_paste_mode};
 
 const SCAN_PREVIEW_LEN: usize = 8;
 
+fn read_secret(file_env: &str, value_env: &str, prompt: &str) -> String {
+    if let Ok(path) = std::env::var(file_env) {
+        if !path.trim().is_empty() {
+            return std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| {
+                    eprintln!("ERROR: cannot read {}: {}", path, e);
+                    process::exit(1);
+                })
+                .trim_end_matches(['\r', '\n'])
+                .to_string();
+        }
+    }
+    if let Ok(password) = std::env::var(value_env) {
+        if !password.is_empty() {
+            return password;
+        }
+    }
+    rpassword::prompt_password(prompt).unwrap_or_default()
+}
+
+pub fn read_admin_password() -> String {
+    read_secret(
+        "VEILKEY_PASSWORD_FILE",
+        "VEILKEY_PASSWORD",
+        "VeilKey password: ",
+    )
+}
+
+pub fn read_master_password() -> String {
+    read_secret(
+        "VEILKEY_MASTER_PASSWORD_FILE",
+        "VEILKEY_MASTER_PASSWORD",
+        "Master password (unlock): ",
+    )
+}
+
 fn process_stream(detector: &mut SecretDetector, r: impl Read) {
     let reader = io::BufReader::new(r);
     for line in reader.lines() {
@@ -610,8 +646,7 @@ pub fn cmd_plugin(args: &[String], api_url: &str, _log_path: &str, _patterns_fil
 
 fn plugin_list(api_url: &str) {
     let client = VeilKeyClient::new(api_url);
-    let password = std::env::var("VEILKEY_PASSWORD")
-        .unwrap_or_else(|_| rpassword::prompt_password("VeilKey password: ").unwrap_or_default());
+    let password = read_admin_password();
     if let Err(e) = client.admin_login(&password) {
         eprintln!("[veilkey] login failed: {}", e);
         process::exit(1);
@@ -734,8 +769,7 @@ fn plugin_sync(args: &[String], api_url: &str) {
     });
 
     let client = VeilKeyClient::new(api_url);
-    let password = std::env::var("VEILKEY_PASSWORD")
-        .unwrap_or_else(|_| rpassword::prompt_password("VeilKey password: ").unwrap_or_default());
+    let password = read_admin_password();
     if let Err(e) = client.admin_login(&password) {
         eprintln!("[veilkey] login failed: {}", e);
         process::exit(1);

--- a/services/veil-cli/src/pty/masker.rs
+++ b/services/veil-cli/src/pty/masker.rs
@@ -1821,13 +1821,13 @@ mod same_width_tests {
     // ── Cross-chunk erase + same-width ──────────────────────────
     #[test]
     fn cc_erase_same_width() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let r = find_cross_chunk_mask("(VEIL) $ Ghdrhkdgh1", "@", &map).unwrap();
-        assert!(!r.output.contains("Ghdrhkdgh1@"));
+        assert!(!r.output.contains("MaskingExamplePass!42"));
     }
     #[test]
     fn cc_no_vkloc_fragments() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let r = find_cross_chunk_mask("$ Ghdrhkdg", "h1@", &map).unwrap();
         let v = strip_ansi(&r.output);
         assert!(!v.contains("VK:6dVK:"), "no VK:LOC fragments: [{}]", v);
@@ -1841,7 +1841,7 @@ mod same_width_tests {
     }
     #[test]
     fn cc_skip_down_arrow() {
-        let m = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let m = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         assert!(find_cross_chunk_mask("tail", "\x1b[B\x1b[2K", &m).is_none());
     }
     #[test]
@@ -1853,13 +1853,13 @@ mod same_width_tests {
     // ── Repeated invocations ────────────────────────────────────
     #[test]
     fn cc_repeated_10x() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let mut tail = String::new();
         for i in 0..10 {
             tail.push_str("(VEIL) $ ");
             let r = find_cross_chunk_mask(&format!("{}Ghdrhkdgh1", tail), "@\r", &map);
             assert!(r.is_some(), "#{}", i);
-            tail.push_str("Ghdrhkdgh1@\nbash: VK:6da25530: not found\n");
+            tail.push_str("MaskingExamplePass!42\nbash: VK:6da25530: not found\n");
             if tail.len() > 4096 {
                 tail = tail[tail.len() - 4096..].to_string();
             }
@@ -1872,7 +1872,7 @@ mod same_width_tests {
         let mut map: Vec<(String, String)> = (0..102)
             .map(|i| (format!("other_{:04}", i), format!("VK:LOCAL:{:08x}", i)))
             .collect();
-        map.push(("Ghdrhkdgh1@".into(), "VK:LOCAL:6da25530".into()));
+        map.push(("MaskingExamplePass!42".into(), "VK:LOCAL:6da25530".into()));
         let r = find_cross_chunk_mask("$ Ghdrhkdgh1", "@", &map);
         assert!(r.is_some());
     }
@@ -1880,9 +1880,9 @@ mod same_width_tests {
     // ── Security ────────────────────────────────────────────────
     #[test]
     fn sec_no_plaintext() {
-        let m = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let m = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let r = find_cross_chunk_mask("$ Ghdrhkdgh1", "@\r", &m).unwrap();
-        assert!(!r.output.contains("Ghdrhkdgh1@"));
+        assert!(!r.output.contains("MaskingExamplePass!42"));
     }
     #[test]
     fn sec_empty_map() {
@@ -2707,7 +2707,7 @@ mod re_masking_tests {
     /// contains a VK: ref — it's already masked output.
     #[test]
     fn already_masked_ref_not_re_masked() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         // Readline recalls history line containing already-masked ref
         let (out, _) = call("bash: VK:LOCAL:6da25530: not found", &map, "", "");
         let v = strip(&out);
@@ -2722,7 +2722,7 @@ mod re_masking_tests {
     /// Arrow up shows previous command with masked ref — must stay full
     #[test]
     fn arrow_recall_preserves_full_ref() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         // First: bash error outputs full ref
         let (out1, tail) = call("bash: VK:LOCAL:6da25530: not found\n", &map, "", "");
         let v1 = strip(&out1);
@@ -2745,7 +2745,7 @@ mod re_masking_tests {
     /// Text starting with "VK:" must not be treated as a secret
     #[test]
     fn vk_prefix_text_not_masked() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let (out, _) = call("VK:LOCAL:6da25530 is a reference", &map, "", "");
         let v = strip(&out);
         assert!(
@@ -2779,7 +2779,7 @@ mod re_masking_tests {
     /// Compact VK ref (VK:hash) in output must not be further truncated
     #[test]
     fn compact_ref_not_further_truncated() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         // Even if compact form appears, it must not become shorter
         let (out, _) = call("VK:6da25530", &map, "", "");
         let v = strip(&out);
@@ -2921,10 +2921,10 @@ mod masking_robustness_tests {
     /// Secret in bash error must be masked
     #[test]
     fn bash_error_masked() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
-        let (out, _) = call("bash: Ghdrhkdgh1@: not found\n", &map, "", "");
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
+        let (out, _) = call("bash: MaskingExamplePass!42: not found\n", &map, "", "");
         let v = strip(&out);
-        assert!(!v.contains("Ghdrhkdgh1@"), "bash error leaked: {}", v);
+        assert!(!v.contains("MaskingExamplePass!42"), "bash error leaked: {}", v);
     }
 
     /// Secret in cat output must be masked
@@ -2983,11 +2983,11 @@ mod masking_robustness_tests {
     /// 10 rounds of error + arrow must not produce VK:LOC
     #[test]
     fn no_vkloc_10_rounds() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let mut combined = String::new();
         let mut tail = String::new();
         for _ in 0..10 {
-            let (raw, t) = call("bash: Ghdrhkdgh1@: err\n", &map, "", &tail);
+            let (raw, t) = call("bash: MaskingExamplePass!42: err\n", &map, "", &tail);
             tail = t;
             combined += &strip(&raw);
             let (_, t) = call("\x1b[A", &map, "", &tail);
@@ -3005,15 +3005,15 @@ mod masking_robustness_tests {
     /// Rapid arrows
     #[test]
     fn rapid_arrows_safe() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let mut tail = String::new();
         for arrow in ["\x1b[A", "\x1b[B", "\x1b[A", "\x1b[B", "\x1b[A"] {
             let (_, t) = call(arrow, &map, "", &tail);
             tail = t;
         }
-        let (raw, _) = call("bash: Ghdrhkdgh1@: err\n", &map, "", &tail);
+        let (raw, _) = call("bash: MaskingExamplePass!42: err\n", &map, "", &tail);
         let v = strip(&raw);
-        assert!(!v.contains("Ghdrhkdgh1@"), "after rapid arrows: {}", v);
+        assert!(!v.contains("MaskingExamplePass!42"), "after rapid arrows: {}", v);
     }
 
     // ═══ Edge cases ═══
@@ -3046,7 +3046,7 @@ mod masking_robustness_tests {
     /// Backspace in input
     #[test]
     fn backspace_safe() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let (_, _) = call("Ghdrhk\x08dgh1@", &map, "", "");
         // No crash
     }
@@ -3054,7 +3054,7 @@ mod masking_robustness_tests {
     /// Ctrl+C
     #[test]
     fn ctrl_c_safe() {
-        let map = mk(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
+        let map = mk(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
         let (_, _) = call("Ghdrhk^C\n", &map, "", "");
         // No crash
     }

--- a/services/veil-cli/src/pty/session.rs
+++ b/services/veil-cli/src/pty/session.rs
@@ -533,8 +533,8 @@ mod tests {
     #[test]
     fn blocks_exact_secret_on_enter() {
         let mut buf = String::new();
-        let map = secrets(&[("Ghdrhkdgh1@", "VK:LOCAL:6da25530")]);
-        let result = check_stdin_for_secrets(b"Ghdrhkdgh1@\r", &mut buf, &map);
+        let map = secrets(&[("MaskingExamplePass!42", "VK:LOCAL:6da25530")]);
+        let result = check_stdin_for_secrets(b"MaskingExamplePass!42\r", &mut buf, &map);
         assert_eq!(result, StdinGuardResult::Blocked);
     }
 

--- a/tests/smoke/veil-masking-test.sh
+++ b/tests/smoke/veil-masking-test.sh
@@ -20,7 +20,7 @@ if [ "$STATUS" = "True" ]; then
 fi
 
 PWFILE=$(mktemp)
-echo "Ghdrhkdgh1@" > "$PWFILE"
+echo "MaskingExamplePass!42" > "$PWFILE"
 export VEILKEY_PASSWORD_FILE="$PWFILE"
 
 FAIL=0
@@ -31,7 +31,7 @@ OUTPUT=$(python3 -c "
 import subprocess, os, time, pty, select, re
 master, slave = pty.openpty()
 proc = subprocess.Popen(
-    ['/usr/local/bin/veilkey-cli', 'wrap-pty', 'bash', '-c', 'echo Ghdrhkdgh1@; exit'],
+    ['/usr/local/bin/veilkey-cli', 'wrap-pty', 'bash', '-c', 'echo MaskingExamplePass!42; exit'],
     stdin=slave, stdout=slave, stderr=slave, close_fds=True, env=os.environ.copy()
 )
 os.close(slave)
@@ -87,7 +87,7 @@ def drain(t=2):
             except: break
     return buf
 time.sleep(3); drain(2)
-os.write(master, b'Ghdrhkdgh1@\n'); time.sleep(1); drain(2)
+os.write(master, b'MaskingExamplePass!42\n'); time.sleep(1); drain(2)
 for _ in range(5):
     os.write(master, b'\x1b[A'); time.sleep(0.05)
 for _ in range(3):


### PR DESCRIPTION
## Summary
- keep plugin-managed env files on disk as refs while passing plaintext runtime env to hooks only in-memory
- add a secure docker-compose hook path and CLI unlock/password-file support for command-only operation
- replace the leaked test fixture password string and remove the leaked shell-history entries from the host

## Testing
- cargo check
- go test ./internal/plugin/... ./internal/api/...
- go test ./internal/api/bulk/...
- live verify: plugin sync on gitlab-lv, GitLab 200, no plaintext secret persisted under /opt/gitlab
