### PR TITLE
fix: resolve VK:LOCAL refs in env vars during veil exec

### DIFF
--- a/services/veil-cli/src/commands.rs
+++ b/services/veil-cli/src/commands.rs
@@ -134,6 +134,27 @@ pub fn cmd_exec(args: &[String], api_url: &str, log_path: &str, patterns_file: O
         })
         .collect();
 
+    // Resolve VK refs in inherited environment variables
+    let resolved_env: Vec<(String, String)> = std::env::vars()
+        .map(|(key, val)| {
+            let new_val = vk_re
+                .replace_all(&val, |caps: &regex::Captures| {
+                    match client.resolve(&caps[0]) {
+                        Ok(v) => {
+                            mask_pairs.push((v.clone(), caps[0].to_string()));
+                            v
+                        }
+                        Err(e) => {
+                            eprintln!("WARNING: resolve env {}={} failed: {}", key, &caps[0], e);
+                            caps[0].to_string()
+                        }
+                    }
+                })
+                .to_string();
+            (key, new_val)
+        })
+        .collect();
+
     // Mask stdout to prevent resolved plaintext from leaking to terminal
     let cfg = match load_config(patterns_file) {
         Ok(c) => c,
@@ -141,6 +162,8 @@ pub fn cmd_exec(args: &[String], api_url: &str, log_path: &str, patterns_file: O
             // Fallback: run without masking rather than blocking execution
             let status = process::Command::new(&resolved[0])
                 .args(&resolved[1..])
+                .env_clear()
+                .envs(resolved_env.iter().map(|(k, v)| (k, v)))
                 .stdin(process::Stdio::inherit())
                 .stdout(process::Stdio::inherit())
                 .stderr(process::Stdio::inherit())
@@ -164,6 +187,8 @@ pub fn cmd_exec(args: &[String], api_url: &str, log_path: &str, patterns_file: O
 
     let mut child = match process::Command::new(&resolved[0])
         .args(&resolved[1..])
+        .env_clear()
+        .envs(resolved_env.iter().map(|(k, v)| (k, v)))
         .stdin(process::Stdio::inherit())
         .stdout(process::Stdio::piped())
         .stderr(process::Stdio::piped())


### PR DESCRIPTION
## Summary
- `veil exec`의 `cmd_exec`에서 환경변수에 포함된 `VK:LOCAL` (및 기타 VK) ref를 resolve하도록 수정
- 기존에는 CLI args만 해석했으나, 이제 상속받은 env vars도 동일한 `client.resolve()` 경로로 해석
- resolved plaintext를 `mask_pairs`에 등록하여 출력 마스킹이 env 기반 시크릿도 커버

## Test plan
- [ ] `CLOUDFLARE_API_KEY=VK:LOCAL:d7af11a6 veil exec bash -c 'echo $CLOUDFLARE_API_KEY'` → 평문 출력 확인
- [ ] stdout/stderr에 resolved 평문이 마스킹되는지 확인
- [ ] VK ref가 없는 env var는 그대로 전달되는지 확인
- [ ] resolve 실패 시 WARNING 출력 후 원본 ref 유지 확인

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)